### PR TITLE
Support attrs decorators even if they are imported from attrs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,9 @@ What's New in astroid 2.15.2?
 =============================
 Release date: TBA
 
+* Support more possible usages of ``attrs`` decorators.
+
+  Closes pylint-dev/pylint#7884
 
 
 What's New in astroid 2.15.1?

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -9,7 +9,14 @@ Without this hook pylint reports unsupported-assignment-operation
 for attrs classes
 """
 from astroid.manager import AstroidManager
-from astroid.nodes.node_classes import AnnAssign, Assign, AssignName, Call, ImportFrom, Unknown
+from astroid.nodes.node_classes import (
+    AnnAssign,
+    Assign,
+    AssignName,
+    Call,
+    ImportFrom,
+    Unknown,
+)
 from astroid.nodes.scoped_nodes import ClassDef
 
 ATTRIB_NAMES = frozenset(
@@ -44,11 +51,13 @@ def is_decorated_with_attrs(node, decorator_names=ATTRS_NAMES) -> bool:
             # Check if by including the origin module of the decorator - and concatenating them we get one of ATTRS_NAMES
             decorator_name = decorator_attribute.as_string()
             local_value = decorator_attribute.scope().locals.get(decorator_name)
-            
-            # TODO: hack, as sometimes its a list? 
-            if isinstance(local_value, ImportFrom) or (isinstance(local_value,list) and isinstance(local_value[0], ImportFrom)):
+
+            # TODO: hack, as sometimes its a list?
+            if isinstance(local_value, ImportFrom) or (
+                isinstance(local_value, list) and isinstance(local_value[0], ImportFrom)
+            ):
                 decorator_module = local_value[0].modname
-                if "{}.{}".format(decorator_module, decorator_name) in ATTRS_NAMES:
+                if f"{decorator_module}.{decorator_name}" in ATTRS_NAMES:
                     return True
     return False
 

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -9,7 +9,7 @@ Without this hook pylint reports unsupported-assignment-operation
 for attrs classes
 """
 from astroid.manager import AstroidManager
-from astroid.nodes.node_classes import AnnAssign, Assign, AssignName, Call, Unknown
+from astroid.nodes.node_classes import AnnAssign, Assign, AssignName, Call, ImportFrom, Unknown
 from astroid.nodes.scoped_nodes import ClassDef
 
 ATTRIB_NAMES = frozenset(
@@ -40,6 +40,16 @@ def is_decorated_with_attrs(node, decorator_names=ATTRS_NAMES) -> bool:
             decorator_attribute = decorator_attribute.func
         if decorator_attribute.as_string() in decorator_names:
             return True
+        else:
+            # Check if by including the origin module of the decorator - and concatenating them we get one of ATTRS_NAMES
+            decorator_name = decorator_attribute.as_string()
+            local_value = decorator_attribute.scope().locals.get(decorator_name)
+            
+            # TODO: hack, as sometimes its a list? 
+            if isinstance(local_value, ImportFrom) or (isinstance(local_value,list) and isinstance(local_value[0], ImportFrom)):
+                decorator_module = local_value[0].modname
+                if "{}.{}".format(decorator_module, decorator_name) in ATTRS_NAMES:
+                    return True
     return False
 
 

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -47,18 +47,18 @@ def is_decorated_with_attrs(node, decorator_names=ATTRS_NAMES) -> bool:
             decorator_attribute = decorator_attribute.func
         if decorator_attribute.as_string() in decorator_names:
             return True
-        else:
-            # Check if by including the origin module of the decorator - and concatenating them we get one of ATTRS_NAMES
-            decorator_name = decorator_attribute.as_string()
-            local_value = decorator_attribute.scope().locals.get(decorator_name)
+        # Check if by including the origin module of the decorator -
+        # and concatenating them we get one of ATTRS_NAMES
+        decorator_name = decorator_attribute.as_string()
+        local_value = decorator_attribute.scope().locals.get(decorator_name)
 
-            # TODO: hack, as sometimes its a list?
-            if isinstance(local_value, ImportFrom) or (
-                isinstance(local_value, list) and isinstance(local_value[0], ImportFrom)
-            ):
-                decorator_module = local_value[0].modname
-                if f"{decorator_module}.{decorator_name}" in ATTRS_NAMES:
-                    return True
+        # TODO: hack, as sometimes its a list?
+        if isinstance(local_value, ImportFrom) or (
+            isinstance(local_value, list) and isinstance(local_value[0], ImportFrom)
+        ):
+            decorator_module = local_value[0].modname
+            if f"{decorator_module}.{decorator_name}" in ATTRS_NAMES:
+                return True
     return False
 
 

--- a/tests/brain/test_attr.py
+++ b/tests/brain/test_attr.py
@@ -90,7 +90,7 @@ class AttrsTest(unittest.TestCase):
         module = astroid.parse(
             """
         import attrs
-        from attrs import field, mutable, frozen
+        from attrs import field, mutable, frozen, define
 
         @attrs.define
         class Foo:

--- a/tests/brain/test_attr.py
+++ b/tests/brain/test_attr.py
@@ -91,6 +91,7 @@ class AttrsTest(unittest.TestCase):
             """
         import attrs
         from attrs import field, mutable, frozen, define
+        from attrs import mutable as my_mutable
 
         @attrs.define
         class Foo:
@@ -151,15 +152,29 @@ class AttrsTest(unittest.TestCase):
         m.d['answer'] = 42
 
         @define
-        class Megs:
+        class FooBar:
             d = attrs.field(default=attrs.Factory(dict))
 
-        n = Megs(d=1)
+        n = FooBar(d=1)
         n.d['answer'] = 42
+
+        @mutable
+        class BarFoo:
+            d = attrs.field(default=attrs.Factory(dict))
+
+        o = BarFoo(d=1)
+        o.d['answer'] = 42
+
+        @my_mutable
+        class FooFoo:
+            d = attrs.field(default=attrs.Factory(dict))
+
+        p = FooFoo(d=1)
+        p.d['answer'] = 42
         """
         )
 
-        for name in ("f", "g", "h", "i", "j", "k", "l", "m", "n"):
+        for name in ("f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"):
             should_be_unknown = next(module.getattr(name)[0].infer()).getattr("d")[0]
             self.assertIsInstance(should_be_unknown, astroid.Unknown)
 

--- a/tests/brain/test_attr.py
+++ b/tests/brain/test_attr.py
@@ -161,11 +161,7 @@ class AttrsTest(unittest.TestCase):
 
         for name in ("f", "g", "h", "i", "j", "k", "l", "m", "n"):
             should_be_unknown = next(module.getattr(name)[0].infer()).getattr("d")[0]
-            try:
-                self.assertIsInstance(should_be_unknown, astroid.Unknown)
-            except:
-                # breakpoint()
-                ...
+            self.assertIsInstance(should_be_unknown, astroid.Unknown)
 
     def test_special_attributes(self) -> None:
         """Make sure special attrs attributes exist"""

--- a/tests/brain/test_attr.py
+++ b/tests/brain/test_attr.py
@@ -167,8 +167,6 @@ class AttrsTest(unittest.TestCase):
                 # breakpoint()
                 ...
 
-                
-
     def test_special_attributes(self) -> None:
         """Make sure special attrs attributes exist"""
 

--- a/tests/brain/test_attr.py
+++ b/tests/brain/test_attr.py
@@ -141,12 +141,33 @@ class AttrsTest(unittest.TestCase):
 
         l = Eggs(d=1)
         l.d['answer'] = 42
+
+
+        @frozen
+        class Legs:
+            d = attrs.field(default=attrs.Factory(dict))
+
+        m = Legs(d=1)
+        m.d['answer'] = 42
+
+        @define
+        class Megs:
+            d = attrs.field(default=attrs.Factory(dict))
+
+        n = Megs(d=1)
+        n.d['answer'] = 42
         """
         )
 
-        for name in ("f", "g", "h", "i", "j", "k", "l"):
+        for name in ("f", "g", "h", "i", "j", "k", "l", "m", "n"):
             should_be_unknown = next(module.getattr(name)[0].infer()).getattr("d")[0]
-            self.assertIsInstance(should_be_unknown, astroid.Unknown)
+            try:
+                self.assertIsInstance(should_be_unknown, astroid.Unknown)
+            except:
+                # breakpoint()
+                ...
+
+                
 
     def test_special_attributes(self) -> None:
         """Make sure special attrs attributes exist"""


### PR DESCRIPTION
This PR is a POC for improving the way that astroid detects `attrs` decorators.
I am assuming that adding `frozen`, `define`, and `mutable` to `ATTRS_NAMES` was considered and was decided against - otherwise, it should probably be preferred

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes https://github.com/PyCQA/pylint/issues/7884
