### PR TITLE
Remove cachedproperty decorator

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@
 astroid's ChangeLog
 ===================
 
-What's New in astroid 2.16.0?
+What's New in astroid 3.0.0?
 =============================
 Release date: TBA
 
@@ -10,9 +10,10 @@ Release date: TBA
 
   Refs #2137
 
-* Remove ``@cached`` decorator (just use ``@cached_property`` from the stdlib).
+* Remove ``@cached`` and ``@cachedproperty`` decorator (just use ``@cached_property`` from the stdlib).
 
   Closes #1780
+  Refs #2140
 
 * Reduce file system access in ``ast_from_file()``.
 

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -27,52 +27,6 @@ _R = TypeVar("_R")
 _P = ParamSpec("_P")
 
 
-# TODO: Remove for astroid 3.0
-class cachedproperty:
-    """Provides a cached property equivalent to the stacking of
-    @cached and @property, but more efficient.
-
-    After first usage, the <property_name> becomes part of the object's
-    __dict__. Doing:
-
-      del obj.<property_name> empties the cache.
-
-    Idea taken from the pyramid_ framework and the mercurial_ project.
-
-    .. _pyramid: http://pypi.python.org/pypi/pyramid
-    .. _mercurial: http://pypi.python.org/pypi/Mercurial
-    """
-
-    __slots__ = ("wrapped",)
-
-    def __init__(self, wrapped):
-        warnings.warn(
-            "cachedproperty has been deprecated and will be removed in astroid 3.0"
-            "Use functools.cached_property instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        try:
-            wrapped.__name__  # noqa[B018]
-        except AttributeError as exc:
-            raise TypeError(f"{wrapped} must have a __name__ attribute") from exc
-        self.wrapped = wrapped
-
-    @property
-    def __doc__(self):
-        doc = getattr(self.wrapped, "__doc__", None)
-        return "<wrapped by the cachedproperty decorator>%s" % (
-            "\n%s" % doc if doc else ""
-        )
-
-    def __get__(self, inst, objtype=None):
-        if inst is None:
-            return self
-        val = self.wrapped(inst)
-        setattr(inst, self.wrapped.__name__, val)
-        return val
-
-
 def path_wrapper(func):
     """Return the given infer function wrapped to handle the path.
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -5,8 +5,7 @@
 import pytest
 from _pytest.recwarn import WarningsRecorder
 
-from astroid.const import PY38_PLUS
-from astroid.decorators import cachedproperty, deprecate_default_argument_values
+from astroid.decorators import deprecate_default_argument_values
 
 
 class SomeClass:
@@ -102,18 +101,3 @@ class TestDeprecationDecorators:
         instance = SomeClass(name="some_name")
         instance.func(name="", var=42)
         assert len(recwarn) == 0
-
-
-@pytest.mark.skipif(not PY38_PLUS, reason="Requires Python 3.8 or higher")
-def test_deprecation_warning_on_cachedproperty() -> None:
-    """Check the DeprecationWarning on cachedproperty."""
-
-    with pytest.warns(DeprecationWarning) as records:
-
-        class MyClass:  # pylint: disable=unused-variable
-            @cachedproperty
-            def my_property(self):
-                return 1
-
-        assert len(records) == 1
-        assert "functools.cached_property" in records[0].message.args[0]


### PR DESCRIPTION
## Description
Followup to #2137
This PR completely removes the `cachedproperty` decorator. `functools.cached_property` is a full replacement.

Also update changelog: `2.16.0` -> `3.0.0`.