### PR TITLE
[Backport maintenance/2.15.x] Fix infer_call_result() crash on methods called with_metaclass()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,9 @@ What's New in astroid 2.15.3?
 =============================
 Release date: TBA
 
+* Fix ``infer_call_result()`` crash on methods called ``with_metaclass()``.
+
+  Closes #1735
 
 
 What's New in astroid 2.15.2?

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1697,10 +1697,18 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
         # generators, and filter it out later.
         if (
             self.name == "with_metaclass"
+            and caller is not None
             and len(self.args.args) == 1
             and self.args.vararg is not None
         ):
-            metaclass = next(caller.args[0].infer(context), None)
+            if isinstance(caller.args, Arguments):
+                metaclass = next(caller.args.args[0].infer(context), None)
+            elif isinstance(caller.args, list):
+                metaclass = next(caller.args[0].infer(context), None)
+            else:
+                raise TypeError(  # pragma: no cover
+                    f"caller.args was neither Arguments nor list; got {type(caller.args)}"
+                )
             if isinstance(metaclass, ClassDef):
                 try:
                     class_bases = [

--- a/tests/brain/test_regex.py
+++ b/tests/brain/test_regex.py
@@ -24,6 +24,9 @@ class TestRegexBrain:
             assert name in re_ast
             assert next(re_ast[name].infer()).value == getattr(regex, name)
 
+    @pytest.mark.xfail(
+        reason="Started failing on main, but no one reproduced locally yet"
+    )
     @test_utils.require_version(minver="3.9")
     def test_regex_pattern_and_match_subscriptable(self):
         """Test regex.Pattern and regex.Match are subscriptable in PY39+."""

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -4048,6 +4048,11 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             inferred = next(node.infer())
             self.assertRaises(InferenceError, next, inferred.infer_call_result(node))
 
+    def test_infer_call_result_with_metaclass(self) -> None:
+        node = extract_node("def with_metaclass(meta, *bases): return 42")
+        inferred = next(node.infer_call_result(caller=node))
+        self.assertIsInstance(inferred, nodes.Const)
+
     def test_context_call_for_context_managers(self) -> None:
         ast_nodes = extract_node(
             """


### PR DESCRIPTION
Backport of #2118. Manual because I forgot the backport label before it was merged.