### PR TITLE
Fix some line numbering related methods

### DIFF
--- a/astroid/nodes/_base_nodes.py
+++ b/astroid/nodes/_base_nodes.py
@@ -212,7 +212,9 @@ class MultiLineWithElseBlockNode(MultiLineBlockNode):
     def blockstart_tolineno(self):
         return self.lineno
 
-    def _elsed_block_range(self, lineno, orelse, last=None):
+    def _elsed_block_range(
+        self, lineno: int, orelse: list[nodes.NodeNG], last: int | None = None
+    ) -> tuple[int, int]:
         """Handle block line numbers range for try/finally, for, if and while
         statements.
         """

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -699,10 +699,10 @@ class Arguments(_base_nodes.AssignTypeNode):
         return None
 
     @cached_property
-    def fromlineno(self):
+    def fromlineno(self) -> int:
         """The first line that this node appears on in the source code.
 
-        :type: int or None
+        Can also return 0 if the line can not be determined.
         """
         lineno = super().fromlineno
         return max(lineno, self.parent.fromlineno or 0)

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2797,15 +2797,13 @@ class If(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
         """
         return self.test.tolineno
 
-    def block_range(self, lineno):
+    def block_range(self, lineno: int) -> tuple[int, int]:
         """Get a range from the given line number to where this node ends.
 
         :param lineno: The line number to start the range at.
-        :type lineno: int
 
         :returns: The range of line numbers that this node belongs to,
             starting at the given line number.
-        :rtype: tuple(int, int)
         """
         if lineno == self.body[0].fromlineno:
             return lineno, lineno
@@ -3622,15 +3620,13 @@ class TryExcept(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
     def _infer_name(self, frame, name):
         return name
 
-    def block_range(self, lineno):
+    def block_range(self, lineno: int) -> tuple[int, int]:
         """Get a range from the given line number to where this node ends.
 
         :param lineno: The line number to start the range at.
-        :type lineno: int
 
         :returns: The range of line numbers that this node belongs to,
             starting at the given line number.
-        :rtype: tuple(int, int)
         """
         last = None
         for exhandler in self.handlers:
@@ -3720,15 +3716,13 @@ class TryFinally(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
         if finalbody is not None:
             self.finalbody = finalbody
 
-    def block_range(self, lineno):
+    def block_range(self, lineno: int) -> tuple[int, int]:
         """Get a range from the given line number to where this node ends.
 
         :param lineno: The line number to start the range at.
-        :type lineno: int
 
         :returns: The range of line numbers that this node belongs to,
             starting at the given line number.
-        :rtype: tuple(int, int)
         """
         child = self.body[0]
         # py2.5 try: except: finally:
@@ -4072,15 +4066,13 @@ class While(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
         """
         return self.test.tolineno
 
-    def block_range(self, lineno):
+    def block_range(self, lineno: int) -> tuple[int, int]:
         """Get a range from the given line number to where this node ends.
 
         :param lineno: The line number to start the range at.
-        :type lineno: int
 
         :returns: The range of line numbers that this node belongs to,
             starting at the given line number.
-        :rtype: tuple(int, int)
         """
         return self._elsed_block_range(lineno, self.orelse)
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -491,15 +491,13 @@ class NodeNG:
                 parent = parent.parent
         return line or 0
 
-    def block_range(self, lineno):
+    def block_range(self, lineno: int) -> tuple[int, int]:
         """Get a range from the given line number to where this node ends.
 
         :param lineno: The line number to start the range at.
-        :type lineno: int
 
         :returns: The range of line numbers that this node belongs to,
             starting at the given line number.
-        :rtype: tuple(int, int or None)
         """
         return lineno, self.tolineno
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -446,15 +446,21 @@ class NodeNG:
     # single node, and they rarely get looked at
 
     @cached_property
-    def fromlineno(self) -> int | None:
-        """The first line that this node appears on in the source code."""
+    def fromlineno(self) -> int:
+        """The first line that this node appears on in the source code.
+
+        Can also return 0 if the line can not be determined.
+        """
         if self.lineno is None:
             return self._fixed_source_line()
         return self.lineno
 
     @cached_property
-    def tolineno(self) -> int | None:
-        """The last line that this node appears on in the source code."""
+    def tolineno(self) -> int:
+        """The last line that this node appears on in the source code.
+
+        Can also return 0 if the line can not be determined.
+        """
         if self.end_lineno is not None:
             return self.end_lineno
         if not self._astroid_fields:
@@ -466,10 +472,11 @@ class NodeNG:
             return self.fromlineno
         return last_child.tolineno
 
-    def _fixed_source_line(self) -> int | None:
+    def _fixed_source_line(self) -> int:
         """Attempt to find the line that this node appears on.
 
         We need this method since not all nodes have :attr:`lineno` set.
+        Will return 0 if the line number can not be determined.
         """
         line = self.lineno
         _node = self
@@ -482,7 +489,7 @@ class NodeNG:
             while parent and line is None:
                 line = parent.lineno
                 parent = parent.parent
-        return line
+        return line or 0
 
     def block_range(self, lineno):
         """Get a range from the given line number to where this node ends.

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1531,8 +1531,11 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
         return type_name
 
     @cached_property
-    def fromlineno(self) -> int | None:
-        """The first line that this node appears on in the source code."""
+    def fromlineno(self) -> int:
+        """The first line that this node appears on in the source code.
+
+        Can also return 0 if the line can not be determined.
+        """
         # lineno is the line number of the first decorator, we want the def
         # statement lineno. Similar to 'ClassDef.fromlineno'
         lineno = self.lineno
@@ -1541,7 +1544,7 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
                 node.tolineno - node.lineno + 1 for node in self.decorators.nodes
             )
 
-        return lineno
+        return lineno or 0
 
     @cached_property
     def blockstart_tolineno(self):
@@ -2152,8 +2155,11 @@ class ClassDef(
     )
 
     @cached_property
-    def fromlineno(self) -> int | None:
-        """The first line that this node appears on in the source code."""
+    def fromlineno(self) -> int:
+        """The first line that this node appears on in the source code.
+
+        Can also return 0 if the line can not be determined.
+        """
         if not PY38_PLUS or IS_PYPY and PY38 and not PYPY_7_3_11_PLUS:
             # For Python < 3.8 the lineno is the line number of the first decorator.
             # We want the class statement lineno. Similar to 'FunctionDef.fromlineno'
@@ -2164,7 +2170,7 @@ class ClassDef(
                     node.tolineno - node.lineno + 1 for node in self.decorators.nodes
                 )
 
-            return lineno
+            return lineno or 0
         return super().fromlineno
 
     @cached_property

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -344,14 +344,12 @@ class Module(LocalsDictNodeNG):
         """
         return self._get_stream()
 
-    def block_range(self, lineno):
+    def block_range(self, lineno: int) -> tuple[Literal[0], Literal[0]]:
         """Get a range from where this node starts to where this node ends.
 
         :param lineno: Unused.
-        :type lineno: int
 
         :returns: The range of line numbers that this node belongs to.
-        :rtype: tuple(int, int)
         """
         return self.fromlineno, self.tolineno
 
@@ -1557,14 +1555,12 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
     def implicit_parameters(self) -> Literal[0, 1]:
         return 1 if self.is_bound() else 0
 
-    def block_range(self, lineno):
+    def block_range(self, lineno: int) -> tuple[int, int]:
         """Get a range from the given line number to where this node ends.
 
         :param lineno: Unused.
-        :type lineno: int
 
         :returns: The range of line numbers that this node belongs to,
-        :rtype: tuple(int, int)
         """
         return self.fromlineno, self.tolineno
 
@@ -2184,14 +2180,12 @@ class ClassDef(
 
         return self.fromlineno
 
-    def block_range(self, lineno):
+    def block_range(self, lineno: int) -> tuple[int, int]:
         """Get a range from the given line number to where this node ends.
 
         :param lineno: Unused.
-        :type lineno: int
 
         :returns: The range of line numbers that this node belongs to,
-        :rtype: tuple(int, int)
         """
         return self.fromlineno, self.tolineno
 


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

``mypy`` was screaming at me for how we used these. We heavily depend on these always returning an `int` so we should handle the `return 0` case wherever needed instead of having it optionally return `None`.
If you want to check if it is really `None` you should just use `node.lineno`.