### PR TITLE
Work in progress: Add pydocstring formatter in pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,3 +94,10 @@ repos:
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]
+  - repo: https://github.com/DanielNoord/pydocstringformatter
+    rev: v0.7.0
+    hooks:
+      - id: pydocstringformatter
+        exclude: tests/testdata
+        args: ["--max-summary-lines=2", "--linewrap-full-docstring"]
+        files: "astroid"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,4 +100,4 @@ repos:
       - id: pydocstringformatter
         exclude: tests/testdata
         args: ["--max-summary-lines=2", "--linewrap-full-docstring"]
-        files: "astroid"
+        files: "astroid,tests"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,7 +95,7 @@ repos:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]
   - repo: https://github.com/DanielNoord/pydocstringformatter
-    rev: v0.7.0
+    rev: v0.7.3
     hooks:
       - id: pydocstringformatter
         exclude: tests/testdata

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -435,7 +435,8 @@ class UnboundMethod(Proxy):
     def infer_call_result(self, caller, context):
         """
         The boundnode of the regular context with a function called
-        on ``object.__new__`` will be of type ``object``,
+        on ``object.__new__`` will be of type ``object``,.
+
         which is incorrect for the argument in general.
         If no context is given the ``object.__new__`` call argument will
         be correctly inferred except when inside a call that requires

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -3,7 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """
-Astroid hook for the attrs library
+Astroid hook for the attrs library.
 
 Without this hook pylint reports unsupported-assignment-operation
 for attrs classes
@@ -45,7 +45,7 @@ def is_decorated_with_attrs(node, decorator_names=ATTRS_NAMES) -> bool:
 
 def attr_attributes_transform(node: ClassDef) -> None:
     """Given that the ClassNode has an attr decorator,
-    rewrite class attributes as instance attributes
+    rewrite class attributes as instance attributes.
     """
     # Astroid can't infer this attribute properly
     # Prevents https://github.com/PyCQA/pylint/issues/1884

--- a/astroid/brain/brain_hypothesis.py
+++ b/astroid/brain/brain_hypothesis.py
@@ -38,7 +38,8 @@ def is_decorated_with_st_composite(node) -> bool:
 
 def remove_draw_parameter_from_composite_strategy(node):
     """Given that the FunctionDef is decorated with @st.composite, remove the
-    first argument (`draw`) - it's always supplied by Hypothesis so we don't
+    first argument (`draw`) - it's always supplied by Hypothesis so we don't.
+
     need to emit the no-value-for-parameter lint.
     """
     del node.args.args[0]

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -499,6 +499,7 @@ def infer_typing_namedtuple_class(class_node, context: InferenceContext | None =
 def infer_typing_namedtuple_function(node, context: InferenceContext | None = None):
     """
     Starting with python3.9, NamedTuple is a function of the typing module.
+
     The class NamedTuple is build dynamically through a call to `type` during
     initialization of the `_NamedTuple` variable.
     """

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -238,7 +238,9 @@ def _forbid_class_getitem_access(node: ClassDef) -> None:
 
     def full_raiser(origin_func, attr, *args, **kwargs):
         """
-        Raises an AttributeInferenceError in case of access to __class_getitem__ method.
+        Raises an AttributeInferenceError in case of access to __class_getitem__
+        method.
+
         Otherwise, just call origin_func.
         """
         if attr == "__class_getitem__":
@@ -262,7 +264,8 @@ def infer_typing_alias(
 ) -> Iterator[ClassDef]:
     """
     Infers the call to _alias function
-    Insert ClassDef, with same name as aliased class,
+    Insert ClassDef, with same name as aliased class,.
+
     in mro to simulate _GenericAlias.
 
     :param node: call node

--- a/astroid/constraint.py
+++ b/astroid/constraint.py
@@ -28,7 +28,10 @@ class Constraint(ABC):
         self.node = node
         """The node that this constraint applies to."""
         self.negate = negate
-        """True if this constraint is negated. E.g., "is not" instead of "is"."""
+        """True if this constraint is negated.
+
+        E.g., "is not" instead of "is".
+        """
 
     @classmethod
     @abstractmethod

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -56,7 +56,7 @@ class InferenceContext:
 
         self.path = path or set()
         """
-        :type: set(tuple(NodeNG, optional(str)))
+        :type: set(tuple(NodeNG, optional(str))).
 
         Path of visited nodes and their lookupname
 
@@ -73,7 +73,7 @@ class InferenceContext:
         """The call arguments and keywords for the given context."""
         self.boundnode = None
         """
-        :type: optional[NodeNG]
+        :type: optional[NodeNG].
 
         The bound node of the given context
 
@@ -81,7 +81,7 @@ class InferenceContext:
         """
         self.extra_context = {}
         """
-        :type: dict(NodeNG, Context)
+        :type: dict(NodeNG, Context).
 
         Context that needs to be passed down through call stacks
         for call arguments
@@ -188,7 +188,8 @@ def copy_context(context: InferenceContext | None) -> InferenceContext:
 
 def bind_context_to_node(context: InferenceContext | None, node) -> InferenceContext:
     """Give a context a boundnode
-    to retrieve the correct function name or attribute value
+    to retrieve the correct function name or attribute value.
+
     with from further inference.
 
     Do not use an existing context since the boundnode could then

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -203,7 +203,9 @@ nodes.Dict._infer = infer_map  # type: ignore[assignment]
 
 def _higher_function_scope(node: nodes.NodeNG) -> nodes.FunctionDef | None:
     """Search for the first function which encloses the given
-    scope. This can be used for looking up in that function's
+    scope.
+
+    This can be used for looking up in that function's
     scope, in case looking up in a lower scope for a particular
     name fails.
 
@@ -986,7 +988,8 @@ def _do_compare(
 ) -> bool | type[util.Uninferable]:
     """
     If all possible combinations are either True or False, return that:
-    >>> _do_compare([1, 2], '<=', [3, 4])
+    >>> _do_compare([1, 2], '<=', [3, 4]).
+
     True
     >>> _do_compare([1, 2], '==', [3, 4])
     False

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -2,8 +2,9 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
-"""astroid manager: avoid multiple astroid build of a same module when
-possible by providing a class responsible to get astroid representation
+"""Astroid manager: avoid multiple astroid build of a same module when
+possible by providing a class responsible to get astroid representation.
+
 from various source and using a cache of built modules)
 """
 

--- a/astroid/nodes/as_string.py
+++ b/astroid/nodes/as_string.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
-"""This module renders Astroid nodes as string"""
+"""This module renders Astroid nodes as string."""
 
 from __future__ import annotations
 
@@ -33,17 +33,17 @@ DOC_NEWLINE = "\0"
 # Visitor pattern require argument all the time and is not better with staticmethod
 # noinspection PyUnusedLocal,PyMethodMayBeStatic
 class AsStringVisitor:
-    """Visitor to render an Astroid node as a valid python code string"""
+    """Visitor to render an Astroid node as a valid python code string."""
 
     def __init__(self, indent: str = "    "):
         self.indent: str = indent
 
     def __call__(self, node) -> str:
-        """Makes this visitor behave as a simple function"""
+        """Makes this visitor behave as a simple function."""
         return node.accept(self).replace(DOC_NEWLINE, "\n")
 
     def _docs_dedent(self, doc_node: Const | None) -> str:
-        """Stop newlines in docs being indented by self._stmt_list"""
+        """Stop newlines in docs being indented by self._stmt_list."""
         if not doc_node:
             return ""
 
@@ -52,7 +52,7 @@ class AsStringVisitor:
         )
 
     def _stmt_list(self, stmts: list, indent: bool = True) -> str:
-        """return a list of nodes to string"""
+        """Return a list of nodes to string."""
         stmts_str: str = "\n".join(
             nstr for nstr in [n.accept(self) for n in stmts] if nstr
         )
@@ -62,7 +62,7 @@ class AsStringVisitor:
         return self.indent + stmts_str.replace("\n", "\n" + self.indent)
 
     def _precedence_parens(self, node, child, is_left: bool = True) -> str:
-        """Wrap child in parens only if required to keep same semantics"""
+        """Wrap child in parens only if required to keep same semantics."""
         if self._should_wrap(node, child, is_left):
             return f"({child.accept(self)})"
 
@@ -70,7 +70,8 @@ class AsStringVisitor:
 
     def _should_wrap(self, node, child, is_left: bool) -> bool:
         """Wrap child if:
-        - it has lower precedence
+        - it has lower precedence.
+
         - same precedence with position opposite to associativity direction
         """
         node_precedence = node.op_precedence()
@@ -102,34 +103,34 @@ class AsStringVisitor:
         return f"async {self.visit_for(node)}"
 
     def visit_arguments(self, node) -> str:
-        """return an astroid.Function node as string"""
+        """Return an astroid.Function node as string."""
         return node.format_args()
 
     def visit_assignattr(self, node) -> str:
-        """return an astroid.AssAttr node as string"""
+        """Return an astroid.AssAttr node as string."""
         return self.visit_attribute(node)
 
     def visit_assert(self, node) -> str:
-        """return an astroid.Assert node as string"""
+        """Return an astroid.Assert node as string."""
         if node.fail:
             return f"assert {node.test.accept(self)}, {node.fail.accept(self)}"
         return f"assert {node.test.accept(self)}"
 
     def visit_assignname(self, node) -> str:
-        """return an astroid.AssName node as string"""
+        """Return an astroid.AssName node as string."""
         return node.name
 
     def visit_assign(self, node) -> str:
-        """return an astroid.Assign node as string"""
+        """Return an astroid.Assign node as string."""
         lhs = " = ".join(n.accept(self) for n in node.targets)
         return f"{lhs} = {node.value.accept(self)}"
 
     def visit_augassign(self, node) -> str:
-        """return an astroid.AugAssign node as string"""
+        """Return an astroid.AugAssign node as string."""
         return f"{node.target.accept(self)} {node.op} {node.value.accept(self)}"
 
     def visit_annassign(self, node) -> str:
-        """Return an astroid.AugAssign node as string"""
+        """Return an astroid.AugAssign node as string."""
 
         target = node.target.accept(self)
         annotation = node.annotation.accept(self)
@@ -138,7 +139,7 @@ class AsStringVisitor:
         return f"{target}: {annotation} = {node.value.accept(self)}"
 
     def visit_binop(self, node) -> str:
-        """return an astroid.BinOp node as string"""
+        """Return an astroid.BinOp node as string."""
         left = self._precedence_parens(node, node.left)
         right = self._precedence_parens(node, node.right, is_left=False)
         if node.op == "**":
@@ -147,16 +148,16 @@ class AsStringVisitor:
         return f"{left} {node.op} {right}"
 
     def visit_boolop(self, node) -> str:
-        """return an astroid.BoolOp node as string"""
+        """Return an astroid.BoolOp node as string."""
         values = [f"{self._precedence_parens(node, n)}" for n in node.values]
         return (f" {node.op} ").join(values)
 
     def visit_break(self, node) -> str:
-        """return an astroid.Break node as string"""
+        """Return an astroid.Break node as string."""
         return "break"
 
     def visit_call(self, node) -> str:
-        """return an astroid.Call node as string"""
+        """Return an astroid.Call node as string."""
         expr_str = self._precedence_parens(node, node.func)
         args = [arg.accept(self) for arg in node.args]
         if node.keywords:
@@ -168,7 +169,7 @@ class AsStringVisitor:
         return f"{expr_str}({', '.join(args)})"
 
     def visit_classdef(self, node) -> str:
-        """return an astroid.ClassDef node as string"""
+        """Return an astroid.ClassDef node as string."""
         decorate = node.decorators.accept(self) if node.decorators else ""
         args = [n.accept(self) for n in node.bases]
         if node._metaclass and not node.has_metaclass_hack():
@@ -181,7 +182,7 @@ class AsStringVisitor:
         )
 
     def visit_compare(self, node) -> str:
-        """return an astroid.Compare node as string"""
+        """Return an astroid.Compare node as string."""
         rhs_str = " ".join(
             f"{op} {self._precedence_parens(node, expr, is_left=False)}"
             for op, expr in node.ops
@@ -189,39 +190,39 @@ class AsStringVisitor:
         return f"{self._precedence_parens(node, node.left)} {rhs_str}"
 
     def visit_comprehension(self, node) -> str:
-        """return an astroid.Comprehension node as string"""
+        """Return an astroid.Comprehension node as string."""
         ifs = "".join(f" if {n.accept(self)}" for n in node.ifs)
         generated = f"for {node.target.accept(self)} in {node.iter.accept(self)}{ifs}"
         return f"{'async ' if node.is_async else ''}{generated}"
 
     def visit_const(self, node) -> str:
-        """return an astroid.Const node as string"""
+        """Return an astroid.Const node as string."""
         if node.value is Ellipsis:
             return "..."
         return repr(node.value)
 
     def visit_continue(self, node) -> str:
-        """return an astroid.Continue node as string"""
+        """Return an astroid.Continue node as string."""
         return "continue"
 
     def visit_delete(self, node) -> str:  # XXX check if correct
-        """return an astroid.Delete node as string"""
+        """Return an astroid.Delete node as string."""
         return f"del {', '.join(child.accept(self) for child in node.targets)}"
 
     def visit_delattr(self, node) -> str:
-        """return an astroid.DelAttr node as string"""
+        """Return an astroid.DelAttr node as string."""
         return self.visit_attribute(node)
 
     def visit_delname(self, node) -> str:
-        """return an astroid.DelName node as string"""
+        """Return an astroid.DelName node as string."""
         return node.name
 
     def visit_decorators(self, node) -> str:
-        """return an astroid.Decorators node as string"""
+        """Return an astroid.Decorators node as string."""
         return "@%s\n" % "\n@".join(item.accept(self) for item in node.nodes)
 
     def visit_dict(self, node) -> str:
-        """return an astroid.Dict node as string"""
+        """Return an astroid.Dict node as string."""
         return "{%s}" % ", ".join(self._visit_dict(node))
 
     def _visit_dict(self, node) -> Iterator[str]:
@@ -238,7 +239,7 @@ class AsStringVisitor:
         return "**"
 
     def visit_dictcomp(self, node) -> str:
-        """return an astroid.DictComp node as string"""
+        """Return an astroid.DictComp node as string."""
         return "{{{}: {} {}}}".format(
             node.key.accept(self),
             node.value.accept(self),
@@ -246,11 +247,11 @@ class AsStringVisitor:
         )
 
     def visit_expr(self, node) -> str:
-        """return an astroid.Discard node as string"""
+        """Return an astroid.Discard node as string."""
         return node.value.accept(self)
 
     def visit_emptynode(self, node) -> str:
-        """dummy method for visiting an Empty node"""
+        """Dummy method for visiting an Empty node."""
         return ""
 
     def visit_excepthandler(self, node) -> str:
@@ -264,11 +265,11 @@ class AsStringVisitor:
         return f"{excs}:\n{self._stmt_list(node.body)}"
 
     def visit_empty(self, node) -> str:
-        """return an Empty node as string"""
+        """Return an Empty node as string."""
         return ""
 
     def visit_for(self, node) -> str:
-        """return an astroid.For node as string"""
+        """Return an astroid.For node as string."""
         fors = "for {} in {}:\n{}".format(
             node.target.accept(self), node.iter.accept(self), self._stmt_list(node.body)
         )
@@ -277,7 +278,7 @@ class AsStringVisitor:
         return fors
 
     def visit_importfrom(self, node) -> str:
-        """return an astroid.ImportFrom node as string"""
+        """Return an astroid.ImportFrom node as string."""
         return "from {} import {}".format(
             "." * (node.level or 0) + node.modname, _import_string(node.names)
         )
@@ -318,7 +319,7 @@ class AsStringVisitor:
         return "{%s}" % result
 
     def handle_functiondef(self, node, keyword) -> str:
-        """return a (possibly async) function definition node as string"""
+        """Return a (possibly async) function definition node as string."""
         decorate = node.decorators.accept(self) if node.decorators else ""
         docs = self._docs_dedent(node.doc_node)
         trailer = ":"
@@ -337,32 +338,32 @@ class AsStringVisitor:
         )
 
     def visit_functiondef(self, node) -> str:
-        """return an astroid.FunctionDef node as string"""
+        """Return an astroid.FunctionDef node as string."""
         return self.handle_functiondef(node, "def")
 
     def visit_asyncfunctiondef(self, node) -> str:
-        """return an astroid.AsyncFunction node as string"""
+        """Return an astroid.AsyncFunction node as string."""
         return self.handle_functiondef(node, "async def")
 
     def visit_generatorexp(self, node) -> str:
-        """return an astroid.GeneratorExp node as string"""
+        """Return an astroid.GeneratorExp node as string."""
         return "({} {})".format(
             node.elt.accept(self), " ".join(n.accept(self) for n in node.generators)
         )
 
     def visit_attribute(self, node) -> str:
-        """return an astroid.Getattr node as string"""
+        """Return an astroid.Getattr node as string."""
         left = self._precedence_parens(node, node.expr)
         if left.isdigit():
             left = f"({left})"
         return f"{left}.{node.attrname}"
 
     def visit_global(self, node) -> str:
-        """return an astroid.Global node as string"""
+        """Return an astroid.Global node as string."""
         return f"global {', '.join(node.names)}"
 
     def visit_if(self, node) -> str:
-        """return an astroid.If node as string"""
+        """Return an astroid.If node as string."""
         ifs = [f"if {node.test.accept(self)}:\n{self._stmt_list(node.body)}"]
         if node.has_elif_block():
             ifs.append(f"el{self._stmt_list(node.orelse, indent=False)}")
@@ -371,7 +372,7 @@ class AsStringVisitor:
         return "\n".join(ifs)
 
     def visit_ifexp(self, node) -> str:
-        """return an astroid.IfExp node as string"""
+        """Return an astroid.IfExp node as string."""
         return "{} if {} else {}".format(
             self._precedence_parens(node, node.body, is_left=True),
             self._precedence_parens(node, node.test, is_left=True),
@@ -379,17 +380,17 @@ class AsStringVisitor:
         )
 
     def visit_import(self, node) -> str:
-        """return an astroid.Import node as string"""
+        """Return an astroid.Import node as string."""
         return f"import {_import_string(node.names)}"
 
     def visit_keyword(self, node) -> str:
-        """return an astroid.Keyword node as string"""
+        """Return an astroid.Keyword node as string."""
         if node.arg is None:
             return f"**{node.value.accept(self)}"
         return f"{node.arg}={node.value.accept(self)}"
 
     def visit_lambda(self, node) -> str:
-        """return an astroid.Lambda node as string"""
+        """Return an astroid.Lambda node as string."""
         args = node.args.accept(self)
         body = node.body.accept(self)
         if args:
@@ -398,40 +399,40 @@ class AsStringVisitor:
         return f"lambda: {body}"
 
     def visit_list(self, node) -> str:
-        """return an astroid.List node as string"""
+        """Return an astroid.List node as string."""
         return f"[{', '.join(child.accept(self) for child in node.elts)}]"
 
     def visit_listcomp(self, node) -> str:
-        """return an astroid.ListComp node as string"""
+        """Return an astroid.ListComp node as string."""
         return "[{} {}]".format(
             node.elt.accept(self), " ".join(n.accept(self) for n in node.generators)
         )
 
     def visit_module(self, node) -> str:
-        """return an astroid.Module node as string"""
+        """Return an astroid.Module node as string."""
         docs = f'"""{node.doc_node.value}"""\n\n' if node.doc_node else ""
         return docs + "\n".join(n.accept(self) for n in node.body) + "\n\n"
 
     def visit_name(self, node) -> str:
-        """return an astroid.Name node as string"""
+        """Return an astroid.Name node as string."""
         return node.name
 
     def visit_namedexpr(self, node) -> str:
-        """Return an assignment expression node as string"""
+        """Return an assignment expression node as string."""
         target = node.target.accept(self)
         value = node.value.accept(self)
         return f"{target} := {value}"
 
     def visit_nonlocal(self, node) -> str:
-        """return an astroid.Nonlocal node as string"""
+        """Return an astroid.Nonlocal node as string."""
         return f"nonlocal {', '.join(node.names)}"
 
     def visit_pass(self, node) -> str:
-        """return an astroid.Pass node as string"""
+        """Return an astroid.Pass node as string."""
         return "pass"
 
     def visit_raise(self, node) -> str:
-        """return an astroid.Raise node as string"""
+        """Return an astroid.Raise node as string."""
         if node.exc:
             if node.cause:
                 return f"raise {node.exc.accept(self)} from {node.cause.accept(self)}"
@@ -439,7 +440,7 @@ class AsStringVisitor:
         return "raise"
 
     def visit_return(self, node) -> str:
-        """return an astroid.Return node as string"""
+        """Return an astroid.Return node as string."""
         if node.is_tuple_return() and len(node.value.elts) > 1:
             elts = [child.accept(self) for child in node.value.elts]
             return f"return {', '.join(elts)}"
@@ -450,17 +451,17 @@ class AsStringVisitor:
         return "return"
 
     def visit_set(self, node) -> str:
-        """return an astroid.Set node as string"""
+        """Return an astroid.Set node as string."""
         return "{%s}" % ", ".join(child.accept(self) for child in node.elts)
 
     def visit_setcomp(self, node) -> str:
-        """return an astroid.SetComp node as string"""
+        """Return an astroid.SetComp node as string."""
         return "{{{} {}}}".format(
             node.elt.accept(self), " ".join(n.accept(self) for n in node.generators)
         )
 
     def visit_slice(self, node) -> str:
-        """return an astroid.Slice node as string"""
+        """Return an astroid.Slice node as string."""
         lower = node.lower.accept(self) if node.lower else ""
         upper = node.upper.accept(self) if node.upper else ""
         step = node.step.accept(self) if node.step else ""
@@ -469,7 +470,7 @@ class AsStringVisitor:
         return f"{lower}:{upper}"
 
     def visit_subscript(self, node) -> str:
-        """return an astroid.Subscript node as string"""
+        """Return an astroid.Subscript node as string."""
         idx = node.slice
         if idx.__class__.__name__.lower() == "index":
             idx = idx.value
@@ -481,7 +482,7 @@ class AsStringVisitor:
         return f"{self._precedence_parens(node, node.value)}[{idxstr}]"
 
     def visit_tryexcept(self, node) -> str:
-        """return an astroid.TryExcept node as string"""
+        """Return an astroid.TryExcept node as string."""
         trys = [f"try:\n{self._stmt_list(node.body)}"]
         for handler in node.handlers:
             trys.append(handler.accept(self))
@@ -490,19 +491,19 @@ class AsStringVisitor:
         return "\n".join(trys)
 
     def visit_tryfinally(self, node) -> str:
-        """return an astroid.TryFinally node as string"""
+        """Return an astroid.TryFinally node as string."""
         return "try:\n{}\nfinally:\n{}".format(
             self._stmt_list(node.body), self._stmt_list(node.finalbody)
         )
 
     def visit_tuple(self, node) -> str:
-        """return an astroid.Tuple node as string"""
+        """Return an astroid.Tuple node as string."""
         if len(node.elts) == 1:
             return f"({node.elts[0].accept(self)}, )"
         return f"({', '.join(child.accept(self) for child in node.elts)})"
 
     def visit_unaryop(self, node) -> str:
-        """return an astroid.UnaryOp node as string"""
+        """Return an astroid.UnaryOp node as string."""
         if node.op == "not":
             operator = "not "
         else:
@@ -510,14 +511,14 @@ class AsStringVisitor:
         return f"{operator}{self._precedence_parens(node, node.operand)}"
 
     def visit_while(self, node) -> str:
-        """return an astroid.While node as string"""
+        """Return an astroid.While node as string."""
         whiles = f"while {node.test.accept(self)}:\n{self._stmt_list(node.body)}"
         if node.orelse:
             whiles = f"{whiles}\nelse:\n{self._stmt_list(node.orelse)}"
         return whiles
 
     def visit_with(self, node) -> str:  # 'with' without 'as' is possible
-        """return an astroid.With node as string"""
+        """Return an astroid.With node as string."""
         items = ", ".join(
             f"{expr.accept(self)}" + (v and f" as {v.accept(self)}" or "")
             for expr, v in node.items
@@ -525,7 +526,7 @@ class AsStringVisitor:
         return f"with {items}:\n{self._stmt_list(node.body)}"
 
     def visit_yield(self, node) -> str:
-        """yield an ast.Yield node as string"""
+        """Yield an ast.Yield node as string."""
         yi_val = (" " + node.value.accept(self)) if node.value else ""
         expr = "yield" + yi_val
         if node.parent.is_statement:
@@ -543,7 +544,7 @@ class AsStringVisitor:
         return f"({expr})"
 
     def visit_starred(self, node) -> str:
-        """return Starred node as string"""
+        """Return Starred node as string."""
         return "*" + node.value.accept(self)
 
     def visit_match(self, node: Match) -> str:
@@ -642,7 +643,7 @@ class AsStringVisitor:
 
 
 def _import_string(names) -> str:
-    """return a list of (name, asname) formatted as a string"""
+    """Return a list of (name, asname) formatted as a string."""
     _names = []
     for name, asname in names:
         if asname is not None:

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2,7 +2,10 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
-"""Module for some node classes. More nodes in scoped_nodes.py"""
+"""Module for some node classes.
+
+More nodes in scoped_nodes.py
+"""
 
 from __future__ import annotations
 
@@ -84,7 +87,8 @@ InferUnaryOp = Callable[[_NodesT, str], ConstFactoryResult]
 
 @decorators.raise_if_nothing_inferred
 def unpack_infer(stmt, context: InferenceContext | None = None):
-    """recursively generate nodes inferred by the given statement.
+    """Recursively generate nodes inferred by the given statement.
+
     If the inferred value is a list or a tuple, recurse on the elements
     """
     if isinstance(stmt, (List, Tuple)):
@@ -110,7 +114,7 @@ def unpack_infer(stmt, context: InferenceContext | None = None):
 
 
 def are_exclusive(stmt1, stmt2, exceptions: list[str] | None = None) -> bool:
-    """return true if the two given statements are mutually exclusive
+    """Return true if the two given statements are mutually exclusive.
 
     `exceptions` may be a list of exception names. If specified, discard If
     branches and check one of the statement is in an exception handler catching
@@ -443,6 +447,7 @@ class AssignName(_base_nodes.NoChildrenNode, LookupMixIn, _base_nodes.ParentAssi
 
     assigned_stmts: ClassVar[AssignedStmtsCall[AssignName]]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -651,7 +656,9 @@ class Arguments(_base_nodes.AssignTypeNode):
         """The arguments that can only be passed positionally."""
 
         self.kw_defaults: list[NodeNG | None]
-        """The default values for keyword arguments that cannot be passed positionally."""
+        """The default values for keyword arguments that cannot be passed
+        positionally.
+        """
 
         self.annotations: list[NodeNG | None]
         """The type annotations of arguments that can be passed positionally."""
@@ -770,6 +777,7 @@ class Arguments(_base_nodes.AssignTypeNode):
 
     assigned_stmts: ClassVar[AssignedStmtsCall[Arguments]]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -789,7 +797,9 @@ class Arguments(_base_nodes.AssignTypeNode):
 
     @cached_property
     def arguments(self):
-        """Get all the arguments for this node, including positional only and positional and keyword"""
+        """Get all the arguments for this node, including positional only and positional
+        and keyword.
+        """
         return list(itertools.chain((self.posonlyargs or ()), self.args or ()))
 
     def format_args(self, *, skippable_names: set[str] | None = None) -> str:
@@ -1109,6 +1119,7 @@ class AssignAttr(_base_nodes.ParentAssignNode):
 
     assigned_stmts: ClassVar[AssignedStmtsCall[AssignAttr]]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -1226,7 +1237,9 @@ class Assign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
         """The value being assigned to the variables."""
 
         self.type_annotation: NodeNG | None = None  # can be None
-        """If present, this will contain the type annotation passed by a type comment"""
+        """If present, this will contain the type annotation passed by a type
+        comment.
+        """
 
         super().__init__(
             lineno=lineno,
@@ -1255,6 +1268,7 @@ class Assign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
 
     assigned_stmts: ClassVar[AssignedStmtsCall[Assign]]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -1352,6 +1366,7 @@ class AnnAssign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
 
     assigned_stmts: ClassVar[AssignedStmtsCall[AnnAssign]]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -1390,6 +1405,7 @@ class AugAssign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
     ) -> None:
         """
         :param op: The operator that is being combined with the assignment.
+
             This includes the equals sign.
 
         :param lineno: The line that this node appears on in the source code.
@@ -1438,6 +1454,7 @@ class AugAssign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
 
     assigned_stmts: ClassVar[AssignedStmtsCall[AugAssign]]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -1470,7 +1487,7 @@ class AugAssign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
         yield self.value
 
     def _get_yield_nodes_skip_lambdas(self):
-        """An AugAssign node can contain a Yield node in the value"""
+        """An AugAssign node can contain a Yield node in the value."""
         yield from self.value._get_yield_nodes_skip_lambdas()
         yield from super()._get_yield_nodes_skip_lambdas()
 
@@ -1827,7 +1844,7 @@ class Compare(NodeNG):
             yield comparator  # we don't want the 'op'
 
     def last_child(self):
-        """An optimized version of list(get_children())[-1]
+        """An optimized version of list(get_children())[-1].
 
         :returns: The last child.
         :rtype: NodeNG
@@ -1863,9 +1880,7 @@ class Comprehension(NodeNG):
     end_col_offset: None
 
     def __init__(self, parent: NodeNG | None = None) -> None:
-        """
-        :param parent: The parent node in the syntax tree.
-        """
+        """:param parent: The parent node in the syntax tree."""
         self.target: NodeNG | None = None
         """What is assigned to by the comprehension."""
 
@@ -1907,6 +1922,7 @@ class Comprehension(NodeNG):
 
     assigned_stmts: ClassVar[AssignedStmtsCall[Comprehension]]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -1921,7 +1937,7 @@ class Comprehension(NodeNG):
     def _get_filtered_stmts(
         self, lookup_node, node, stmts, mystmt: _base_nodes.Statement | None
     ):
-        """method used in filter_stmts"""
+        """Method used in filter_stmts."""
         if self is mystmt:
             if isinstance(lookup_node, (Const, Name)):
                 return [lookup_node], True
@@ -1990,7 +2006,10 @@ class Const(_base_nodes.NoChildrenNode, Instance):
         """The value that the constant represents."""
 
         self.kind: str | None = kind  # can be None
-        """"The string prefix. "u" for u-prefixed strings and ``None`` otherwise. Python 3.8+ only."""
+        """"The string prefix.
+
+        "u" for u-prefixed strings and ``None`` otherwise. Python 3.8+ only.
+        """
 
         super().__init__(
             lineno=lineno,
@@ -2168,6 +2187,7 @@ class Decorators(NodeNG):
 
     def scope(self) -> LocalsDictNodeNG:
         """The first parent node defining a new scope.
+
         These can be Module, FunctionDef, ClassDef, Lambda, or GeneratorExp nodes.
 
         :returns: The first parent scope node.
@@ -2412,7 +2432,7 @@ class Dict(NodeNG, Instance):
             yield value
 
     def last_child(self):
-        """An optimized version of list(get_children())[-1]
+        """An optimized version of list(get_children())[-1].
 
         :returns: The last child, or None if no children exist.
         :rtype: NodeNG or None
@@ -2560,7 +2580,9 @@ class EmptyNode(_base_nodes.NoChildrenNode):
 class ExceptHandler(
     _base_nodes.MultiLineBlockNode, _base_nodes.AssignTypeNode, _base_nodes.Statement
 ):
-    """Class representing an :class:`ast.ExceptHandler`. node.
+    """Class representing an :class:`ast.ExceptHandler`.
+
+    node.
 
     An :class:`ExceptHandler` is an ``except`` block on a try-except.
 
@@ -2624,6 +2646,7 @@ class ExceptHandler(
 
     assigned_stmts: ClassVar[AssignedStmtsCall[ExceptHandler]]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -2670,7 +2693,7 @@ class ExceptHandler(
         return self.lineno
 
     def catch(self, exceptions: list[str] | None) -> bool:
-        """Check if this node handles any of the given
+        """Check if this node handles any of the given.
 
         :param exceptions: The names of the exceptions to check for.
         """
@@ -2747,7 +2770,9 @@ class For(
         """The contents of the ``else`` block of the loop."""
 
         self.type_annotation: NodeNG | None = None  # can be None
-        """If present, this will contain the type annotation passed by a type comment"""
+        """If present, this will contain the type annotation passed by a type
+        comment.
+        """
 
         super().__init__(
             lineno=lineno,
@@ -2786,6 +2811,7 @@ class For(
 
     assigned_stmts: ClassVar[AssignedStmtsCall[For]]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -3182,7 +3208,7 @@ class If(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
         return len(self.orelse) == 1 and isinstance(self.orelse[0], If)
 
     def _get_yield_nodes_skip_lambdas(self):
-        """An If node can contain a Yield node in the test"""
+        """An If node can contain a Yield node in the test."""
         yield from self.test._get_yield_nodes_skip_lambdas()
         yield from super()._get_yield_nodes_skip_lambdas()
 
@@ -3240,6 +3266,7 @@ class If(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
 
 class IfExp(NodeNG):
     """Class representing an :class:`ast.IfExp` node.
+
     >>> import astroid
     >>> node = astroid.extract_node('value if condition else other')
     >>> node
@@ -3318,6 +3345,7 @@ class IfExp(NodeNG):
 
 class Import(_base_nodes.ImportNode):
     """Class representing an :class:`ast.Import` node.
+
     >>> import astroid
     >>> node = astroid.extract_node('import astroid')
     >>> node
@@ -3491,6 +3519,7 @@ class List(BaseContainer):
 
     assigned_stmts: ClassVar[AssignedStmtsCall[List]]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -3922,6 +3951,7 @@ class Starred(_base_nodes.ParentAssignNode):
 
     assigned_stmts: ClassVar[AssignedStmtsCall[Starred]]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -4255,6 +4285,7 @@ class Tuple(BaseContainer):
 
     assigned_stmts: ClassVar[AssignedStmtsCall[Tuple]]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -4471,7 +4502,7 @@ class While(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
         yield from self.orelse
 
     def _get_yield_nodes_skip_lambdas(self):
-        """A While node can contain a Yield node in the test"""
+        """A While node can contain a Yield node in the test."""
         yield from self.test._get_yield_nodes_skip_lambdas()
         yield from super()._get_yield_nodes_skip_lambdas()
 
@@ -4525,7 +4556,9 @@ class With(
         """The contents of the ``with`` block."""
 
         self.type_annotation: NodeNG | None = None  # can be None
-        """If present, this will contain the type annotation passed by a type comment"""
+        """If present, this will contain the type annotation passed by a type
+        comment.
+        """
 
         super().__init__(
             lineno=lineno,
@@ -4556,6 +4589,7 @@ class With(
 
     assigned_stmts: ClassVar[AssignedStmtsCall[With]]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -4804,7 +4838,7 @@ class JoinedStr(NodeNG):
 
 
 class NamedExpr(_base_nodes.AssignTypeNode):
-    """Represents the assignment from the assignment expression
+    """Represents the assignment from the assignment expression.
 
     >>> import astroid
     >>> module = astroid.parse('if a := 1: pass')
@@ -4817,7 +4851,8 @@ class NamedExpr(_base_nodes.AssignTypeNode):
     optional_assign = True
     """Whether this node optionally assigns a variable.
 
-    Since NamedExpr are not always called they do not always assign."""
+    Since NamedExpr are not always called they do not always assign.
+    """
 
     def __init__(
         self,
@@ -4842,13 +4877,13 @@ class NamedExpr(_base_nodes.AssignTypeNode):
             source code. Note: This is after the last symbol.
         """
         self.target: NodeNG
-        """The assignment target
+        """The assignment target.
 
         :type: Name
         """
 
         self.value: NodeNG
-        """The value that gets assigned in the expression"""
+        """The value that gets assigned in the expression."""
 
         super().__init__(
             lineno=lineno,
@@ -4864,6 +4899,7 @@ class NamedExpr(_base_nodes.AssignTypeNode):
 
     assigned_stmts: ClassVar[AssignedStmtsCall[NamedExpr]]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -4892,6 +4928,7 @@ class NamedExpr(_base_nodes.AssignTypeNode):
 
     def scope(self) -> LocalsDictNodeNG:
         """The first parent node defining a new scope.
+
         These can be Module, FunctionDef, ClassDef, Lambda, or GeneratorExp nodes.
 
         :returns: The first parent scope node.
@@ -4911,6 +4948,7 @@ class NamedExpr(_base_nodes.AssignTypeNode):
 
     def set_local(self, name: str, stmt: NodeNG) -> None:
         """Define that the given name is declared in the given statement node.
+
         NamedExpr's in Arguments, Keyword or Comprehension are evaluated in their
         parent's parent scope. So we add to their frame's locals.
 
@@ -4925,7 +4963,9 @@ class NamedExpr(_base_nodes.AssignTypeNode):
 
 class Unknown(_base_nodes.AssignTypeNode):
     """This node represents a node in a constructed AST where
-    introspection is not possible.  At the moment, it's only used in
+    introspection is not possible.
+
+     At the moment, it's only used in
     the args attribute of FunctionDef nodes where function signature
     introspection failed.
     """
@@ -4941,7 +4981,7 @@ class Unknown(_base_nodes.AssignTypeNode):
 
 
 class EvaluatedObject(NodeNG):
-    """Contains an object that has already been inferred
+    """Contains an object that has already been inferred.
 
     This class is useful to pre-evaluate a particular node,
     with the resulting class acting as the non-evaluated node.
@@ -4955,10 +4995,10 @@ class EvaluatedObject(NodeNG):
         self, original: NodeNG, value: NodeNG | type[util.Uninferable]
     ) -> None:
         self.original: NodeNG = original
-        """The original node that has already been evaluated"""
+        """The original node that has already been evaluated."""
 
         self.value: NodeNG | type[util.Uninferable] = value
-        """The inferred value"""
+        """The inferred value."""
 
         super().__init__(
             lineno=self.original.lineno,
@@ -5243,6 +5283,7 @@ class MatchMapping(_base_nodes.AssignTypeNode, Pattern):
         ]
     ]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -5350,6 +5391,7 @@ class MatchStar(_base_nodes.AssignTypeNode, Pattern):
         ]
     ]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 
@@ -5421,6 +5463,7 @@ class MatchAs(_base_nodes.AssignTypeNode, Pattern):
         ]
     ]
     """Returns the assigned statement (non inferred) according to the assignment type.
+
     See astroid/protocols.py for actual implementation.
     """
 

--- a/astroid/nodes/scoped_nodes/mixin.py
+++ b/astroid/nodes/scoped_nodes/mixin.py
@@ -20,8 +20,9 @@ _T = TypeVar("_T")
 
 
 class LocalsDictNodeNG(node_classes.LookupMixIn):
-    """this class provides locals handling common to Module, FunctionDef
-    and ClassDef nodes, including a dict like interface for direct access
+    """This class provides locals handling common to Module, FunctionDef
+    and ClassDef nodes, including a dict like interface for direct access.
+
     to locals information
     """
 
@@ -70,7 +71,7 @@ class LocalsDictNodeNG(node_classes.LookupMixIn):
         raise NotImplementedError
 
     def _scope_lookup(self, node, name, offset=0):
-        """XXX method for interfacing the scope lookup"""
+        """XXX method for interfacing the scope lookup."""
         try:
             stmts = _filter_stmts(node, self.locals[name], self, offset)
         except KeyError:
@@ -104,7 +105,7 @@ class LocalsDictNodeNG(node_classes.LookupMixIn):
     __setitem__ = set_local
 
     def _append_node(self, child: nodes.NodeNG) -> None:
-        """append a child, linking it in the tree"""
+        """Append a child, linking it in the tree."""
         # pylint: disable=no-member; depending by the class
         # which uses the current class as a mixin or base class.
         # It's rewritten in 2.0, so it makes no sense for now

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -4,7 +4,8 @@
 
 """
 This module contains the classes for "scoped" node, i.e. which are opening a
-new local scope in the language definition : Module, ClassDef, FunctionDef (and
+new local scope in the language definition : Module, ClassDef, FunctionDef (and.
+
 Lambda, GeneratorExp, DictComp and SetComp to some extent).
 """
 
@@ -75,7 +76,6 @@ def _c3_merge(sequences, cls, context):
     """Merges MROs in *sequences* to a single MRO using the C3 algorithm.
 
     Adapted from http://www.python.org/download/releases/2.3/mro/.
-
     """
     result = []
     while True:
@@ -111,7 +111,9 @@ def _c3_merge(sequences, cls, context):
 
 def clean_typing_generic_mro(sequences: list[list[ClassDef]]) -> None:
     """A class can inherit from typing.Generic directly, as base,
-    and as base of bases. The merged MRO must however only contain the last entry.
+    and as base of bases.
+
+    The merged MRO must however only contain the last entry.
     To prepare for _c3_merge, remove some typing.Generic entries from
     sequences if multiple are present.
 
@@ -692,6 +694,7 @@ class GeneratorExp(ComprehensionScope):
     ):
         """
         :param lineno: The line that this node appears on in the source code.
+
         :type lineno: int or None
 
         :param col_offset: The column that this node appears on in the
@@ -780,6 +783,7 @@ class DictComp(ComprehensionScope):
     ):
         """
         :param lineno: The line that this node appears on in the source code.
+
         :type lineno: int or None
 
         :param col_offset: The column that this node appears on in the
@@ -874,6 +878,7 @@ class SetComp(ComprehensionScope):
     ):
         """
         :param lineno: The line that this node appears on in the source code.
+
         :type lineno: int or None
 
         :param col_offset: The column that this node appears on in the
@@ -1076,6 +1081,7 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
     ):
         """
         :param lineno: The line that this node appears on in the source code.
+
         :type lineno: int or None
 
         :param col_offset: The column that this node appears on in the
@@ -1154,7 +1160,8 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
 
     def argnames(self) -> list[str]:
         """Get the names of each of the arguments, including that
-        of the collections of variable-length arguments ("args", "kwargs",
+        of the collections of variable-length arguments ("args", "kwargs",.
+
         etc.), as well as positional-only and keyword-only arguments.
 
         :returns: The names of the arguments.
@@ -1274,17 +1281,19 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
     :type: bool
     """
     type_annotation = None
-    """If present, this will contain the type annotation passed by a type comment
+    """If present, this will contain the type annotation passed by a type comment.
 
     :type: NodeNG or None
     """
     type_comment_args = None
     """
     If present, this will contain the type annotation for arguments
-    passed by a type comment
+    passed by a type comment.
     """
     type_comment_returns = None
-    """If present, this will contain the return type annotation, passed by a type comment"""
+    """If present, this will contain the return type annotation, passed by a type
+    comment.
+    """
     # attributes below are set by the builder module or by raw factories
     _other_fields = ("name", "doc", "position")
     _other_other_fields = (
@@ -1309,6 +1318,7 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
     ):
         """
         :param name: The name of the function.
+
         :type name: str or None
 
         :param doc: The function docstring.
@@ -1654,7 +1664,7 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
         return bool(next(self._get_yield_nodes_skip_lambdas(), False))
 
     def infer_yield_result(self, context: InferenceContext | None = None):
-        """Infer what the function yields when called
+        """Infer what the function yields when called.
 
         :returns: What the function yields
         :rtype: iterable(NodeNG or Uninferable) or None
@@ -1796,7 +1806,7 @@ class AsyncFunctionDef(FunctionDef):
 
 
 def _rec_get_names(args, names: list[str] | None = None) -> list[str]:
-    """return a list of all argument names"""
+    """Return a list of all argument names."""
     if names is None:
         names = []
     for arg in args:
@@ -1842,8 +1852,8 @@ def _is_metaclass(klass, seen=None) -> bool:
 
 
 def _class_type(klass, ancestors=None):
-    """return a ClassDef node type to differ metaclass and exception
-    from 'regular' classes
+    """Return a ClassDef node type to differ metaclass and exception
+    from 'regular' classes.
     """
     # XXX we have to store ancestors in case we have an ancestor loop
     if klass._type is not None:
@@ -1957,6 +1967,7 @@ class ClassDef(
     ):
         """
         :param name: The name of the class.
+
         :type name: str or None
 
         :param doc: The class docstring.
@@ -2260,7 +2271,7 @@ class ClassDef(
         return result
 
     def infer_call_result(self, caller, context: InferenceContext | None = None):
-        """infer what a class is returning when called"""
+        """Infer what a class is returning when called."""
         if self.is_subtype_of("builtins.type", context) and len(caller.args) == 3:
             result = self._infer_type_call(caller, context)
             yield result
@@ -2341,7 +2352,7 @@ class ClassDef(
 
     @property
     def basenames(self):
-        """The names of the parent classes
+        """The names of the parent classes.
 
         Names are given in the order they appear in the class definition.
 

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -4,7 +4,8 @@
 
 """
 Inference objects are a way to represent composite AST nodes,
-which are used only as inference results, so they can't be found in the
+which are used only as inference results, so they can't be found in the.
+
 original AST tree. For instance, inferring the following frozenset use,
 leads to an inferred FrozenSet:
 

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -734,7 +734,8 @@ def starred_assigned_stmts(  # noqa: C901
 ) -> Any:
     """
     Arguments:
-        self: nodes.Starred
+        self: nodes.Starred.
+
         node: a node related to the current underlying Node.
         context: Inference context used for caching already inferred objects
         assign_path:

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -2,8 +2,8 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
-"""this module contains a set of functions to create astroid trees from scratch
-(build_* functions) or from living object (object_build_* functions)
+"""This module contains a set of functions to create astroid trees from scratch
+(build_* functions) or from living object (object_build_* functions).
 """
 
 from __future__ import annotations
@@ -56,8 +56,8 @@ def _add_dunder_class(func, member) -> None:
 
 
 def attach_dummy_node(node, name: str, runtime_object=_EMPTY_OBJECT_MARKER) -> None:
-    """create a dummy node and register it in the locals of the given
-    node with the specified name
+    """Create a dummy node and register it in the locals of the given
+    node with the specified name.
     """
     enode = nodes.EmptyNode()
     enode.object = runtime_object
@@ -65,23 +65,23 @@ def attach_dummy_node(node, name: str, runtime_object=_EMPTY_OBJECT_MARKER) -> N
 
 
 def attach_const_node(node, name: str, value) -> None:
-    """create a Const node and register it in the locals of the given
-    node with the specified name
+    """Create a Const node and register it in the locals of the given
+    node with the specified name.
     """
     if name not in node.special_attributes:
         _attach_local_node(node, nodes.const_factory(value), name)
 
 
 def attach_import_node(node, modname: str, membername: str) -> None:
-    """create a ImportFrom node and register it in the locals of the given
-    node with the specified name
+    """Create a ImportFrom node and register it in the locals of the given
+    node with the specified name.
     """
     from_node = nodes.ImportFrom(modname, [(membername, None)])
     _attach_local_node(node, from_node, membername)
 
 
 def build_module(name: str, doc: str | None = None) -> nodes.Module:
-    """create and initialize an astroid Module node"""
+    """Create and initialize an astroid Module node."""
     node = nodes.Module(name, pure_python=False, package=False)
     node.postinit(
         body=[],
@@ -112,7 +112,7 @@ def build_function(
     doc: str | None = None,
     kwonlyargs: list[str] | None = None,
 ) -> nodes.FunctionDef:
-    """create and initialize an astroid FunctionDef node"""
+    """Create and initialize an astroid FunctionDef node."""
     # first argument is now a list of decorators
     func = nodes.FunctionDef(name)
     argsnode = nodes.Arguments(parent=func)
@@ -157,12 +157,12 @@ def build_function(
 
 
 def build_from_import(fromname: str, names: list[str]) -> nodes.ImportFrom:
-    """create and initialize an astroid ImportFrom import statement"""
+    """Create and initialize an astroid ImportFrom import statement."""
     return nodes.ImportFrom(fromname, [(name, None) for name in names])
 
 
 def register_arguments(func: nodes.FunctionDef, args: list | None = None) -> None:
-    """add given arguments to local
+    """Add given arguments to local.
 
     args is a list that may contains nested lists
     (i.e. def func(a, (b, c, d)): ...)
@@ -187,7 +187,7 @@ def register_arguments(func: nodes.FunctionDef, args: list | None = None) -> Non
 def object_build_class(
     node: nodes.Module | nodes.ClassDef, member: type, localname: str
 ) -> nodes.ClassDef:
-    """create astroid for a living class object"""
+    """Create astroid for a living class object."""
     basenames = [base.__name__ for base in member.__bases__]
     return _base_class_object_build(node, member, basenames, localname=localname)
 
@@ -225,7 +225,7 @@ def _get_args_info_from_callable(
 def object_build_function(
     node: nodes.Module | nodes.ClassDef, member: _FunctionTypes, localname: str
 ) -> None:
-    """create astroid for a living function object"""
+    """Create astroid for a living function object."""
     args, posonlyargs, defaults, kwonlyargs = _get_args_info_from_callable(member)
 
     func = build_function(
@@ -243,7 +243,7 @@ def object_build_function(
 def object_build_datadescriptor(
     node: nodes.Module | nodes.ClassDef, member: type, name: str
 ) -> nodes.ClassDef:
-    """create astroid for a living data descriptor object"""
+    """Create astroid for a living data descriptor object."""
     return _base_class_object_build(node, member, [], name)
 
 
@@ -252,7 +252,7 @@ def object_build_methoddescriptor(
     member: _FunctionTypes,
     localname: str,
 ) -> None:
-    """create astroid for a living method descriptor object"""
+    """Create astroid for a living method descriptor object."""
     # FIXME get arguments ?
     func = build_function(
         getattr(member, "__name__", None) or localname, doc=member.__doc__
@@ -268,8 +268,8 @@ def _base_class_object_build(
     name: str | None = None,
     localname: str | None = None,
 ) -> nodes.ClassDef:
-    """create astroid for a living class object, with a given set of base names
-    (e.g. ancestors)
+    """Create astroid for a living class object, with a given set of base names
+    (e.g. ancestors).
     """
     class_name = name or getattr(member, "__name__", None) or localname
     assert isinstance(class_name, str)
@@ -325,7 +325,7 @@ def _build_from_function(
 
 
 class InspectBuilder:
-    """class for building nodes from living object
+    """Class for building nodes from living object.
 
     this is actually a really minimal representation, including only Module,
     FunctionDef and ClassDef nodes and some others as guessed.
@@ -342,8 +342,9 @@ class InspectBuilder:
         modname: str | None = None,
         path: str | None = None,
     ) -> nodes.Module:
-        """build astroid from a living module (i.e. using inspect)
-        this is used when there is no python source code available (either
+        """Build astroid from a living module (i.e. using inspect)
+        this is used when there is no python source code available (either.
+
         because it's a built-in module or because the .py is not available)
         """
         self._module = module
@@ -369,8 +370,8 @@ class InspectBuilder:
     def object_build(
         self, node: nodes.Module | nodes.ClassDef, obj: types.ModuleType | type
     ) -> None:
-        """recursive method which create a partial ast from real objects
-        (only function, class, and method are handled)
+        """Recursive method which create a partial ast from real objects
+        (only function, class, and method are handled).
         """
         if obj in self._done:
             return None
@@ -430,7 +431,7 @@ class InspectBuilder:
         return None
 
     def imported_member(self, node, member, name: str) -> bool:
-        """verify this is not an imported class or handle it"""
+        """Verify this is not an imported class or handle it."""
         # /!\ some classes like ExtensionClass doesn't have a __module__
         # attribute ! Also, this may trigger an exception on badly built module
         # (see http://www.logilab.org/ticket/57299 for instance)
@@ -480,7 +481,7 @@ def _set_proxied(const) -> nodes.ClassDef:
 
 
 def _astroid_bootstrapping() -> None:
-    """astroid bootstrapping the builtins module"""
+    """Astroid bootstrapping the builtins module."""
     # this boot strapping is necessary since we need the Const nodes to
     # inspect_build builtins, and then we can proxy Const
     builder = InspectBuilder()

--- a/astroid/test_utils.py
+++ b/astroid/test_utils.py
@@ -18,7 +18,9 @@ from astroid import manager, nodes, transforms
 
 
 def require_version(minver: str = "0.0.0", maxver: str = "4.0.0") -> Callable:
-    """Compare version of python interpreter to the given one and skips the test if older."""
+    """Compare version of python interpreter to the given one and skips the test if
+    older.
+    """
 
     def parse(python_version: str) -> tuple[int, ...]:
         try:

--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -68,7 +68,8 @@ class TransformVisitor:
 
     def register_transform(self, node_class, transform, predicate=None) -> None:
         """Register `transform(node)` function to be applied on the given
-        astroid's `node_class` if `predicate` is None or returns true
+        astroid's `node_class` if `predicate` is None or returns true.
+
         when called with the node as argument.
 
         The transform function may return a value which is then used to


### PR DESCRIPTION
## Description

Follow-up to #1792 

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

