### PR TITLE
Fix constructors of ``BinOp``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ Release date: TBA
   Closes #1780
 
 * Improved signature of the ``__init__`` and ``__postinit__`` methods of the following nodes:
+  - ``nodes.BinOp``
   - ``nodes.If``
   - ``nodes.IfExp``
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1497,40 +1497,24 @@ class BinOp(NodeNG):
     _astroid_fields = ("left", "right")
     _other_fields = ("op",)
 
-    @decorators.deprecate_default_argument_values(op="str")
+    left: NodeNG
+    """What is being applied to the operator on the left side."""
+
+    right: NodeNG
+    """What is being applied to the operator on the right side."""
+
     def __init__(
         self,
-        op: str | None = None,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
+        op: str,
+        lineno: int,
+        col_offset: int,
+        parent: NodeNG,
         *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
+        end_lineno: int | None,
+        end_col_offset: int | None,
     ) -> None:
-        """
-        :param op: The operator.
-
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.left: NodeNG | None = None
-        """What is being applied to the operator on the left side."""
-
-        self.op: str | None = op
+        self.op = op
         """The operator."""
-
-        self.right: NodeNG | None = None
-        """What is being applied to the operator on the right side."""
 
         super().__init__(
             lineno=lineno,
@@ -1540,13 +1524,7 @@ class BinOp(NodeNG):
             parent=parent,
         )
 
-    def postinit(self, left: NodeNG | None = None, right: NodeNG | None = None) -> None:
-        """Do some setup after initialisation.
-
-        :param left: What is being applied to the operator on the left side.
-
-        :param right: What is being applied to the operator on the right side.
-        """
+    def postinit(self, left: NodeNG, right: NodeNG) -> None:
         self.left = left
         self.right = right
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |


## Description

This one removes quite a lot of warnings now that `op` is a `str` by default 🚀 