### PR TITLE
Don't resolve symlinks.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ What's New in astroid 2.16.0?
 =============================
 Release date: TBA
 
+* No longer resolve symlinks to modules.
+
+  Closes #2127
+
 * Remove ``@cached`` decorator (just use ``@cached_property`` from the stdlib).
 
   Closes #1780

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -270,13 +270,6 @@ def _get_relative_base_path(filename: str, path_to_check: str) -> list[str] | No
     if os.path.normcase(abs_filename).startswith(path_to_check):
         importable_path = abs_filename
 
-    real_filename = os.path.realpath(filename)
-    if os.path.normcase(real_filename).startswith(path_to_check):
-        importable_path = real_filename
-
-    # if "var" in path_to_check:
-    #     breakpoint()
-
     if importable_path:
         base_path = os.path.splitext(importable_path)[0]
         relative_base_path = base_path[len(path_to_check) :]


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

This patch removes code that resolves symlinks when resolving a module path.

This causes problems, as described in the linked-to bug, and IMHO since the Python interpreter doesn't resolve symlinks there's no good reason why a code analyzer should do so.

Closes: #2127.
