### PR TITLE
Promote most dunder definitions on ``FunctionModel`` to ``ObjectModel``

### DIFF
--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -161,6 +161,28 @@ class ObjectModel:
 
         return bases.BoundMethod(proxy=node, bound=_get_bound_node(self))
 
+    # These are here just for completion.
+    @property
+    def attr___ne__(self):
+        return node_classes.Unknown()
+
+    attr___subclasshook__ = attr___ne__
+    attr___str__ = attr___ne__
+    attr___sizeof__ = attr___ne__
+    attr___setattr___ = attr___ne__
+    attr___repr__ = attr___ne__
+    attr___reduce__ = attr___ne__
+    attr___reduce_ex__ = attr___ne__
+    attr___lt__ = attr___ne__
+    attr___eq__ = attr___ne__
+    attr___gt__ = attr___ne__
+    attr___format__ = attr___ne__
+    attr___delattr___ = attr___ne__
+    attr___getattribute__ = attr___ne__
+    attr___hash__ = attr___ne__
+    attr___dir__ = attr___ne__
+    attr___class__ = attr___ne__
+
 
 class ModuleModel(ObjectModel):
     def _builtins(self):
@@ -422,29 +444,9 @@ class FunctionModel(ObjectModel):
         return DescriptorBoundMethod(proxy=self._instance, bound=self._instance)
 
     # These are here just for completion.
-    @property
-    def attr___ne__(self):
-        return node_classes.Unknown()
-
-    attr___subclasshook__ = attr___ne__
-    attr___str__ = attr___ne__
-    attr___sizeof__ = attr___ne__
-    attr___setattr___ = attr___ne__
-    attr___repr__ = attr___ne__
-    attr___reduce__ = attr___ne__
-    attr___reduce_ex__ = attr___ne__
-    attr___lt__ = attr___ne__
-    attr___eq__ = attr___ne__
-    attr___gt__ = attr___ne__
-    attr___format__ = attr___ne__
-    attr___delattr___ = attr___ne__
-    attr___getattribute__ = attr___ne__
-    attr___hash__ = attr___ne__
-    attr___dir__ = attr___ne__
-    attr___call__ = attr___ne__
-    attr___class__ = attr___ne__
-    attr___closure__ = attr___ne__
-    attr___code__ = attr___ne__
+    attr___call__ = ObjectModel.attr___ne__
+    attr___closure__ = ObjectModel.attr___ne__
+    attr___code__ = ObjectModel.attr___ne__
 
 
 class ClassModel(ObjectModel):

--- a/tests/unittest_object_model.py
+++ b/tests/unittest_object_model.py
@@ -262,7 +262,6 @@ class ModuleModelTest(unittest.TestCase):
         xml.__repr__ #@
         xml.__reduce__ #@
 
-        xml.__setattr__ #@
         xml.__reduce_ex__ #@
         xml.__lt__ #@
         xml.__eq__ #@
@@ -272,6 +271,8 @@ class ModuleModelTest(unittest.TestCase):
         xml.__getattribute__ #@
         xml.__hash__ #@
         xml.__dir__ #@
+
+        xml.__setattr__ #@
         xml.__call__ #@
         xml.__closure__ #@
         """
@@ -316,9 +317,13 @@ class ModuleModelTest(unittest.TestCase):
 
         # The following nodes are just here for theoretical completeness,
         # and they either return Uninferable or raise InferenceError.
-        for ast_node in ast_nodes[11:28]:
+        for ast_node in ast_nodes[11:25]:
+            inferred = next(ast_node.infer())
+            assert inferred is util.Uninferable
+
+        for ast_node in ast_nodes[25:28]:
             with pytest.raises(InferenceError):
-                next(ast_node.infer())
+                inferred = next(ast_node.infer())
 
 
 class FunctionModelTest(unittest.TestCase):


### PR DESCRIPTION
## Description

Create ``DunderCompletionMixin`` in order to let ``ModuleModel`` share the same dunder definitions that were already present on ``FunctionModel``.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactor |



## Related Issue

Refs PyCQA/pylint#6094