### PR TITLE
Fix crash with invalid field call

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,8 +16,12 @@ Release date: TBA
 
 * Fixes handling of nested partial functions
 
-  Closes pyCQA/pylint#2462
+  Closes PyCQA/pylint#2462
   Closes #1208
+
+* Fix crash with invalid dataclass field call
+
+  Closes PyCQA/pylint#5153
 
 
 What's New in astroid 2.8.2?

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -308,6 +308,7 @@ def _looks_like_dataclass_field_call(node: Call, check_scope: bool = True) -> bo
         scope = stmt.scope()
         if not (
             isinstance(stmt, AnnAssign)
+            and stmt.value is not None
             and isinstance(scope, ClassDef)
             and is_decorated_with_dataclass(scope)
         ):

--- a/tests/unittest_brain_dataclasses.py
+++ b/tests/unittest_brain_dataclasses.py
@@ -664,3 +664,20 @@ def test_annotated_enclosed_field_call(module: str):
     inferred = node.inferred()
     assert len(inferred) == 1 and isinstance(inferred[0], nodes.ClassDef)
     assert "attribute" in inferred[0].instance_attrs
+
+
+@parametrize_module
+def test_invalid_field_call(module: str) -> None:
+    """Test inference of invalid field call doesn't crash."""
+    code = astroid.extract_node(
+        f"""
+    from {module} import dataclass, field
+
+    @dataclass
+    class A:
+        val: field()
+    """
+    )
+    inferred = code.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.ClassDef)


### PR DESCRIPTION
## Description
Don't crash astroid if an invalid dataclass `field` call is used.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
Closes PyCQA/pylint#5153
