### PR TITLE
Better deprecation messages for guard functions

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2873,7 +2873,9 @@ class If(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         True
         """
         warnings.warn(
-            "The 'is_sys_guard' function is deprecated and will be removed in astroid 3.0.0",
+            "The 'is_sys_guard' function is deprecated and will be removed in astroid 3.0.0 "
+            "It has been moved to pylint and can be imported from 'pylint.checkers.utils' "
+            "starting with pylint 2.12",
             DeprecationWarning,
         )
         if isinstance(self.test, Compare):
@@ -2898,7 +2900,9 @@ class If(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         True
         """
         warnings.warn(
-            "The 'is_typing_guard' function is deprecated and will be removed in astroid 3.0.0",
+            "The 'is_typing_guard' function is deprecated and will be removed in astroid 3.0.0 "
+            "It has been moved to pylint and can be imported from 'pylint.checkers.utils' "
+            "starting with pylint 2.12",
             DeprecationWarning,
         )
         return isinstance(


### PR DESCRIPTION
## Description
Following the suggestion of @DanielNoord here: https://github.com/PyCQA/astroid/pull/1202#issuecomment-936446485
Added a note to the deprecation messages for `is_typing_guard` and `is_sys_guard` to point to `pylint.checkers.utils`.
