### PR TITLE
Port property-related workaround from `infer_functiondef` to `infer_property`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -57,6 +57,10 @@ Release date: TBA
 
   Closes pylint-dev/pylint#8544
 
+* ``infer_property()`` now observes the same property-specific workaround as ``infer_functiondef``.
+
+  Refs #1490
+
 What's New in astroid 2.15.3?
 =============================
 Release date: TBA

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -564,7 +564,7 @@ def infer_property(
         lineno=node.lineno,
         col_offset=node.col_offset,
     )
-    # Set parent outside __init__: https://github.com/pylint-dev/astroid#1490
+    # Set parent outside __init__: https://github.com/pylint-dev/astroid/issues/1490
     prop_func.parent = node
     prop_func.postinit(
         body=[],

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -562,9 +562,10 @@ def infer_property(
         function=inferred,
         name=inferred.name,
         lineno=node.lineno,
-        parent=node,
         col_offset=node.col_offset,
     )
+    # Set parent outside __init__: https://github.com/pylint-dev/astroid#1490
+    prop_func.parent = node
     prop_func.postinit(
         body=[],
         args=inferred.args,

--- a/tests/brain/test_builtin.py
+++ b/tests/brain/test_builtin.py
@@ -24,6 +24,14 @@ class BuiltinsTest(unittest.TestCase):
         )
         inferred_property = list(class_with_property.value.infer())[0]
         self.assertTrue(isinstance(inferred_property, objects.Property))
+        class_parent = inferred_property.parent.parent.parent
+        self.assertIsInstance(class_parent, nodes.ClassDef)
+        self.assertFalse(
+            any(
+                isinstance(getter, objects.Property)
+                for getter in class_parent.locals["getter"]
+            )
+        )
         self.assertTrue(hasattr(inferred_property, "args"))
 
 


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Refs #1490

Needed for https://github.com/pylint-dev/pylint/pull/8494
