### PR TITLE
Fix infer_call_result() crash on methods called with_metaclass()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -61,6 +61,9 @@ What's New in astroid 2.15.3?
 =============================
 Release date: TBA
 
+* Fix ``infer_call_result()`` crash on methods called ``with_metaclass()``.
+
+  Closes #1735
 
 
 What's New in astroid 2.15.2?

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1701,7 +1701,7 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
             elif isinstance(caller.args, list):
                 metaclass = next(caller.args[0].infer(context), None)
             else:
-                raise TypeError(
+                raise TypeError(  # pragma: no cover
                     f"caller.args was neither Arguments nor list; got {type(caller.args)}"
                 )
             if isinstance(metaclass, ClassDef):

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1693,12 +1693,17 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
         if (
             self.name == "with_metaclass"
             and caller is not None
-            and isinstance(caller.args, Arguments)
-            and caller.args.args
             and len(self.args.args) == 1
             and self.args.vararg is not None
         ):
-            metaclass = next(caller.args.args[0].infer(context), None)
+            if isinstance(caller.args, Arguments):
+                metaclass = next(caller.args.args[0].infer(context), None)
+            elif isinstance(caller.args, list):
+                metaclass = next(caller.args[0].infer(context), None)
+            else:
+                raise TypeError(
+                    f"caller.args was neither Arguments nor list; got {type(caller.args)}"
+                )
             if isinstance(metaclass, ClassDef):
                 try:
                     class_bases = [

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1692,10 +1692,13 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
         # generators, and filter it out later.
         if (
             self.name == "with_metaclass"
+            and caller is not None
+            and isinstance(caller.args, Arguments)
+            and caller.args.args
             and len(self.args.args) == 1
             and self.args.vararg is not None
         ):
-            metaclass = next(caller.args[0].infer(context), None)
+            metaclass = next(caller.args.args[0].infer(context), None)
             if isinstance(metaclass, ClassDef):
                 try:
                     class_bases = [

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -4055,6 +4055,11 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             inferred = next(node.infer())
             self.assertRaises(InferenceError, next, inferred.infer_call_result(node))
 
+    def test_infer_call_result_with_metaclass(self) -> None:
+        node = extract_node("def with_metaclass(meta, *bases): return 42")
+        inferred = next(node.infer_call_result(caller=node))
+        self.assertIsInstance(inferred, nodes.Const)
+
     def test_context_call_for_context_managers(self) -> None:
         ast_nodes = extract_node(
             """


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Closes #1735