### PR TITLE
Remove unnecessary disable from ``pylintrc``

### DIFF
--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,5 @@
 black==21.7b0
-pylint==2.11.2
+pylint==2.11.1
 isort==5.9.2
 flake8==4.0.1
 mypy==0.910


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

With the refractor of `nodes` the `too-many-lines` option can be removed!

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Related Issue

Closes #465