### PR TITLE
Suppress UserWarning when finding module specs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -65,6 +65,10 @@ Release date: TBA
 
   Closes #1735
 
+* Suppress ``UserWarning`` when finding module specs.
+
+  Closes pylint-dev/pylint#7906
+
 
 What's New in astroid 2.15.2?
 =============================

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -148,7 +148,8 @@ class ImportlibFinder(Finder):
             )
         else:
             try:
-                with warnings.catch_warnings(action="ignore"):
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", category=UserWarning)
                     spec = importlib.util.find_spec(modname)
                 if (
                     spec

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -13,11 +13,11 @@ import os
 import pathlib
 import sys
 import types
+import warnings
 import zipimport
 from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import Any, NamedTuple
-from warnings import catch_warnings
 
 from astroid.const import PY310_PLUS
 from astroid.modutils import EXT_LIB_DIRS
@@ -148,7 +148,7 @@ class ImportlibFinder(Finder):
             )
         else:
             try:
-                with catch_warnings(category=UserWarning, action="ignore"):
+                with warnings.catch_warnings(action="ignore"):
                     spec = importlib.util.find_spec(modname)
                 if (
                     spec

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -17,6 +17,7 @@ import zipimport
 from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import Any, NamedTuple
+from warnings import catch_warnings
 
 from astroid.const import PY310_PLUS
 from astroid.modutils import EXT_LIB_DIRS
@@ -147,7 +148,8 @@ class ImportlibFinder(Finder):
             )
         else:
             try:
-                spec = importlib.util.find_spec(modname)
+                with catch_warnings(category=UserWarning, action="ignore"):
+                    spec = importlib.util.find_spec(modname)
                 if (
                     spec
                     and spec.loader  # type: ignore[comparison-overlap] # noqa: E501

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -10,6 +10,7 @@ import unittest
 from collections.abc import Iterator
 from contextlib import contextmanager
 from unittest import mock
+from warnings import catch_warnings
 
 import pytest
 
@@ -381,6 +382,14 @@ class AstroidManagerTest(
     def test_raises_exception_for_empty_modname(self) -> None:
         with pytest.raises(AstroidBuildingError):
             self.manager.ast_from_module_name(None)
+
+
+class IsolatedAstroidManagerTest(resources.AstroidCacheSetupMixin, unittest.TestCase):
+    def test_no_user_warning(self):
+        mgr = manager.AstroidManager()
+        with catch_warnings(category=UserWarning, action="error"):
+            mgr.ast_from_module_name("setuptools")
+            mgr.ast_from_module_name("pip")
 
 
 class BorgAstroidManagerTC(unittest.TestCase):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -387,7 +387,8 @@ class AstroidManagerTest(
 class IsolatedAstroidManagerTest(resources.AstroidCacheSetupMixin, unittest.TestCase):
     def test_no_user_warning(self):
         mgr = manager.AstroidManager()
-        with warnings.catch_warnings(action="error"):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", category=UserWarning)
             mgr.ast_from_module_name("setuptools")
             mgr.ast_from_module_name("pip")
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -7,10 +7,10 @@ import site
 import sys
 import time
 import unittest
+import warnings
 from collections.abc import Iterator
 from contextlib import contextmanager
 from unittest import mock
-from warnings import catch_warnings
 
 import pytest
 
@@ -387,7 +387,7 @@ class AstroidManagerTest(
 class IsolatedAstroidManagerTest(resources.AstroidCacheSetupMixin, unittest.TestCase):
     def test_no_user_warning(self):
         mgr = manager.AstroidManager()
-        with catch_warnings(category=UserWarning, action="error"):
+        with warnings.catch_warnings(action="error"):
             mgr.ast_from_module_name("setuptools")
             mgr.ast_from_module_name("pip")
 


### PR DESCRIPTION
Last one for the week, promise :-)

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Suppress the UserWarning emitted when linting this code:

```python
import setuptools
import pip
```

Closes pylint-dev/pylint#7906
