### PR TITLE
Remove inference tip cache

### DIFF
--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -79,7 +79,7 @@ from astroid.exceptions import (
     UnresolvableName,
     UseInferenceDefault,
 )
-from astroid.inference_tip import _inference_tip_cached, inference_tip
+from astroid.inference_tip import inference_tip
 from astroid.objects import ExceptionInstance
 
 # isort: off

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -409,11 +409,8 @@ class AstroidManager:
         re-register transforms."""
         # import here because of cyclic imports
         # pylint: disable=import-outside-toplevel
-        from astroid.inference_tip import clear_inference_tip_cache
         from astroid.interpreter.objectmodel import ObjectModel
         from astroid.nodes.node_classes import LookupMixIn
-
-        clear_inference_tip_cache()
 
         self.astroid_cache.clear()
         # NB: not a new TransformVisitor()

--- a/tests/unittest_regrtest.py
+++ b/tests/unittest_regrtest.py
@@ -338,6 +338,30 @@ def test(val):
         assert isinstance(inferred, Instance)
         assert inferred.qname() == ".A"
 
+    def test_inference_context_consideration(self) -> None:
+        # Test for https://github.com/PyCQA/astroid/issues/1828
+        code = """
+        class Base:
+            def return_type(self):
+                return type(self)()
+
+        class A(Base):
+            def method(self):
+                return self.return_type()
+
+        class B(Base):
+            def method(self):
+                return self.return_type()
+
+        A().method() #@
+        B().method() #@
+        """
+        node1, node2 = extract_node(code)
+        inferred1 = next(node1.infer())
+        assert inferred1.qname() == ".A"
+        inferred2 = next(node2.infer())
+        assert inferred2.qname() == ".B"
+
 
 class Whatever:
     a = property(lambda x: x, lambda x: x)  # type: ignore[misc]

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -1699,9 +1699,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
                 "FinalClass",
                 "ClassB",
                 "MixinB",
-                # We don't recognize what 'cls' is at time of .format() call, only
-                # what it is at the end.
-                # "strMixin",
+                "strMixin",
                 "ClassA",
                 "MixinA",
                 "intMixin",


### PR DESCRIPTION
## ChangeLog

Fixed type inconsistently inferred for base methods returning type(self).

## Description

Remove inference tip cache. It misses the context to properly evaluate a base class method returned type when the returned type depends on the subclass instance calling the method.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #1828
