### PR TITLE
Bump the upper constraint of wrapt to 1.14

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,7 +12,7 @@ What's New in astroid 2.8.3?
 ============================
 Release date: TBA
 
-
+* Bump the `wrapt` upper constraint to `wrapt>=1.11, <1.14`
 
 What's New in astroid 2.8.2?
 ============================

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ project_urls =
 packages = find:
 install_requires =
     lazy_object_proxy>=1.4.0
-    wrapt>=1.11,<1.13
+    wrapt>=1.11,<1.14
     setuptools>=20.0
     typed-ast>=1.4.0,<1.5;implementation_name=="cpython" and python_version<"3.8"
     typing-extensions>=3.10;python_version<"3.10"


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
- [wrapt==1.13.1](https://wrapt.readthedocs.io/en/latest/changes.html#version-1-13-0) has been released and it doesn't contain any breaking changes. The current constraint `wrapt<1.13` conflicts when fetching new version so upgrading the constraint to `>=1.11, <1.14` to resolve this conflict.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |