### PR TITLE
Remove ``lazy_object_proxy`` as a dependency

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -70,6 +70,9 @@ Release date: TBA
 
 * Remove dependency on ``wrapt``.
 
+* Remove dependency on ``lazy_object_proxy``. This includes the removal
+  of the assosicated ``lazy_import``, ``lazy_descriptor`` and ``proxy_alias`` utility functions.
+
 * ``CallSite._unpack_args`` and ``CallSite._unpack_keywords`` now use ``safe_infer()`` for
   better inference and fewer false positives.
 

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -34,7 +34,7 @@ from astroid.typing import (
     InferenceResult,
     SuccessfulInferenceResult,
 )
-from astroid.util import Uninferable, UninferableBase, lazy_descriptor
+from astroid.util import Uninferable, UninferableBase
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -643,7 +643,10 @@ class Generator(BaseInstance):
     Proxied class is set once for all in raw_building.
     """
 
-    special_attributes = lazy_descriptor(objectmodel.GeneratorModel)
+    # We defer initialization of special_attributes to the __init__ method since the constructor
+    # of GeneratorModel requires the raw_building to be complete
+    # TODO: This should probably be refactored.
+    special_attributes: objectmodel.GeneratorModel
 
     def __init__(
         self, parent=None, generator_initial_context: InferenceContext | None = None
@@ -651,6 +654,9 @@ class Generator(BaseInstance):
         super().__init__()
         self.parent = parent
         self._call_context = copy_context(generator_initial_context)
+
+        # See comment above: this is a deferred initialization.
+        Generator.special_attributes = objectmodel.GeneratorModel()
 
     def infer_yield_types(self):
         yield from self.parent.infer_yield_result(self._call_context)

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -9,20 +9,10 @@ import sys
 import warnings
 from typing import Any
 
-import lazy_object_proxy
-
 if sys.version_info >= (3, 8):
     from typing import Final, Literal
 else:
     from typing_extensions import Final, Literal
-
-
-def lazy_descriptor(obj):
-    class DescriptorProxy(lazy_object_proxy.Proxy):
-        def __get__(self, instance, owner=None):
-            return self.__class__.__get__(self, instance)
-
-    return DescriptorProxy(obj)
 
 
 class UninferableBase:
@@ -128,19 +118,6 @@ def _instancecheck(cls, other) -> bool:
         stacklevel=2,
     )
     return is_instance_of
-
-
-def proxy_alias(alias_name, node_type):
-    """Get a Proxy from the given name to the given node type."""
-    proxy = type(
-        alias_name,
-        (lazy_object_proxy.Proxy,),
-        {
-            "__class__": object.__dict__["__class__"],
-            "__instancecheck__": _instancecheck,
-        },
-    )
-    return proxy(lambda: node_type)
 
 
 def check_warnings_filter() -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
 ]
 requires-python = ">=3.7.2"
 dependencies = [
-    "lazy_object_proxy>=1.4.0",
     "typed-ast>=1.4.0,<2.0;implementation_name=='cpython' and python_version<'3.8'",
     "typing-extensions>=4.0.0;python_version<'3.11'",
 ]
@@ -73,7 +72,6 @@ module = [
     "_io.*",
     "gi.*",
     "importlib.*",
-    "lazy_object_proxy.*",
     "nose.*",
     "numpy.*",
     "pytest",


### PR DESCRIPTION
## Type of Changes


|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

I think only depending on `typed-as` (which will be removed after `3.7` support has been dropped) and `typing-extensions` is much nicer. EDIT: Well, now there is only one dependency.
This hack is very ugly, but I think it much better to use shady CPython behaviour rather than some rather unknown library that causes weird import cycles and deferred properties.


