### PR TITLE
Make all arguments to ``nodes.NodeNG.__init__`` required

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,7 +19,12 @@ Release date: TBA
   We have tried to minimize the amount of breaking changes caused by this change
   but some are unavoidable.
 
-* Improved signature of the ``__init__`` and ``__postinit__`` methods of the following nodes:
+* Improved signature of the ``__init__`` and ``__postinit__`` methods of most nodes.
+  This includes makes ``lineno``, ``col_offset``, ``end_lineno``, ``end_col_offset`` and ``parent``
+  required arguments for ``nodes.NodeNG`` and its subclasses.
+  For most other nodes, arguments of their ``__postinit__`` methods have been made required to better
+  represent how they would normally be constructed by the standard library ``ast`` module.
+  The following nodes were changed or updated:
   - ``nodes.AnnAssign``
   - ``nodes.Arguments``
   - ``nodes.Assign``
@@ -50,12 +55,13 @@ Release date: TBA
   - ``nodes.ListComp``
   - ``nodes.Module``
   - ``nodes.Name``
+  - ``nodes.NodeNG``
   - ``nodes.Raise``
   - ``nodes.Return``
   - ``nodes.SetComp``
   - ``nodes.Slice``
   - ``nodes.Starred``
-  - ``nodes.Super``, we also added the ``call`` parameter to its ``__init__`` method.
+  - ``objects.Super``, we also added the ``call`` parameter to its ``__init__`` method.
   - ``nodes.TryExcept``
   - ``nodes.Subscript``
   - ``nodes.UnaryOp``

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -606,7 +606,13 @@ class BoundMethod(UnboundMethod):
             end_lineno=caller.end_lineno,
             end_col_offset=caller.end_col_offset,
         )
-        empty = Pass()
+        empty = Pass(
+            parent=cls,
+            lineno=caller.lineno,
+            col_offset=caller.col_offset,
+            end_lineno=caller.end_lineno,
+            end_col_offset=caller.end_col_offset,
+        )
         cls.postinit(
             bases=bases.elts,
             body=[empty],

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -633,7 +633,11 @@ def infer_slice(node, context: InferenceContext | None = None):
         args.extend([None] * (3 - len(args)))
 
     slice_node = nodes.Slice(
-        lineno=node.lineno, col_offset=node.col_offset, parent=node.parent
+        lineno=node.lineno,
+        col_offset=node.col_offset,
+        parent=node.parent,
+        end_lineno=node.end_lineno,
+        end_col_offset=node.end_col_offset,
     )
     slice_node.postinit(*args)
     return slice_node

--- a/astroid/brain/brain_fstrings.py
+++ b/astroid/brain/brain_fstrings.py
@@ -19,7 +19,13 @@ def _clone_node_with_lineno(
     cls = node.__class__
     other_fields = node._other_fields
     _astroid_fields = node._astroid_fields
-    init_params = {"lineno": lineno, "col_offset": node.col_offset, "parent": parent}
+    init_params = {
+        "lineno": lineno,
+        "col_offset": node.col_offset,
+        "parent": parent,
+        "end_lineno": node.end_lineno,
+        "end_col_offset": node.end_col_offset,
+    }
     postinit_params = {param: getattr(node, param) for param in _astroid_fields}
     if other_fields:
         init_params.update({param: getattr(node, param) for param in other_fields})
@@ -41,7 +47,11 @@ def _transform_formatted_value(  # pylint: disable=inconsistent-return-statement
     if node.value and node.value.lineno == 1:
         if node.lineno != node.value.lineno:
             new_node = nodes.FormattedValue(
-                lineno=node.lineno, col_offset=node.col_offset, parent=node.parent
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                parent=node.parent,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
             )
             new_value = _clone_node_with_lineno(
                 node=node.value, lineno=node.lineno, parent=new_node

--- a/astroid/brain/brain_random.py
+++ b/astroid/brain/brain_random.py
@@ -31,7 +31,13 @@ def _clone_node_with_lineno(node, parent, lineno):
     cls = node.__class__
     other_fields = node._other_fields
     _astroid_fields = node._astroid_fields
-    init_params = {"lineno": lineno, "col_offset": node.col_offset, "parent": parent}
+    init_params = {
+        "lineno": lineno,
+        "col_offset": node.col_offset,
+        "parent": parent,
+        "end_lineno": node.end_lineno,
+        "end_col_offset": node.end_col_offset,
+    }
     postinit_params = {param: getattr(node, param) for param in _astroid_fields}
     if other_fields:
         init_params.update({param: getattr(node, param) for param in other_fields})
@@ -67,7 +73,13 @@ def infer_random_sample(node, context: InferenceContext | None = None):
     except ValueError as exc:
         raise UseInferenceDefault from exc
 
-    new_node = List(lineno=node.lineno, col_offset=node.col_offset, parent=node.scope())
+    new_node = List(
+        lineno=node.lineno,
+        col_offset=node.col_offset,
+        parent=node.scope(),
+        end_lineno=node.end_lineno,
+        end_col_offset=node.end_col_offset,
+    )
     new_elts = [
         _clone_node_with_lineno(elt, parent=new_node, lineno=new_node.lineno)
         for elt in elts

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4047,6 +4047,8 @@ class EvaluatedObject(NodeNG):
             lineno=self.original.lineno,
             col_offset=self.original.col_offset,
             parent=self.original.parent,
+            end_lineno=self.original.end_lineno,
+            end_col_offset=self.original.end_col_offset,
         )
 
     def _infer(
@@ -4134,7 +4136,13 @@ class MatchCase(_base_nodes.MultiLineBlockNode):
         self.pattern: Pattern
         self.guard: NodeNG | None
         self.body: list[NodeNG]
-        super().__init__(parent=parent)
+        super().__init__(
+            parent=parent,
+            lineno=None,
+            col_offset=None,
+            end_lineno=None,
+            end_col_offset=None,
+        )
 
     def postinit(
         self,

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -92,39 +92,26 @@ class NodeNG:
 
     def __init__(
         self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
+        lineno: int | None,
+        col_offset: int | None,
+        parent: NodeNG | None,
         *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
+        end_lineno: int | None,
+        end_col_offset: int | None,
     ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.lineno: int | None = lineno
+        self.lineno = lineno
         """The line that this node appears on in the source code."""
 
-        self.col_offset: int | None = col_offset
+        self.col_offset = col_offset
         """The column that this node appears on in the source code."""
 
-        self.parent: NodeNG | None = parent
+        self.parent = parent
         """The parent node in the syntax tree."""
 
-        self.end_lineno: int | None = end_lineno
+        self.end_lineno = end_lineno
         """The last line this node appears on in the source code."""
 
-        self.end_col_offset: int | None = end_col_offset
+        self.end_col_offset = end_col_offset
         """The end column this node appears on in the source code.
 
         Note: This is after the last symbol.

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1795,7 +1795,13 @@ class TreeRebuilder:
                 parent=parent,
             )
         else:
-            newnode = nodes.TryExcept(node.lineno, node.col_offset, parent)
+            newnode = nodes.TryExcept(
+                node.lineno,
+                node.col_offset,
+                parent,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+            )
         newnode.postinit(
             [self.visit(child, newnode) for child in node.body],
             [self.visit(child, newnode) for child in node.handlers],

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1799,8 +1799,8 @@ class TreeRebuilder:
                 node.lineno,
                 node.col_offset,
                 parent,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
+                end_lineno=None,
+                end_col_offset=None,
             )
         newnode.postinit(
             [self.visit(child, newnode) for child in node.body],

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -307,7 +307,17 @@ class ModuleModelTest(unittest.TestCase):
 
         init_ = next(ast_nodes[9].infer())
         assert isinstance(init_, bases.BoundMethod)
-        init_result = next(init_.infer_call_result(nodes.Call()))
+        init_result = next(
+            init_.infer_call_result(
+                nodes.Call(
+                    parent=None,
+                    lineno=None,
+                    col_offset=None,
+                    end_lineno=None,
+                    end_col_offset=None,
+                )
+            )
+        )
         assert isinstance(init_result, nodes.Const)
         assert init_result.value is None
 
@@ -485,7 +495,17 @@ class FunctionModelTest(unittest.TestCase):
 
         init_ = next(ast_nodes[9].infer())
         assert isinstance(init_, bases.BoundMethod)
-        init_result = next(init_.infer_call_result(nodes.Call()))
+        init_result = next(
+            init_.infer_call_result(
+                nodes.Call(
+                    parent=None,
+                    lineno=None,
+                    col_offset=None,
+                    end_lineno=None,
+                    end_col_offset=None,
+                )
+            )
+        )
         assert isinstance(init_result, nodes.Const)
         assert init_result.value is None
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -87,7 +87,13 @@ class TestTransforms(unittest.TestCase):
 
     def test_transform_patches_locals(self) -> None:
         def transform_function(node: FunctionDef) -> None:
-            assign = nodes.Assign()
+            assign = nodes.Assign(
+                parent=node,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+            )
             name = nodes.AssignName(
                 name="value",
                 lineno=0,


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Description

Now that we plan on doing `3.0` instead I feel much more comfortable with this change. I have seen in `ast` that there are definite cases where we need all line information to be `None`. Either way, I think it is much better to make that explicit instead of relying on implicit defaults three way down in your inheritance pattern.

With this PR we make a lot of our ``__init__``'s more explicit. I am not in favour of the required code duplication but am very much in favour of making the `astroid` code more explicit and easy to understand.