### PR TITLE
Refactor and remove ``redefined-variable-type`` disable

### DIFF
--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -68,7 +68,7 @@ def dataclass_transform(node: ClassDef) -> None:
         return
 
     try:
-        reversed_mro = reversed(node.mro())
+        reversed_mro = list(reversed(node.mro()))
     except MroError:
         reversed_mro = [node]
 
@@ -208,9 +208,9 @@ def _generate_dataclass_init(assigns: List[AnnAssign]) -> str:
         if not init_var:
             assignments.append(assignment_str)
 
-    params = ", ".join(["self"] + params)
-    assignments = "\n    ".join(assignments) if assignments else "pass"
-    return f"def __init__({params}) -> None:\n    {assignments}"
+    params_string = ", ".join(["self"] + params)
+    assignments_string = "\n    ".join(assignments) if assignments else "pass"
+    return f"def __init__({params_string}) -> None:\n    {assignments_string}"
 
 
 def infer_dataclass_attribute(

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -110,7 +110,7 @@ class NodeNG:
             # explicit_inference is not bound, give it self explicitly
             try:
                 # pylint: disable=not-callable
-                results = tuple(self._explicit_inference(self, context, **kwargs))
+                results = list(self._explicit_inference(self, context, **kwargs))
                 if context is not None:
                     context.nodes_inferred += len(results)
                 yield from results

--- a/pylintrc
+++ b/pylintrc
@@ -96,11 +96,6 @@ disable=fixme,
         too-many-statements,
         # We know about it and we're doing our best to remove it in 2.0 (oups)
         cyclic-import,
-        # The check is faulty in most cases and it doesn't take in
-        # account how the variable is being used. For instance,
-        # using a variable that is a list or a generator in an
-        # iteration context is fine.
-        redefined-variable-type,
         # Requires major redesign for fixing this (and private
         # access in the same project is fine)
         protected-access,


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

Seems easy enough to fix this and allow this check to be enabled. Would be necessary for `mypy` (at some point) anyway.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue
