### PR TITLE
Don't add typing stubs for packages that we only use in tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,14 +63,7 @@ repos:
         types: [python]
         args: []
         require_serial: true
-        additional_dependencies:
-          [
-            "types-pkg_resources==0.1.3",
-            "types-six",
-            "types-attrs",
-            "types-python-dateutil",
-            "types-typed-ast",
-          ]
+        additional_dependencies: ["types-typed-ast"]
         exclude: tests/testdata| # exclude everything, we're not ready
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0-alpha.6

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,4 +3,3 @@
 contributors-txt>=0.7.4
 tbump~=6.9.0
 types-typed-ast; implementation_name=="cpython" and python_version<"3.8"
-types-pkg_resources==0.1.3

--- a/requirements_test_brain.txt
+++ b/requirements_test_brain.txt
@@ -1,12 +1,9 @@
 attrs
-types-attrs
 nose
 numpy>=1.17.0; python_version<"3.11"
 python-dateutil
 PyQt6
 regex
-types-python-dateutil
 six
-types-six
 urllib3
 typing_extensions>=4.4.0

--- a/tests/brain/test_attr.py
+++ b/tests/brain/test_attr.py
@@ -10,7 +10,7 @@ import astroid
 from astroid import nodes
 
 try:
-    import attr as attr_module  # pylint: disable=unused-import
+    import attr  # type: ignore[import]  # pylint: disable=unused-import
 
     HAS_ATTR = True
 except ImportError:

--- a/tests/brain/test_dateutil.py
+++ b/tests/brain/test_dateutil.py
@@ -9,7 +9,7 @@ import unittest
 from astroid import builder
 
 try:
-    import dateutil  # pylint: disable=unused-import
+    import dateutil  # type: ignore[import]  # pylint: disable=unused-import
 
     HAS_DATEUTIL = True
 except ImportError:

--- a/tests/brain/test_regex.py
+++ b/tests/brain/test_regex.py
@@ -3,7 +3,7 @@
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
 try:
-    import regex
+    import regex  # type: ignore[import]
 
     HAS_REGEX = True
 except ImportError:

--- a/tests/brain/test_six.py
+++ b/tests/brain/test_six.py
@@ -12,7 +12,7 @@ from astroid import MANAGER, builder, nodes
 from astroid.nodes.scoped_nodes import ClassDef
 
 try:
-    import six  # pylint: disable=unused-import
+    import six  # type: ignore[import]  # pylint: disable=unused-import
 
     HAS_SIX = True
 except ImportError:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -36,7 +36,7 @@ from astroid.objects import ExceptionInstance
 from . import resources
 
 try:
-    import six  # pylint: disable=unused-import
+    import six  # type: ignore[import]  # pylint: disable=unused-import
 
     HAS_SIX = True
 except ImportError:

--- a/tests/test_modutils.py
+++ b/tests/test_modutils.py
@@ -26,7 +26,7 @@ from astroid.interpreter._import import spec
 from . import resources
 
 try:
-    import urllib3  # pylint: disable=unused-import
+    import urllib3  # type: ignore[import]  # pylint: disable=unused-import
 
     HAS_URLLIB3 = True
 except ImportError:

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -13,7 +13,7 @@ from astroid.const import PY311_PLUS
 from astroid.exceptions import InferenceError
 
 try:
-    import six  # pylint: disable=unused-import
+    import six  # type: ignore[import]  # pylint: disable=unused-import
 
     HAS_SIX = True
 except ImportError:

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -47,7 +47,7 @@ from astroid.nodes.scoped_nodes.scoped_nodes import _is_metaclass
 from . import resources
 
 try:
-    import six  # pylint: disable=unused-import
+    import six  # type: ignore[import]  # pylint: disable=unused-import
 
     HAS_SIX = True
 except ImportError:


### PR DESCRIPTION


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This just adds more dependencies while we don't even really use these packages. Let's just ignore the import errors and make our `mypy` config easier and more maintainable.