### PR TITLE
Add typing to the ``scope_lookup`` interface

### DIFF
--- a/astroid/filter_statements.py
+++ b/astroid/filter_statements.py
@@ -11,6 +11,8 @@ It is not considered public.
 from __future__ import annotations
 
 from astroid import nodes
+from astroid.nodes import node_classes
+from astroid.typing import SuccessfulInferenceResult
 
 
 def _get_filtered_node_statements(
@@ -41,7 +43,12 @@ def _get_if_statement_ancestor(node: nodes.NodeNG) -> nodes.If | None:
     return None
 
 
-def _filter_stmts(base_node: nodes.NodeNG, stmts, frame, offset):
+def _filter_stmts(
+    base_node: node_classes.LookupMixIn,
+    stmts: list[SuccessfulInferenceResult],
+    frame: nodes.LocalsDictNodeNG,
+    offset: int,
+) -> list[nodes.NodeNG]:
     """Filter the given list of statements to remove ignorable statements.
 
     If base_node is not a frame itself and the name is found in the inner
@@ -49,16 +56,12 @@ def _filter_stmts(base_node: nodes.NodeNG, stmts, frame, offset):
     statements according to base_node's location.
 
     :param stmts: The statements to filter.
-    :type stmts: list(nodes.NodeNG)
 
     :param frame: The frame that all of the given statements belong to.
-    :type frame: nodes.NodeNG
 
     :param offset: The line offset to filter statements up to.
-    :type offset: int
 
     :returns: The filtered statements.
-    :rtype: list(nodes.NodeNG)
     """
     # if offset == -1, my actual frame is not the inner frame but its parent
     #
@@ -102,7 +105,7 @@ def _filter_stmts(base_node: nodes.NodeNG, stmts, frame, offset):
         # disabling lineno filtering
         mylineno = 0
 
-    _stmts = []
+    _stmts: list[nodes.NodeNG] = []
     _stmt_parents = []
     statements = _get_filtered_node_statements(base_node, stmts)
     for node, stmt in statements:

--- a/astroid/nodes/scoped_nodes/mixin.py
+++ b/astroid/nodes/scoped_nodes/mixin.py
@@ -51,12 +51,13 @@ class LocalsDictNodeNG(node_classes.LookupMixIn):
         """
         return self
 
-    def scope_lookup(self, node, name: str, offset: int = 0):
+    def scope_lookup(
+        self, node: node_classes.LookupMixIn, name: str, offset: int = 0
+    ) -> tuple[LocalsDictNodeNG, list[nodes.NodeNG]]:
         """Lookup where the given variable is assigned.
 
         :param node: The node to look for assignments up to.
             Any assignments after the given node are ignored.
-        :type node: NodeNG
 
         :param name: The name of the variable to find assignments for.
 
@@ -65,11 +66,12 @@ class LocalsDictNodeNG(node_classes.LookupMixIn):
         :returns: This scope node and the list of assignments associated to the
             given name according to the scope where it has been found (locals,
             globals or builtin).
-        :rtype: tuple(str, list(NodeNG))
         """
         raise NotImplementedError
 
-    def _scope_lookup(self, node, name, offset=0):
+    def _scope_lookup(
+        self, node: node_classes.LookupMixIn, name: str, offset: int = 0
+    ) -> tuple[LocalsDictNodeNG, list[nodes.NodeNG]]:
         """XXX method for interfacing the scope lookup"""
         try:
             stmts = _filter_stmts(node, self.locals[name], self, offset)

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -353,23 +353,21 @@ class Module(LocalsDictNodeNG):
         """
         return self.fromlineno, self.tolineno
 
-    def scope_lookup(self, node, name, offset=0):
+    def scope_lookup(
+        self, node: node_classes.LookupMixIn, name: str, offset: int = 0
+    ) -> tuple[LocalsDictNodeNG, list[node_classes.NodeNG]]:
         """Lookup where the given variable is assigned.
 
         :param node: The node to look for assignments up to.
             Any assignments after the given node are ignored.
-        :type node: NodeNG
 
         :param name: The name of the variable to find assignments for.
-        :type name: str
 
         :param offset: The line offset to filter statements up to.
-        :type offset: int
 
         :returns: This scope node and the list of assignments associated to the
             given name according to the scope where it has been found (locals,
             globals or builtin).
-        :rtype: tuple(str, list(NodeNG))
         """
         if name in self.scope_attrs and name not in self.locals:
             try:
@@ -1182,23 +1180,21 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
         # to None due to a strong interaction between Lambda and FunctionDef.
         return self.body.infer(context)
 
-    def scope_lookup(self, node, name, offset=0):
+    def scope_lookup(
+        self, node: node_classes.LookupMixIn, name: str, offset: int = 0
+    ) -> tuple[LocalsDictNodeNG, list[NodeNG]]:
         """Lookup where the given names is assigned.
 
         :param node: The node to look for assignments up to.
             Any assignments after the given node are ignored.
-        :type node: NodeNG
 
         :param name: The name to find assignments for.
-        :type name: str
 
         :param offset: The line offset to filter statements up to.
-        :type offset: int
 
         :returns: This scope node and the list of assignments associated to the
             given name according to the scope where it has been found (locals,
             globals or builtin).
-        :rtype: tuple(str, list(NodeNG))
         """
         if node in self.args.defaults or node in self.args.kw_defaults:
             frame = self.parent.frame(future=True)
@@ -1767,7 +1763,9 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
 
         yield from self.body
 
-    def scope_lookup(self, node, name, offset=0):
+    def scope_lookup(
+        self, node: node_classes.LookupMixIn, name: str, offset: int = 0
+    ) -> tuple[LocalsDictNodeNG, list[nodes.NodeNG]]:
         """Lookup where the given name is assigned."""
         if name == "__class__":
             # __class__ is an implicit closure reference created by the compiler
@@ -2304,23 +2302,21 @@ class ClassDef(
         else:
             yield self.instantiate_class()
 
-    def scope_lookup(self, node, name, offset=0):
+    def scope_lookup(
+        self, node: node_classes.LookupMixIn, name: str, offset: int = 0
+    ) -> tuple[LocalsDictNodeNG, list[nodes.NodeNG]]:
         """Lookup where the given name is assigned.
 
         :param node: The node to look for assignments up to.
             Any assignments after the given node are ignored.
-        :type node: NodeNG
 
         :param name: The name to find assignments for.
-        :type name: str
 
         :param offset: The line offset to filter statements up to.
-        :type offset: int
 
         :returns: This scope node and the list of assignments associated to the
             given name according to the scope where it has been found (locals,
             globals or builtin).
-        :rtype: tuple(str, list(NodeNG))
         """
         # If the name looks like a builtin name, just try to look
         # into the upper scope of this class. We might have a

--- a/astroid/nodes/scoped_nodes/utils.py
+++ b/astroid/nodes/scoped_nodes/utils.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from astroid.manager import AstroidManager
@@ -15,7 +14,7 @@ if TYPE_CHECKING:
     from astroid import nodes
 
 
-def builtin_lookup(name: str) -> tuple[nodes.Module, Sequence[nodes.NodeNG]]:
+def builtin_lookup(name: str) -> tuple[nodes.Module, list[nodes.NodeNG]]:
     """Lookup a name in the builtin module.
 
     Return the list of matching statements and the ast for the builtin module
@@ -30,7 +29,7 @@ def builtin_lookup(name: str) -> tuple[nodes.Module, Sequence[nodes.NodeNG]]:
     if name == "__dict__":
         return _builtin_astroid, ()
     try:
-        stmts: Sequence[nodes.NodeNG] = _builtin_astroid.locals[name]  # type: ignore[assignment]
+        stmts: list[nodes.NodeNG] = _builtin_astroid.locals[name]  # type: ignore[assignment]
     except KeyError:
-        stmts = ()
+        stmts = []
     return _builtin_astroid, stmts


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Description

The added typing just makes it easier to follow what is happening and makes me somewhat more confident that this is correct 😄