### PR TITLE
Reduce file system access in `ast_from_file()`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,8 @@ Release date: TBA
 
   Closes #1780
 
+* Reduce file system access in ``ast_from_file()``.
+
 * ``nodes.FunctionDef`` no longer inherits from ``nodes.Lambda``.
   This is a breaking change but considered a bug fix as the nodes did not share the same
   API and were not interchangeable.

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -101,16 +101,24 @@ class AstroidManager:
         source: bool = False,
     ) -> nodes.Module:
         """Given a module name, return the astroid object."""
-        try:
-            filepath = get_source_file(filepath, include_no_ext=True)
-            source = True
-        except NoSourceFile:
-            pass
         if modname is None:
             try:
                 modname = ".".join(modpath_from_file(filepath))
             except ImportError:
                 modname = filepath
+        if (
+            modname in self.astroid_cache
+            and self.astroid_cache[modname].file == filepath
+        ):
+            return self.astroid_cache[modname]
+        # Call get_source_file() only after a cache miss,
+        # since it calls os.path.exists().
+        try:
+            filepath = get_source_file(filepath, include_no_ext=True)
+            source = True
+        except NoSourceFile:
+            pass
+        # Second attempt on the cache after get_source_file().
         if (
             modname in self.astroid_cache
             and self.astroid_cache[modname].file == filepath

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -488,9 +488,8 @@ def get_module_files(
 
 def get_source_file(filename: str, include_no_ext: bool = False) -> str:
     """Given a python module's file name return the matching source file
-    name (the filename will be returned identically if it's already an.
-
-    absolute path to a python source file...)
+    name (the filename will be returned identically if it's already an
+    absolute path to a python source file).
 
     :param filename: python module's file name
 


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
Found while looking into #2124.

I noticed that for projects such as `music21` (in the pylint primer), we are making tens of thousands of unnecessary calls to `get_source_file()` for a path such as `project.__init__.py`. Since that method accesses the filesystem with `os.path.exists()`, that can be a significant burden. On my M1 Mac running Python 3.11, music21 lints in 171 instead of 171.6 seconds now.

with cProfile on a script that runs `pylint music21`:
Before: 63,346 calls to `<frozen genericpath>:16(exists)`
After: 10,333 calls to `<frozen genericpath>:16(exists)`