### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
@@ -140,7 +140,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
     steps:
       - name: Set temp directory
         run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
@@ -193,7 +193,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.7", "pypy3.8", "pypy3.9"]
+        python-version: ["pypy3.8", "pypy3.9"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.5.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        exclude: astroid/__init__.py|tests/testdata
+        exclude: tests/testdata
         args: [--py38-plus]
   - repo: https://github.com/Pierre-Sassoulas/black-disable-checker/
     rev: v1.1.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,8 +26,8 @@ repos:
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        exclude: tests/testdata
-        args: [--py37-plus]
+        exclude: astroid/__init__.py|tests/testdata
+        args: [--py38-plus]
   - repo: https://github.com/Pierre-Sassoulas/black-disable-checker/
     rev: v1.1.3
     hooks:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,6 @@ sphinx:
   configuration: doc/conf.py
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: doc/requirements.txt

--- a/ChangeLog
+++ b/ChangeLog
@@ -81,6 +81,9 @@ Release date: TBA
 
   Refs #1490
 
+* Remove support for Python 3.7.
+
+
 What's New in astroid 2.15.4?
 =============================
 Release date: TBA

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ What's New in astroid 2.16.0?
 =============================
 Release date: TBA
 
+* Remove support for Python 3.7.
+
+  Refs #2137
+
 * Remove ``@cached`` decorator (just use ``@cached_property`` from the stdlib).
 
   Closes #1780
@@ -80,10 +84,6 @@ Release date: TBA
 * ``infer_property()`` now observes the same property-specific workaround as ``infer_functiondef``.
 
   Refs #1490
-
-* Remove support for Python 3.7.
-
-  Refs #2137
 
 
 What's New in astroid 2.15.4?

--- a/ChangeLog
+++ b/ChangeLog
@@ -83,6 +83,8 @@ Release date: TBA
 
 * Remove support for Python 3.7.
 
+  Refs #2137
+
 
 What's New in astroid 2.15.4?
 =============================

--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -181,7 +181,7 @@ from astroid.nodes import (  # pylint: disable=redefined-builtin (Ellipsis)
 from astroid.util import Uninferable
 
 # Performance hack for tokenize. See https://bugs.python.org/issue43014
-# Adapted from https://github.com/pylint-dev/pycodestyle/pull/993
+# Adapted from https://github.com/PyCQA/pycodestyle/pull/993
 if (
     not PY310_PLUS
     and callable(getattr(tokenize, "_compile", None))

--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -187,7 +187,7 @@ if (
     and callable(getattr(tokenize, "_compile", None))
     and getattr(tokenize._compile, "__wrapped__", None) is None  # type: ignore[attr-defined]
 ):
-    tokenize._compile = functools.lru_cache()(tokenize._compile)  # type: ignore[attr-defined]
+    tokenize._compile = functools.lru_cache(tokenize._compile)  # type: ignore[attr-defined]
 
 # load brain plugins
 for module in BRAIN_MODULES_DIRECTORY.iterdir():

--- a/astroid/_ast.py
+++ b/astroid/_ast.py
@@ -5,22 +5,9 @@
 from __future__ import annotations
 
 import ast
-import sys
-import types
-from collections.abc import Callable
-from functools import partial
 from typing import NamedTuple
 
-from astroid.const import PY38_PLUS, Context
-
-if sys.version_info >= (3, 8):
-    # On Python 3.8, typed_ast was merged back into `ast`
-    _ast_py3: types.ModuleType | None = ast
-else:
-    try:
-        import typed_ast.ast3 as _ast_py3
-    except ImportError:
-        _ast_py3 = None
+from astroid.const import Context
 
 
 class FunctionType(NamedTuple):
@@ -29,7 +16,6 @@ class FunctionType(NamedTuple):
 
 
 class ParserModule(NamedTuple):
-    module: types.ModuleType
     unary_op_classes: dict[type[ast.unaryop], str]
     cmp_op_classes: dict[type[ast.cmpop], str]
     bool_op_classes: dict[type[ast.boolop], str]
@@ -37,41 +23,23 @@ class ParserModule(NamedTuple):
     context_classes: dict[type[ast.expr_context], Context]
 
     def parse(self, string: str, type_comments: bool = True) -> ast.Module:
-        parse_func: Callable[[str], ast.Module]
-        if self.module is _ast_py3:
-            if PY38_PLUS:
-                parse_func = partial(self.module.parse, type_comments=type_comments)
-            else:
-                parse_func = partial(
-                    self.module.parse, feature_version=sys.version_info.minor
-                )
-        else:
-            parse_func = self.module.parse
-        return parse_func(string)
+        return ast.parse(string, type_comments=type_comments)
 
 
 def parse_function_type_comment(type_comment: str) -> FunctionType | None:
     """Given a correct type comment, obtain a FunctionType object."""
-    if _ast_py3 is None:
-        return None
-
-    func_type = _ast_py3.parse(type_comment, "<type_comment>", "func_type")  # type: ignore[attr-defined]
+    func_type = ast.parse(type_comment, "<type_comment>", "func_type")  # type: ignore[attr-defined]
     return FunctionType(argtypes=func_type.argtypes, returns=func_type.returns)
 
 
 def get_parser_module(type_comments: bool = True) -> ParserModule:
-    parser_module = ast
-    if type_comments and _ast_py3:
-        parser_module = _ast_py3
-
-    unary_op_classes = _unary_operators_from_module(parser_module)
-    cmp_op_classes = _compare_operators_from_module(parser_module)
-    bool_op_classes = _bool_operators_from_module(parser_module)
-    bin_op_classes = _binary_operators_from_module(parser_module)
-    context_classes = _contexts_from_module(parser_module)
+    unary_op_classes = _unary_operators_from_module()
+    cmp_op_classes = _compare_operators_from_module()
+    bool_op_classes = _bool_operators_from_module()
+    bin_op_classes = _binary_operators_from_module()
+    context_classes = _contexts_from_module()
 
     return ParserModule(
-        parser_module,
         unary_op_classes,
         cmp_op_classes,
         bool_op_classes,
@@ -80,62 +48,51 @@ def get_parser_module(type_comments: bool = True) -> ParserModule:
     )
 
 
-def _unary_operators_from_module(
-    module: types.ModuleType,
-) -> dict[type[ast.unaryop], str]:
-    return {module.UAdd: "+", module.USub: "-", module.Not: "not", module.Invert: "~"}
+def _unary_operators_from_module() -> dict[type[ast.unaryop], str]:
+    return {ast.UAdd: "+", ast.USub: "-", ast.Not: "not", ast.Invert: "~"}
 
 
-def _binary_operators_from_module(
-    module: types.ModuleType,
-) -> dict[type[ast.operator], str]:
-    binary_operators = {
-        module.Add: "+",
-        module.BitAnd: "&",
-        module.BitOr: "|",
-        module.BitXor: "^",
-        module.Div: "/",
-        module.FloorDiv: "//",
-        module.MatMult: "@",
-        module.Mod: "%",
-        module.Mult: "*",
-        module.Pow: "**",
-        module.Sub: "-",
-        module.LShift: "<<",
-        module.RShift: ">>",
-    }
-    return binary_operators
-
-
-def _bool_operators_from_module(
-    module: types.ModuleType,
-) -> dict[type[ast.boolop], str]:
-    return {module.And: "and", module.Or: "or"}
-
-
-def _compare_operators_from_module(
-    module: types.ModuleType,
-) -> dict[type[ast.cmpop], str]:
+def _binary_operators_from_module() -> dict[type[ast.operator], str]:
     return {
-        module.Eq: "==",
-        module.Gt: ">",
-        module.GtE: ">=",
-        module.In: "in",
-        module.Is: "is",
-        module.IsNot: "is not",
-        module.Lt: "<",
-        module.LtE: "<=",
-        module.NotEq: "!=",
-        module.NotIn: "not in",
+        ast.Add: "+",
+        ast.BitAnd: "&",
+        ast.BitOr: "|",
+        ast.BitXor: "^",
+        ast.Div: "/",
+        ast.FloorDiv: "//",
+        ast.MatMult: "@",
+        ast.Mod: "%",
+        ast.Mult: "*",
+        ast.Pow: "**",
+        ast.Sub: "-",
+        ast.LShift: "<<",
+        ast.RShift: ">>",
     }
 
 
-def _contexts_from_module(
-    module: types.ModuleType,
-) -> dict[type[ast.expr_context], Context]:
+def _bool_operators_from_module() -> dict[type[ast.boolop], str]:
+    return {ast.And: "and", ast.Or: "or"}
+
+
+def _compare_operators_from_module() -> dict[type[ast.cmpop], str]:
     return {
-        module.Load: Context.Load,
-        module.Store: Context.Store,
-        module.Del: Context.Del,
-        module.Param: Context.Store,
+        ast.Eq: "==",
+        ast.Gt: ">",
+        ast.GtE: ">=",
+        ast.In: "in",
+        ast.Is: "is",
+        ast.IsNot: "is not",
+        ast.Lt: "<",
+        ast.LtE: "<=",
+        ast.NotEq: "!=",
+        ast.NotIn: "not in",
+    }
+
+
+def _contexts_from_module() -> dict[type[ast.expr_context], Context]:
+    return {
+        ast.Load: Context.Load,
+        ast.Store: Context.Store,
+        ast.Del: Context.Del,
+        ast.Param: Context.Store,
     }

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -9,9 +9,8 @@ from __future__ import annotations
 
 import collections
 import collections.abc
-import sys
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from astroid import nodes
 from astroid.const import PY310_PLUS
@@ -35,11 +34,6 @@ from astroid.typing import (
     SuccessfulInferenceResult,
 )
 from astroid.util import Uninferable, UninferableBase, lazy_descriptor
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 if TYPE_CHECKING:
     from astroid.constraint import Constraint

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -14,9 +14,8 @@ dataclasses. References:
 
 from __future__ import annotations
 
-import sys
 from collections.abc import Iterator
-from typing import Tuple, Union
+from typing import Literal, Tuple, Union
 
 from astroid import bases, context, helpers, nodes
 from astroid.builder import parse
@@ -26,11 +25,6 @@ from astroid.inference_tip import inference_tip
 from astroid.manager import AstroidManager
 from astroid.typing import InferenceResult
 from astroid.util import Uninferable, UninferableBase
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 _FieldDefaultReturn = Union[
     None,

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import functools
 import keyword
-import sys
 from collections.abc import Iterator
 from textwrap import dedent
+from typing import Final
 
 import astroid
 from astroid import arguments, bases, inference_tip, nodes, util
@@ -24,12 +24,6 @@ from astroid.exceptions import (
     UseInferenceDefault,
 )
 from astroid.manager import AstroidManager
-
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
-
 
 ENUM_BASE_NAMES = {
     "Enum",

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -6,10 +6,10 @@
 
 from __future__ import annotations
 
-import sys
 import typing
 from collections.abc import Iterator
 from functools import partial
+from typing import Final
 
 from astroid import context, extract_node, inference_tip
 from astroid.builder import _extract_single_node
@@ -33,11 +33,6 @@ from astroid.nodes.node_classes import (
     Tuple,
 )
 from astroid.nodes.scoped_nodes import ClassDef, FunctionDef
-
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
 
 TYPING_TYPEVARS = {"TypeVar", "NewType"}
 TYPING_TYPEVARS_QUALIFIED: Final = {

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -47,13 +47,12 @@ class cachedproperty:
     __slots__ = ("wrapped",)
 
     def __init__(self, wrapped):
-        if sys.version_info >= (3, 8):
-            warnings.warn(
-                "cachedproperty has been deprecated and will be removed in astroid 3.0 for Python 3.8+. "
-                "Use functools.cached_property instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        warnings.warn(
+            "cachedproperty has been deprecated and will be removed in astroid 3.0 for Python 3.8+. "
+            "Use functools.cached_property instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         try:
             wrapped.__name__  # noqa[B018]
         except AttributeError as exc:

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -27,8 +27,7 @@ _R = TypeVar("_R")
 _P = ParamSpec("_P")
 
 
-# TODO: Remove when support for 3.7 is dropped
-# TODO: astroid 3.0 -> move class behind sys.version_info < (3, 8) guard
+# TODO: Remove for astroid 3.0
 class cachedproperty:
     """Provides a cached property equivalent to the stacking of
     @cached and @property, but more efficient.
@@ -48,7 +47,7 @@ class cachedproperty:
 
     def __init__(self, wrapped):
         warnings.warn(
-            "cachedproperty has been deprecated and will be removed in astroid 3.0 for Python 3.8+. "
+            "cachedproperty has been deprecated and will be removed in astroid 3.0"
             "Use functools.cached_property instead.",
             DeprecationWarning,
             stacklevel=2,

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -17,17 +17,12 @@ import warnings
 import zipimport
 from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import Any, Literal, NamedTuple, Protocol
 
 from astroid.const import PY310_PLUS
 from astroid.modutils import EXT_LIB_DIRS
 
 from . import util
-
-if sys.version_info >= (3, 8):
-    from typing import Literal, Protocol
-else:
-    from typing_extensions import Literal, Protocol
 
 
 # The MetaPathFinder protocol comes from typeshed, which says:

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -26,10 +26,9 @@ from __future__ import annotations
 import itertools
 import os
 import pprint
-import sys
 import types
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import astroid
 from astroid import bases, nodes, util
@@ -37,11 +36,6 @@ from astroid.context import InferenceContext, copy_context
 from astroid.exceptions import AttributeInferenceError, InferenceError, NoDefault
 from astroid.manager import AstroidManager
 from astroid.nodes import node_classes
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 if TYPE_CHECKING:
     from astroid.objects import Property
@@ -115,7 +109,7 @@ class ObjectModel:
     def __contains__(self, name) -> bool:
         return name in self.attributes()
 
-    @lru_cache()  # noqa
+    @lru_cache  # noqa
     def attributes(self) -> list[str]:
         """Get the attributes which are exported by this object model."""
         return [o[LEN_OF_IMPL_PREFIX:] for o in dir(self) if o.startswith(IMPL_PREFIX)]

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -155,7 +155,7 @@ def _handle_blacklist(
             filenames.remove(norecurs)
 
 
-@lru_cache()
+@lru_cache
 def _cache_normalize_path_(path: str) -> str:
     return _normalize_path(path)
 

--- a/astroid/nodes/_base_nodes.py
+++ b/astroid/nodes/_base_nodes.py
@@ -10,8 +10,8 @@ Previously these were called Mixin nodes.
 from __future__ import annotations
 
 import itertools
-import sys
 from collections.abc import Iterator
+from functools import cached_property
 from typing import TYPE_CHECKING, ClassVar
 
 from astroid.exceptions import AttributeInferenceError
@@ -19,11 +19,6 @@ from astroid.nodes.node_ng import NodeNG
 
 if TYPE_CHECKING:
     from astroid import nodes
-
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from astroid.decorators import cachedproperty as cached_property
 
 
 class Statement(NodeNG):

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -8,12 +8,20 @@ from __future__ import annotations
 
 import abc
 import itertools
-import sys
 import typing
 import warnings
 from collections.abc import Generator, Iterable, Iterator, Mapping
-from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, TypeVar, Union
+from functools import cached_property, lru_cache
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Literal,
+    Optional,
+    TypeVar,
+    Union,
+)
 
 from astroid import decorators, util
 from astroid.bases import Instance, _infer_stmts
@@ -39,19 +47,9 @@ from astroid.typing import (
     SuccessfulInferenceResult,
 )
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 if TYPE_CHECKING:
     from astroid import nodes
     from astroid.nodes import LocalsDictNodeNG
-
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from astroid.decorators import cachedproperty as cached_property
 
 
 def _is_const(value) -> bool:
@@ -354,7 +352,7 @@ class BaseContainer(_base_nodes.ParentAssignNode, Instance, metaclass=abc.ABCMet
 class LookupMixIn(NodeNG):
     """Mixin to look up a name in the right scope."""
 
-    @lru_cache()  # noqa
+    @lru_cache  # noqa
     def lookup(self, name: str) -> tuple[LocalsDictNodeNG, list[NodeNG]]:
         """Lookup where the given variable is assigned.
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -5,14 +5,15 @@
 from __future__ import annotations
 
 import pprint
-import sys
 import warnings
 from collections.abc import Generator, Iterator
+from functools import cached_property
 from functools import singledispatch as _singledispatch
 from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
+    Literal,
     Tuple,
     Type,
     TypeVar,
@@ -39,15 +40,6 @@ from astroid.typing import InferenceErrorInfo, InferenceResult, InferFn
 if TYPE_CHECKING:
     from astroid import nodes
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from astroid.decorators import cachedproperty as cached_property
 
 # Types for 'NodeNG.nodes_of_class()'
 _NodesT = TypeVar("_NodesT", bound="NodeNG")

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -13,11 +13,10 @@ from __future__ import annotations
 import io
 import itertools
 import os
-import sys
 import warnings
 from collections.abc import Generator, Iterable, Iterator, Sequence
-from functools import lru_cache
-from typing import TYPE_CHECKING, ClassVar, NoReturn, TypeVar, overload
+from functools import cached_property, lru_cache
+from typing import TYPE_CHECKING, ClassVar, Literal, NoReturn, TypeVar, overload
 
 from astroid import bases, util
 from astroid.const import IS_PYPY, PY38, PY38_PLUS, PY39_PLUS, PYPY_7_3_11_PLUS
@@ -46,14 +45,6 @@ from astroid.nodes.scoped_nodes.mixin import ComprehensionScope, LocalsDictNodeN
 from astroid.nodes.scoped_nodes.utils import builtin_lookup
 from astroid.nodes.utils import Position
 from astroid.typing import InferBinaryOp, InferenceResult, SuccessfulInferenceResult
-
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
-    from astroid.decorators import cachedproperty as cached_property
 
 if TYPE_CHECKING:
     from astroid import nodes

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -13,9 +13,9 @@ leads to an inferred FrozenSet:
 
 from __future__ import annotations
 
-import sys
 from collections.abc import Generator, Iterator
-from typing import Any, TypeVar
+from functools import cached_property
+from typing import Any, Literal, TypeVar
 
 from astroid import bases, decorators, util
 from astroid.context import InferenceContext
@@ -29,14 +29,6 @@ from astroid.interpreter import objectmodel
 from astroid.manager import AstroidManager
 from astroid.nodes import node_classes, scoped_nodes
 from astroid.typing import InferenceResult, SuccessfulInferenceResult
-
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
-    from astroid.decorators import cachedproperty as cached_property
 
 _T = TypeVar("_T")
 

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -14,7 +14,7 @@ import token
 from collections.abc import Callable, Generator
 from io import StringIO
 from tokenize import TokenInfo, generate_tokens
-from typing import TYPE_CHECKING, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Final, TypeVar, Union, cast, overload
 
 from astroid import nodes
 from astroid._ast import ParserModule, get_parser_module, parse_function_type_comment
@@ -23,12 +23,6 @@ from astroid.manager import AstroidManager
 from astroid.nodes import NodeNG
 from astroid.nodes.utils import Position
 from astroid.typing import SuccessfulInferenceResult
-
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
-
 
 REDIRECT: Final[dict[str, str]] = {
     "arguments": "Arguments",
@@ -74,16 +68,15 @@ class TreeRebuilder:
             self._parser_module = get_parser_module()
         else:
             self._parser_module = parser_module
-        self._module = self._parser_module.module
 
     def _get_doc(self, node: T_Doc) -> tuple[T_Doc, ast.Constant | ast.Str | None]:
         """Return the doc ast node."""
         try:
-            if node.body and isinstance(node.body[0], self._module.Expr):
+            if node.body and isinstance(node.body[0], ast.Expr):
                 first_value = node.body[0].value
-                if isinstance(first_value, self._module.Str) or (
+                if isinstance(first_value, ast.Str) or (
                     PY38_PLUS
-                    and isinstance(first_value, self._module.Constant)
+                    and isinstance(first_value, ast.Constant)
                     and isinstance(first_value.value, str)
                 ):
                     doc_ast_node = first_value
@@ -400,11 +393,9 @@ class TreeRebuilder:
         ) -> nodes.FormattedValue:
             ...
 
-        if sys.version_info >= (3, 8):
-
-            @overload
-            def visit(self, node: ast.NamedExpr, parent: NodeNG) -> nodes.NamedExpr:
-                ...
+        @overload
+        def visit(self, node: ast.NamedExpr, parent: NodeNG) -> nodes.NamedExpr:
+            ...
 
         if sys.version_info < (3, 9):
             # Not used in Python 3.9+
@@ -629,7 +620,6 @@ class TreeRebuilder:
         defaults = [self.visit(child, newnode) for child in node.defaults]
         varargannotation: NodeNG | None = None
         kwargannotation: NodeNG | None = None
-        posonlyargs: list[nodes.AssignName] = []
         if node.vararg:
             vararg = node.vararg.arg
             varargannotation = self.visit(node.vararg.annotation, newnode)
@@ -652,24 +642,19 @@ class TreeRebuilder:
             self.visit(arg.annotation, newnode) for arg in node.kwonlyargs
         ]
 
-        posonlyargs_annotations: list[NodeNG | None] = []
-        if PY38_PLUS:
-            posonlyargs = [self.visit(child, newnode) for child in node.posonlyargs]
-            posonlyargs_annotations = [
-                self.visit(arg.annotation, newnode) for arg in node.posonlyargs
-            ]
+        posonlyargs = [self.visit(child, newnode) for child in node.posonlyargs]
+        posonlyargs_annotations = [
+            self.visit(arg.annotation, newnode) for arg in node.posonlyargs
+        ]
         type_comment_args = [
             self.check_type_comment(child, parent=newnode) for child in node.args
         ]
         type_comment_kwonlyargs = [
             self.check_type_comment(child, parent=newnode) for child in node.kwonlyargs
         ]
-        type_comment_posonlyargs: list[NodeNG | None] = []
-        if PY38_PLUS:
-            type_comment_posonlyargs = [
-                self.check_type_comment(child, parent=newnode)
-                for child in node.posonlyargs
-            ]
+        type_comment_posonlyargs = [
+            self.check_type_comment(child, parent=newnode) for child in node.posonlyargs
+        ]
 
         newnode.postinit(
             args=args,
@@ -1038,15 +1023,12 @@ class TreeRebuilder:
             return None
         # /!\ node is actually an _ast.FunctionDef node while
         # parent is an astroid.nodes.FunctionDef node
-        if sys.version_info >= (3, 8):
-            # Set the line number of the first decorator for Python 3.8+.
-            lineno = node.decorator_list[0].lineno
-            end_lineno = node.decorator_list[-1].end_lineno
-            end_col_offset = node.decorator_list[-1].end_col_offset
-        else:
-            lineno = node.lineno
-            end_lineno = None
-            end_col_offset = None
+
+        # Set the line number of the first decorator for Python 3.8+.
+        lineno = node.decorator_list[0].lineno
+        end_lineno = node.decorator_list[-1].end_lineno
+        end_col_offset = node.decorator_list[-1].end_col_offset
+
         newnode = nodes.Decorators(
             lineno=lineno,
             col_offset=node.col_offset,
@@ -1455,23 +1437,19 @@ class TreeRebuilder:
         )
         return newnode
 
-    if sys.version_info >= (3, 8):
-
-        def visit_namedexpr(
-            self, node: ast.NamedExpr, parent: NodeNG
-        ) -> nodes.NamedExpr:
-            newnode = nodes.NamedExpr(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                # end_lineno and end_col_offset added in 3.8
-                end_lineno=getattr(node, "end_lineno", None),
-                end_col_offset=getattr(node, "end_col_offset", None),
-                parent=parent,
-            )
-            newnode.postinit(
-                self.visit(node.target, newnode), self.visit(node.value, newnode)
-            )
-            return newnode
+    def visit_namedexpr(self, node: ast.NamedExpr, parent: NodeNG) -> nodes.NamedExpr:
+        newnode = nodes.NamedExpr(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
+        newnode.postinit(
+            self.visit(node.target, newnode), self.visit(node.value, newnode)
+        )
+        return newnode
 
     if sys.version_info < (3, 9):
         # Not used in Python 3.9+.
@@ -1776,26 +1754,23 @@ class TreeRebuilder:
 
     def visit_tryexcept(self, node: ast.Try, parent: NodeNG) -> nodes.TryExcept:
         """Visit a TryExcept node by returning a fresh instance of it."""
-        if sys.version_info >= (3, 8):
-            # TryExcept excludes the 'finally' but that will be included in the
-            # end_lineno from 'node'. Therefore, we check all non 'finally'
-            # children to find the correct end_lineno and column.
-            end_lineno = node.end_lineno
-            end_col_offset = node.end_col_offset
-            all_children: list[ast.AST] = [*node.body, *node.handlers, *node.orelse]
-            for child in reversed(all_children):
-                end_lineno = child.end_lineno
-                end_col_offset = child.end_col_offset
-                break
-            newnode = nodes.TryExcept(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=end_lineno,
-                end_col_offset=end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.TryExcept(node.lineno, node.col_offset, parent)
+        # TryExcept excludes the 'finally' but that will be included in the
+        # end_lineno from 'node'. Therefore, we check all non 'finally'
+        # children to find the correct end_lineno and column.
+        end_lineno = node.end_lineno
+        end_col_offset = node.end_col_offset
+        all_children: list[ast.AST] = [*node.body, *node.handlers, *node.orelse]
+        for child in reversed(all_children):
+            end_lineno = child.end_lineno
+            end_col_offset = child.end_col_offset
+            break
+        newnode = nodes.TryExcept(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
         newnode.postinit(
             [self.visit(child, newnode) for child in node.body],
             [self.visit(child, newnode) for child in node.handlers],

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -4,18 +4,13 @@
 
 from __future__ import annotations
 
-import sys
-from typing import TYPE_CHECKING, Any, Callable, Generator, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Generator, TypedDict, TypeVar, Union
 
 if TYPE_CHECKING:
     from astroid import bases, exceptions, nodes, transforms, util
     from astroid.context import InferenceContext
     from astroid.interpreter._import import spec
 
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
 
 _NodesT = TypeVar("_NodesT", bound="nodes.NodeNG")
 

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -5,16 +5,10 @@
 
 from __future__ import annotations
 
-import sys
 import warnings
-from typing import Any
+from typing import Any, Final, Literal
 
 import lazy_object_proxy
-
-if sys.version_info >= (3, 8):
-    from typing import Final, Literal
-else:
-    from typing_extensions import Final, Literal
 
 
 def lazy_descriptor(obj):

--- a/pylintrc
+++ b/pylintrc
@@ -39,7 +39,7 @@ unsafe-load-any-extension=no
 extension-pkg-whitelist=
 
 # Minimum supported python version
-py-version = 3.7.2
+py-version = 3.8.0
 
 
 [REPORTS]
@@ -107,6 +107,7 @@ disable=fixme,
         # This one would help performance but we need to fix the pipeline first
         # and there are a lot of warning for it
         consider-using-f-string,
+        consider-using-assignment-expr,
 
 enable=useless-suppression
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -28,10 +27,9 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
     "Topic :: Software Development :: Testing",
 ]
-requires-python = ">=3.7.2"
+requires-python = ">=3.8.0"
 dependencies = [
     "lazy_object_proxy>=1.4.0",
-    "typed-ast>=1.4.0,<2.0;implementation_name=='cpython' and python_version<'3.8'",
     "typing-extensions>=4.0.0;python_version<'3.11'",
 ]
 dynamic = ["version"]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,4 +2,3 @@
 -r requirements_test_pre_commit.txt
 contributors-txt>=0.7.4
 tbump~=6.9.0
-types-typed-ast; implementation_name=="cpython" and python_version<"3.8"

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -1953,11 +1953,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         import abc
         import typing
         import dataclasses
-
-        if sys.version_info >= (3, 8):
-            from typing import Protocol
-        else:
-            from typing_extensions import Protocol
+        from typing import Protocol
 
         T = typing.TypeVar("T")
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311}
+envlist = py{38,39,310,311}
 skip_missing_interpreters = true
 isolated_build = true
 


### PR DESCRIPTION
## Description
Similar to https://github.com/pylint-dev/pylint/pull/8609
EOL for Python 3.7 is 2023-06-27.

`2.16.0` already includes a lot of (unintentional) breaking changes. We might as well include this one too.
_Maybe even do `3.0.0` instead?_