### PR TITLE
Infer members of ``Enums`` as instances of the ``Enum`` they belong to

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1367,6 +1367,11 @@ Release date: 2022-07-09
 
   Closes pylint-dev/pylint#5776
 
+* Members of ``Enums`` are now correctly inferred as instances of the ``Enum`` they belong
+  to instead of instances of their own class.
+
+  Closes #744
+
 * Rename ``ModuleSpec`` -> ``module_type`` constructor parameter to match attribute
   name and improve typing. Use ``type`` instead.
 

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -241,7 +241,17 @@ class BaseInstance(Proxy):
 
     special_attributes: objectmodel.ObjectModel
 
-    def display_type(self) -> str:
+    def __init__(self, proxied: nodes.ClassDef | None = None) -> None:
+        self._explicit_instance_attrs: dict[str, list[nodes.NodeNG]] = {}
+        """Attributes that have been explicitly set during initialization
+        of the specific instance.
+
+        This dictionary can be used to differentiate between attributes assosciated to
+        the proxy and attributes that are specific to the instantiated instance.
+        """
+        super().__init__(proxied)
+
+    def display_type(self):
         return "Instance of"
 
     def getattr(
@@ -250,6 +260,12 @@ class BaseInstance(Proxy):
         context: InferenceContext | None = None,
         lookupclass: bool = True,
     ) -> list[InferenceResult]:
+        # See if the attribute is set explicitly for this instance
+        try:
+            return self._explicit_instance_attrs[name]
+        except KeyError:
+            pass
+
         try:
             values = self._proxied.instance_attr(name, context)
         except AttributeInferenceError as exc:

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -386,148 +386,74 @@ INT_FLAG_ADDITION_METHODS = """
 
 def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
     """Specific inference for enums."""
-    for basename in (b for cls in node.mro() for b in cls.basenames):
-        if node.root().name == "enum":
-            # Skip if the class is directly from enum module.
-            break
-        dunder_members = {}
-        target_names = set()
-        for local, values in node.locals.items():
-            if (
-                any(not isinstance(value, nodes.AssignName) for value in values)
-                or local == "_ignore_"
-            ):
-                continue
+    if node.root().name == "enum":
+        # Skip if the class is directly from enum module.
+        return node
+    dunder_members: dict[str, bases.Instance] = {}
+    for local, values in node.locals.items():
+        if (
+            any(not isinstance(value, nodes.AssignName) for value in values)
+            or local == "_ignore_"
+        ):
+            continue
 
-            stmt = values[0].statement()
-            if isinstance(stmt, nodes.Assign):
-                if isinstance(stmt.targets[0], nodes.Tuple):
-                    targets = stmt.targets[0].itered()
-                else:
-                    targets = stmt.targets
-            elif isinstance(stmt, nodes.AnnAssign):
-                targets = [stmt.target]
+        stmt = values[0].statement()
+        if isinstance(stmt, nodes.Assign):
+            if isinstance(stmt.targets[0], nodes.Tuple):
+                targets: list[nodes.NodeNG] = stmt.targets[0].itered()
             else:
+                targets = stmt.targets
+            value_node = stmt.value
+        elif isinstance(stmt, nodes.AnnAssign):
+            targets = [stmt.target]  # type: ignore[list-item] # .target shouldn't be None
+            value_node = stmt.value
+        else:
+            continue
+
+        new_targets: list[bases.Instance] = []
+        for target in targets:
+            if isinstance(target, nodes.Starred):
                 continue
 
-            inferred_return_value = None
-            if stmt.value is not None:
-                if isinstance(stmt.value, nodes.Const):
-                    if isinstance(stmt.value.value, str):
-                        inferred_return_value = repr(stmt.value.value)
-                    else:
-                        inferred_return_value = stmt.value.value
-                else:
-                    inferred_return_value = stmt.value.as_string()
+            # Instantiate a class of the Enum with the value and name
+            # attributes set to the values of the assignment
+            # See: https://docs.python.org/3/library/enum.html#creating-an-enum
+            target_node = node.instantiate_class()
+            target_node._explicit_instance_attrs["value"] = [value_node]
+            target_node._explicit_instance_attrs["name"] = [
+                nodes.const_factory(target.name)
+            ]
 
-            new_targets = []
-            for target in targets:
-                if isinstance(target, nodes.Starred):
-                    continue
-                target_names.add(target.name)
-                # Replace all the assignments with our mocked class.
-                classdef = dedent(
-                    """
-                class {name}({types}):
-                    @property
-                    def value(self):
-                        return {return_value}
-                    @property
-                    def _value_(self):
-                        return {return_value}
-                    @property
-                    def name(self):
-                        return "{name}"
-                    @property
-                    def _name_(self):
-                        return "{name}"
-                """.format(
-                        name=target.name,
-                        types=", ".join(node.basenames),
-                        return_value=inferred_return_value,
-                    )
-                )
-                if "IntFlag" in basename:
-                    # Alright, we need to add some additional methods.
-                    # Unfortunately we still can't infer the resulting objects as
-                    # Enum members, but once we'll be able to do that, the following
-                    # should result in some nice symbolic execution
-                    classdef += INT_FLAG_ADDITION_METHODS.format(name=target.name)
+            new_targets.append(target_node)
+            dunder_members[local] = target_node
 
-                fake = AstroidBuilder(
-                    AstroidManager(), apply_transforms=False
-                ).string_build(classdef)[target.name]
-                fake.parent = target.parent
-                for method in node.mymethods():
-                    fake.locals[method.name] = [method]
-                new_targets.append(fake.instantiate_class())
-                if stmt.value is None:
-                    continue
-                dunder_members[local] = fake
-            node.locals[local] = new_targets
+        node.locals[local] = new_targets
 
-        # The undocumented `_value2member_map_` member:
-        node.locals["_value2member_map_"] = [
-            nodes.Dict(
-                parent=node,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
+    # Creation of the __members__ attribute of the Enum node
+    members = nodes.Dict(
+        parent=node,
+        lineno=node.lineno,
+        col_offset=node.col_offset,
+        end_lineno=node.end_lineno,
+        end_col_offset=node.end_col_offset,
+    )
+    members.postinit(
+        [
+            (
+                nodes.Const(k, parent=members),
+                nodes.Name(
+                    v.name,
+                    parent=members,
+                    lineno=v.lineno,
+                    col_offset=v.col_offset,
+                    end_lineno=v.end_lineno,
+                    end_col_offset=v.end_col_offset,
+                ),
             )
+            for k, v in dunder_members.items()
         ]
-
-        members = nodes.Dict(
-            parent=node,
-            lineno=node.lineno,
-            col_offset=node.col_offset,
-            end_lineno=node.end_lineno,
-            end_col_offset=node.end_col_offset,
-        )
-        members.postinit(
-            [
-                (
-                    nodes.Const(k, parent=members),
-                    nodes.Name(
-                        v.name,
-                        parent=members,
-                        lineno=v.lineno,
-                        col_offset=v.col_offset,
-                        end_lineno=v.end_lineno,
-                        end_col_offset=v.end_col_offset,
-                    ),
-                )
-                for k, v in dunder_members.items()
-            ]
-        )
-        node.locals["__members__"] = [members]
-        # The enum.Enum class itself defines two @DynamicClassAttribute data-descriptors
-        # "name" and "value" (which we override in the mocked class for each enum member
-        # above). When dealing with inference of an arbitrary instance of the enum
-        # class, e.g. in a method defined in the class body like:
-        #     class SomeEnum(enum.Enum):
-        #         def method(self):
-        #             self.name  # <- here
-        # In the absence of an enum member called "name" or "value", these attributes
-        # should resolve to the descriptor on that particular instance, i.e. enum member.
-        # For "value", we have no idea what that should be, but for "name", we at least
-        # know that it should be a string, so infer that as a guess.
-        if "name" not in target_names:
-            code = dedent('''
-                @property
-                def name(self):
-                    """The name of the Enum member.
-
-                    This is a reconstruction by astroid: enums are too dynamic to understand, but we at least
-                    know 'name' should be a string, so this is astroid's best guess.
-                    """
-                    return ''
-                ''')
-            name_dynamicclassattr = AstroidBuilder(AstroidManager()).string_build(code)[
-                "name"
-            ]
-            node.locals["name"] = [name_dynamicclassattr]
-        break
+    )
+    node.locals["__members__"] = [members]
     return node
 
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -292,6 +292,8 @@ class BaseContainer(_base_nodes.ParentAssignNode, Instance, metaclass=abc.ABCMet
             parent=parent,
         )
 
+        Instance.__init__(self, None)
+
     def postinit(self, elts: list[SuccessfulInferenceResult]) -> None:
         self.elts = elts
 
@@ -2372,6 +2374,7 @@ class Dict(NodeNG, Instance):
             end_col_offset=end_col_offset,
             parent=parent,
         )
+        Instance.__init__(self, self._proxied)
 
     def postinit(self, items: list[tuple[InferenceResult, InferenceResult]]) -> None:
         """Do some setup after initialisation.

--- a/tests/brain/test_enum.py
+++ b/tests/brain/test_enum.py
@@ -9,7 +9,8 @@ import unittest
 import pytest
 
 import astroid
-from astroid import bases, builder, nodes, objects
+from astroid import bases, builder, nodes, objects, util
+from astroid.const import PY311_PLUS
 from astroid.exceptions import InferenceError
 
 
@@ -29,11 +30,17 @@ class EnumBrainTest(unittest.TestCase):
 
         enumeration = next(module["MyEnum"].infer())
         one = enumeration["one"]
-        self.assertEqual(one.pytype(), ".MyEnum.one")
+        self.assertEqual(one.pytype(), ".MyEnum")
 
         for propname in ("name", "value"):
-            prop = next(iter(one.getattr(propname)))
-            self.assertIn("builtins.property", prop.decoratornames())
+            # On the base Enum class 'name' and 'value' are properties
+            # decorated by DynamicClassAttribute in < 3.11.
+            prop = next(iter(one._proxied.getattr(propname)))
+            if PY311_PLUS:
+                expected_name = "enum.property"
+            else:
+                expected_name = "types.DynamicClassAttribute"
+            self.assertIn(expected_name, prop.decoratornames())
 
         meth = one.getattr("mymethod")[0]
         self.assertIsInstance(meth, nodes.FunctionDef)
@@ -262,18 +269,17 @@ class EnumBrainTest(unittest.TestCase):
         """
         i_name, i_value, c_name, c_value = astroid.extract_node(code)
 
-        # <instance>.name should be a string, <class>.name should be a property (that
+        # <instance>.name should be Uninferable, <class>.name should be a property (that
         # forwards the lookup to __getattr__)
         inferred = next(i_name.infer())
-        assert isinstance(inferred, nodes.Const)
-        assert inferred.pytype() == "builtins.str"
+        assert inferred is util.Uninferable
         inferred = next(c_name.infer())
         assert isinstance(inferred, objects.Property)
 
-        # Inferring .value should not raise InferenceError. It is probably Uninferable
-        # but we don't particularly care
-        next(i_value.infer())
-        next(c_value.infer())
+        inferred = next(i_value.infer())
+        assert inferred is util.Uninferable
+        inferred = next(c_value.infer())
+        assert isinstance(inferred, objects.Property)
 
     def test_enum_name_property_has_docstring(self) -> None:
         code = """
@@ -302,19 +308,23 @@ class EnumBrainTest(unittest.TestCase):
         """
         i_name, i_value, c_name, c_value = astroid.extract_node(code)
 
-        # All of these cases should be inferred as enum members
-        inferred = next(i_name.infer())
-        assert isinstance(inferred, bases.Instance)
-        assert inferred.pytype() == ".TrickyEnum.name"
-        inferred = next(c_name.infer())
-        assert isinstance(inferred, bases.Instance)
-        assert inferred.pytype() == ".TrickyEnum.name"
-        inferred = next(i_value.infer())
-        assert isinstance(inferred, bases.Instance)
-        assert inferred.pytype() == ".TrickyEnum.value"
-        inferred = next(c_value.infer())
-        assert isinstance(inferred, bases.Instance)
-        assert inferred.pytype() == ".TrickyEnum.value"
+        # All of these cases should be inferred as enum instances
+        # and refer to the same instance
+        name_inner = next(i_name.infer())
+        assert isinstance(name_inner, bases.Instance)
+        assert name_inner.pytype() == ".TrickyEnum"
+        name_outer = next(c_name.infer())
+        assert isinstance(name_outer, bases.Instance)
+        assert name_outer.pytype() == ".TrickyEnum"
+        assert name_inner == name_outer
+
+        value_inner = next(i_value.infer())
+        assert isinstance(value_inner, bases.Instance)
+        assert value_inner.pytype() == ".TrickyEnum"
+        value_outer = next(c_value.infer())
+        assert isinstance(value_outer, bases.Instance)
+        assert value_outer.pytype() == ".TrickyEnum"
+        assert value_inner == value_outer
 
     def test_enum_subclass_member_name(self) -> None:
         ast_node = astroid.extract_node("""
@@ -420,7 +430,15 @@ class EnumBrainTest(unittest.TestCase):
         """)
         inferred = next(ast_node.infer())
         assert isinstance(inferred, bases.Instance)
-        assert inferred._proxied.name == "ENUM_KEY"
+        assert inferred._proxied.name == "MyEnum"
+
+        name_node = inferred.getattr("name")[0]
+        assert isinstance(name_node, nodes.Const)
+        assert name_node.value == "ENUM_KEY"
+
+        value_node = inferred.getattr("value")[0]
+        assert isinstance(value_node, nodes.Const)
+        assert value_node.value == "enum_value"
 
     def test_class_named_enum(self) -> None:
         """Test that the user-defined class named `Enum` is not inferred as `enum.Enum`"""

--- a/tests/brain/test_ssl.py
+++ b/tests/brain/test_ssl.py
@@ -41,7 +41,11 @@ def test_ssl_brain() -> None:
     # TLSVersion is inferred from the main module, not from the brain
     inferred_cert_required = next(module.body[4].value.infer())
     assert isinstance(inferred_cert_required, bases.Instance)
-    assert inferred_cert_required._proxied.name == "CERT_REQUIRED"
+    assert inferred_cert_required._proxied.name == "VerifyMode"
+
+    value_node = inferred_cert_required.getattr("value")[0]
+    assert isinstance(value_node, nodes.Const)
+    assert value_node.value == 2
 
 
 @pytest.mark.skipif(not PY312_PLUS, reason="Uses new 3.12 constant")


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Closes #744

Also partially refs https://github.com/PyCQA/astroid/issues/142.

We need some way to store attributes that are specific to an individual instance. I'm not sure if this is the best way so I'm open to feedback!

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
