### PR TITLE
Update comment to catch up with reality

### DIFF
--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -550,7 +550,7 @@ class TreeRebuilder:
         )
         return newnode
 
-    # Not used in Python 3.8+.
+    # Not used in Python 3.9+.
     def visit_extslice(self, node, parent):
         """visit an ExtSlice node by returning a fresh instance of it"""
         newnode = nodes.ExtSlice(parent=parent)
@@ -727,7 +727,7 @@ class TreeRebuilder:
         )
         return newnode
 
-    # Not used in Python 3.8+.
+    # Not used in Python 3.9+.
     def visit_index(self, node, parent):
         """visit a Index node by returning a fresh instance of it"""
         newnode = nodes.Index(parent=parent)


### PR DESCRIPTION
## Description
`ast.Index` and `ast.ExcSlice` where removed in Python 3.9, not like originally planned in 3.8
https://github.com/PyCQA/astroid/commit/3746acc55f5445e1e350fa4a4ca225fad823ed12
https://bugs.python.org/issue34822