### PR TITLE
Add predicate functions to BinOp class

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -67,6 +67,13 @@ else:
 if TYPE_CHECKING:
     from astroid.nodes import LocalsDictNodeNG
 
+from enum import Enum
+class operator_category(Enum):
+    UNKNOWN = 0
+    COMPUTATION = 1
+    COMPARISON = 2
+    ASSIGNMENT = 3
+
 
 def _is_const(value):
     return isinstance(value, tuple(CONST_CLS))
@@ -1518,6 +1525,28 @@ class BinOp(NodeNG):
     def op_left_associative(self):
         # 2**3**4 == 2**(3**4)
         return self.op != "**"
+
+    def is_computation(self) -> bool:
+        return self.op in ("+",  "-",  "*",  "/",  "//", "%",  "@",\
+                                     "**",  "|",  "&",  "^",  "<<",  ">>")
+
+    def is_comparison(self) -> bool:
+        return self.op in ("==",  "!=",  "<",  ">",  "<=",  ">=", \
+                                     "is",  "is not",  "in",  "not in")
+
+    def is_assignment(self) -> bool:
+        return self.op in ("=",  "+=",  "-=",  "*=",  "/=",  "//=", "%=",  "@=",\
+                                     "**=",  "|=",  "&=",  "^=",  "<<=",  ">>=")
+
+    def get_category(self) -> operator_category:
+        if self.is_computation():
+            return operator_category.COMPUTATION
+        elif self.is_comparison():
+            return operator_category.COMPARISON
+        elif self.is_assignment():
+            return operator_category.ASSIGNMENT
+        else:
+            return operator_category.UNKNOWN
 
 
 class BoolOp(NodeNG):


### PR DESCRIPTION
## Description
[Binary operations](https://en.wikipedia.org/wiki/Operator_%28computer_programming%29 "Description for the usage of operators") can be applied in some contexts.
Some checks can be reused for corresponding purposes.
Thus I propose to add an enumeration and a few functions for type determination so that the provided software functionality can be clarified further.

## Related issues
:thinking: Development discussion on the topic “[Improve descriptions for binary operations](https://github.com/PyCQA/astroid/issues/1214#issuecomment-948307058 "Feedback from 2021-10-21")”

:thought_balloon: I hope that another presentation of a few software development ideas in a source code format can help to achieve a better understanding for involved implementation details.