### PR TITLE
Fix constructors of ``AugAssign``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ Release date: TBA
   Closes #1780
 
 * Improved signature of the ``__init__`` and ``__postinit__`` methods of the following nodes:
+  - ``nodes.AugAssign``
   - ``nodes.If``
   - ``nodes.IfExp``
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1385,44 +1385,27 @@ class AugAssign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
     _astroid_fields = ("target", "value")
     _other_fields = ("op",)
 
-    @decorators.deprecate_default_argument_values(op="str")
+    target: Name | Attribute | Subscript
+    """What is being assigned to."""
+
+    value: NodeNG
+    """The value being assigned to the variable."""
+
     def __init__(
         self,
-        op: str | None = None,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
+        op: str,
+        lineno: int,
+        col_offset: int,
+        parent: NodeNG,
         *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
+        end_lineno: int | None,
+        end_col_offset: int | None,
     ) -> None:
-        """
-        :param op: The operator that is being combined with the assignment.
-            This includes the equals sign.
-
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.target: NodeNG | None = None
-        """What is being assigned to."""
-
-        self.op: str | None = op
+        self.op = op
         """The operator that is being combined with the assignment.
 
         This includes the equals sign.
         """
-
-        self.value: NodeNG | None = None
-        """The value being assigned to the variable."""
 
         super().__init__(
             lineno=lineno,
@@ -1432,15 +1415,7 @@ class AugAssign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
             parent=parent,
         )
 
-    def postinit(
-        self, target: NodeNG | None = None, value: NodeNG | None = None
-    ) -> None:
-        """Do some setup after initialisation.
-
-        :param target: What is being assigned to.
-
-        :param value: The value being assigned to the variable.
-        """
+    def postinit(self, target: Name | Attribute | Subscript, value: NodeNG) -> None:
         self.target = target
         self.value = value
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |


## Description

This one removes quite a lot of warnings as well now that `op` is a `str` by default 🚀 

This is the last one from me for now. Let's first merge all the others.