### PR TITLE
Fix `ClassDef.igetattr` on multiple attributes (`not-an-iterable` false-positive)

### DIFF
--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2649,12 +2649,13 @@ class ClassDef(
             # to the attribute happening *after* the attribute's definition (e.g. AugAssigns on lists)
             if len(attributes) > 1:
                 first_attr, attributes = attributes[0], attributes[1:]
-                first_scope = first_attr.scope()
-                attributes = [first_attr] + [
-                    attr
-                    for attr in attributes
-                    if attr.parent and attr.parent.scope() == first_scope
-                ]
+                if first_attr.parent:
+                    first_scope = first_attr.parent.scope()
+                    attributes = [first_attr] + [
+                        attr
+                        for attr in attributes
+                        if attr.parent and attr.parent.scope() == first_scope
+                    ]
 
             for inferred in bases._infer_stmts(attributes, context, frame=self):
                 # yield Uninferable object instead of descriptors when necessary

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -2164,6 +2164,18 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         f2 = next(instance.igetattr("f2"))
         self.assertIsInstance(f2, BoundMethod)
 
+    def test_instance_duplicate_method_issue1015(self) -> None:
+        data = """
+            class Klass:
+                def foo(self): ...
+                def foo(self):
+                    yield
+        """
+        astroid = builder.parse(data)
+        inst = Instance(astroid["Klass"])
+        attrs = list(inst.igetattr("foo"))
+        self.assertEqual(len(attrs), 2, attrs)
+
     def test_class_extra_decorators_frame_is_not_class(self) -> None:
         ast_node = builder.extract_node(
             """


### PR DESCRIPTION
## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

This is an attempt at fixing #1015; however I really don't know `astroid`'s code base so this is more like a shot in the dark, which needs a careful review!

In a few words:

```py
class A:
    def foo(self): ...
    def foo(self):
        yield

for _ in A().foo():
    pass
```

Only the first implementation returning `...` is considered, resulting in `pylint` complaining:

```
E1133: Non-iterable value A().foo() is used in an iterating context (not-an-iterable)
```

This is especially annoying when we define `@overload` variants for typing purposes.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #1015

Ping @nelfin @belm0 who are probably interested in this.