### PR TITLE
Support attrs decorators even if they are imported from attrs (#2059)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,9 @@ What's New in astroid 2.15.2?
 =============================
 Release date: TBA
 
+* Support more possible usages of ``attrs`` decorators.
+
+  Closes pylint-dev/pylint#7884
 
 
 What's New in astroid 2.15.1?

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -8,6 +8,7 @@ Astroid hook for the attrs library
 Without this hook pylint reports unsupported-assignment-operation
 for attrs classes
 """
+from astroid.helpers import safe_infer
 from astroid.manager import AstroidManager
 from astroid.nodes.node_classes import AnnAssign, Assign, AssignName, Call, Unknown
 from astroid.nodes.scoped_nodes import ClassDef
@@ -39,6 +40,10 @@ def is_decorated_with_attrs(node, decorator_names=ATTRS_NAMES) -> bool:
         if isinstance(decorator_attribute, Call):  # decorator with arguments
             decorator_attribute = decorator_attribute.func
         if decorator_attribute.as_string() in decorator_names:
+            return True
+
+        inferred = safe_infer(decorator_attribute)
+        if inferred and inferred.root().name == "attr._next_gen":
             return True
     return False
 

--- a/tests/brain/test_attr.py
+++ b/tests/brain/test_attr.py
@@ -90,7 +90,8 @@ class AttrsTest(unittest.TestCase):
         module = astroid.parse(
             """
         import attrs
-        from attrs import field, mutable, frozen
+        from attrs import field, mutable, frozen, define
+        from attrs import mutable as my_mutable
 
         @attrs.define
         class Foo:
@@ -141,10 +142,39 @@ class AttrsTest(unittest.TestCase):
 
         l = Eggs(d=1)
         l.d['answer'] = 42
+
+
+        @frozen
+        class Legs:
+            d = attrs.field(default=attrs.Factory(dict))
+
+        m = Legs(d=1)
+        m.d['answer'] = 42
+
+        @define
+        class FooBar:
+            d = attrs.field(default=attrs.Factory(dict))
+
+        n = FooBar(d=1)
+        n.d['answer'] = 42
+
+        @mutable
+        class BarFoo:
+            d = attrs.field(default=attrs.Factory(dict))
+
+        o = BarFoo(d=1)
+        o.d['answer'] = 42
+
+        @my_mutable
+        class FooFoo:
+            d = attrs.field(default=attrs.Factory(dict))
+
+        p = FooFoo(d=1)
+        p.d['answer'] = 42
         """
         )
 
-        for name in ("f", "g", "h", "i", "j", "k", "l"):
+        for name in ("f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"):
             should_be_unknown = next(module.getattr(name)[0].infer()).getattr("d")[0]
             self.assertIsInstance(should_be_unknown, astroid.Unknown)
 


### PR DESCRIPTION
Use inference to determine membership of ``attr(s)`` module

Co-authored-by: Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
(cherry picked from commit 489c90fb29970d9362f21f26247bd45a39832dcd)

<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

Refs #XXXX

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #XXXX
