### PR TITLE
Correcting commit 74d79ef

### DIFF
--- a/astroid/context.py
+++ b/astroid/context.py
@@ -99,7 +99,7 @@ class InferenceContext:
         starts with the same context but diverge as each side is inferred
         so the InferenceContext will need be cloned"""
         # XXX copy lookupname/callcontext ?
-        clone = InferenceContext(self.path, inferred=self.inferred)
+        clone = InferenceContext(set(self.path), inferred=self.inferred)
         clone.callcontext = self.callcontext
         clone.boundnode = self.boundnode
         clone.extra_context = self.extra_context

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -1720,7 +1720,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         """
         ast = extract_node(code, __name__)
         expr = ast.func.expr
-        self.assertIs(next(expr.infer()), util.Uninferable)
+        self.assertRaises(InferenceError, next, expr.infer())
 
     def test_tuple_builtin_inference(self):
         code = """


### PR DESCRIPTION
# Description

This PR is here to fix the pb arising after commit 74d79ef. This commit breaks the unittest `InferenceTest.test_two_parents_from_same_module`.

Proceeding by bisection, i revert the strictly necessary to have all unittest ok.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
