### PR TITLE
Remove unused constants

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -88,8 +88,14 @@ Release date: TBA
 
   Refs #1490
 
-* Remove ``astroid.const.PY38_PLUS`` and the previously deprecated ``astroid.const.BUILTINS``,
-  ``astroid.bases.BUILTINS``, as well as ``astroid.const.Load``, ``..Store``, and ``..Del``.
+* Remove unused and / or deprecated constants:
+  - ``astroid.bases.BOOL_SPECIAL_METHOD``
+  - ``astroid.bases.BUILTINS``
+  - ``astroid.const.BUILTINS``
+  - ``astroid.const.PY38_PLUS``
+  - ``astroid.const.Load``
+  - ``astroid.const.Store``
+  - ``astroid.const.Del``
 
   Refs #2141
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -88,8 +88,8 @@ Release date: TBA
 
   Refs #1490
 
-* Remove ``astroid.const.PY38_PLUS`` and the previously deprecated ``astroid.const.BUILTINS`` as well
-  as ``astroid.bases.BUILTINS``.
+* Remove ``astroid.const.PY38_PLUS`` and the previously deprecated ``astroid.const.BUILTINS``,
+  ``astroid.bases.BUILTINS``, as well as ``astroid.const.Load``, ``..Store``, and ``..Del``.
 
   Refs #2141
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -88,6 +88,11 @@ Release date: TBA
 
   Refs #1490
 
+* Remove ``astroid.const.PY38_PLUS`` and the previously deprecated ``astroid.const.BUILTINS`` as well
+  as ``astroid.bases.BUILTINS``.
+
+  Refs #2141
+
 
 What's New in astroid 2.15.4?
 =============================

--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -46,7 +46,7 @@ from astroid.astroid_manager import MANAGER
 from astroid.bases import BaseInstance, BoundMethod, Instance, UnboundMethod
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import extract_node, parse
-from astroid.const import BRAIN_MODULES_DIRECTORY, PY310_PLUS, Context, Del, Load, Store
+from astroid.const import BRAIN_MODULES_DIRECTORY, PY310_PLUS, Context
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidBuildingException,

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -39,9 +39,6 @@ if TYPE_CHECKING:
     from astroid.constraint import Constraint
 
 
-# TODO: check if needs special treatment
-BOOL_SPECIAL_METHOD = "__bool__"
-
 PROPERTIES = {"builtins.property", "abc.abstractproperty"}
 if PY310_PLUS:
     PROPERTIES.add("enum.property")
@@ -382,7 +379,7 @@ class Instance(BaseInstance):
         context.boundnode = self
 
         try:
-            result = _infer_method_result_truth(self, BOOL_SPECIAL_METHOD, context)
+            result = _infer_method_result_truth(self, "__bool__", context)
         except (InferenceError, AttributeInferenceError):
             # Fallback to __len__.
             try:

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
 
 # TODO: check if needs special treatment
 BOOL_SPECIAL_METHOD = "__bool__"
-BUILTINS = "builtins"  # TODO Remove in 2.8
 
 PROPERTIES = {"builtins.property", "abc.abstractproperty"}
 if PY310_PLUS:

--- a/astroid/brain/brain_ssl.py
+++ b/astroid/brain/brain_ssl.py
@@ -6,7 +6,7 @@
 
 from astroid import parse
 from astroid.brain.helpers import register_module_extender
-from astroid.const import PY38_PLUS, PY310_PLUS
+from astroid.const import PY310_PLUS
 from astroid.manager import AstroidManager
 
 
@@ -41,9 +41,7 @@ def _options_enum() -> str:
         OP_SINGLE_ECDH_USE = 10
         OP_NO_COMPRESSION = 11
         OP_NO_TICKET = 12
-        OP_NO_RENEGOTIATION = 13"""
-    if PY38_PLUS:
-        enum += """
+        OP_NO_RENEGOTIATION = 13
         OP_ENABLE_MIDDLEBOX_COMPAT = 14"""
     return enum
 

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -13,7 +13,7 @@ from typing import Final
 
 from astroid import context, extract_node, inference_tip
 from astroid.builder import _extract_single_node
-from astroid.const import PY38_PLUS, PY39_PLUS
+from astroid.const import PY39_PLUS
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
@@ -428,7 +428,7 @@ if PY39_PLUS:
     AstroidManager().register_transform(
         FunctionDef, inference_tip(infer_typedDict), _looks_like_typedDict
     )
-elif PY38_PLUS:
+else:
     AstroidManager().register_transform(
         ClassDef, inference_tip(infer_old_typedDict), _looks_like_typedDict
     )

--- a/astroid/brain/brain_unittest.py
+++ b/astroid/brain/brain_unittest.py
@@ -5,7 +5,6 @@
 """Astroid hooks for unittest module."""
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.const import PY38_PLUS
 from astroid.manager import AstroidManager
 
 
@@ -27,7 +26,4 @@ def IsolatedAsyncioTestCaseImport():
     )
 
 
-if PY38_PLUS:
-    register_module_extender(
-        AstroidManager(), "unittest", IsolatedAsyncioTestCaseImport
-    )
+register_module_extender(AstroidManager(), "unittest", IsolatedAsyncioTestCaseImport)

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -26,12 +26,6 @@ class Context(enum.Enum):
     Del = 3
 
 
-# TODO Remove in 3.0 in favor of Context
-Load = Context.Load
-Store = Context.Store
-Del = Context.Del
-
-
 ASTROID_INSTALL_DIRECTORY = Path(__file__).parent
 BRAIN_MODULES_DIRECTORY = ASTROID_INSTALL_DIRECTORY / "brain"
 

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -7,7 +7,6 @@ import sys
 from pathlib import Path
 
 PY38 = sys.version_info[:2] == (3, 8)
-PY38_PLUS = sys.version_info >= (3, 8)
 PY39_PLUS = sys.version_info >= (3, 9)
 PY310_PLUS = sys.version_info >= (3, 10)
 PY311_PLUS = sys.version_info >= (3, 11)

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -10,7 +10,6 @@ PY38 = sys.version_info[:2] == (3, 8)
 PY39_PLUS = sys.version_info >= (3, 9)
 PY310_PLUS = sys.version_info >= (3, 10)
 PY311_PLUS = sys.version_info >= (3, 11)
-BUILTINS = "builtins"  # TODO Remove in 2.8
 
 WIN32 = sys.platform == "win32"
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -19,7 +19,7 @@ from functools import cached_property, lru_cache
 from typing import TYPE_CHECKING, ClassVar, Literal, NoReturn, TypeVar, overload
 
 from astroid import bases, util
-from astroid.const import IS_PYPY, PY38, PY38_PLUS, PY39_PLUS, PYPY_7_3_11_PLUS
+from astroid.const import IS_PYPY, PY38, PY39_PLUS, PYPY_7_3_11_PLUS
 from astroid.context import (
     CallContext,
     InferenceContext,
@@ -2000,7 +2000,7 @@ class ClassDef(
 
         Can also return 0 if the line can not be determined.
         """
-        if not PY38_PLUS or IS_PYPY and PY38 and not PYPY_7_3_11_PLUS:
+        if IS_PYPY and PY38 and not PYPY_7_3_11_PLUS:
             # For Python < 3.8 the lineno is the line number of the first decorator.
             # We want the class statement lineno. Similar to 'FunctionDef.fromlineno'
             # PyPy (3.8): Fixed with version v7.3.11

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -19,7 +19,7 @@ import unittest.mock
 import pytest
 
 from astroid import Instance, builder, nodes, test_utils, util
-from astroid.const import IS_PYPY, PY38, PY38_PLUS, PY39_PLUS, PYPY_7_3_11_PLUS
+from astroid.const import IS_PYPY, PY38, PY39_PLUS, PYPY_7_3_11_PLUS
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidSyntaxError,
@@ -62,10 +62,7 @@ class FromToLineNoTest(unittest.TestCase):
             else:
                 self.assertEqual(strarg.tolineno, 5)
         else:
-            if not PY38_PLUS:
-                self.assertEqual(strarg.fromlineno, 5)
-            else:
-                self.assertEqual(strarg.fromlineno, 4)
+            self.assertEqual(strarg.fromlineno, 4)
             self.assertEqual(strarg.tolineno, 5)
         namearg = callfunc.args[1]
         self.assertIsInstance(namearg, nodes.Name)
@@ -160,8 +157,8 @@ class FromToLineNoTest(unittest.TestCase):
 
         c = ast_module.body[2]
         assert isinstance(c, nodes.ClassDef)
-        if not PY38_PLUS or IS_PYPY and PY38 and not PYPY_7_3_11_PLUS:
-            # Not perfect, but best we can do for Python 3.7 and PyPy 3.8 (< v7.3.11).
+        if IS_PYPY and PY38 and not PYPY_7_3_11_PLUS:
+            # Not perfect, but best we can do for PyPy 3.8 (< v7.3.11).
             # Can't detect closing bracket on new line.
             assert c.fromlineno == 12
         else:
@@ -923,8 +920,7 @@ def test_module_build_dunder_file() -> None:
     assert module.path[0] == collections.__file__
 
 
-@pytest.mark.skipif(
-    PY38_PLUS,
+@pytest.mark.xfail(
     reason=(
         "The builtin ast module does not fail with a specific error "
         "for syntax error caused by invalid type comments."

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -31,7 +31,7 @@ from astroid import decorators as decoratorsmod
 from astroid.arguments import CallSite
 from astroid.bases import BoundMethod, Instance, UnboundMethod, UnionType
 from astroid.builder import AstroidBuilder, _extract_single_node, extract_node, parse
-from astroid.const import PY38_PLUS, PY39_PLUS, PY310_PLUS
+from astroid.const import PY39_PLUS, PY310_PLUS
 from astroid.context import CallContext, InferenceContext
 from astroid.exceptions import (
     AstroidTypeError,
@@ -959,8 +959,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual("module.C", should_be_c[0].qname())
         self.assertEqual("module.D", should_be_d[0].qname())
 
-    @pytest.mark.skipif(
-        PY38_PLUS,
+    @pytest.mark.xfail(
         reason="pathlib.Path cannot be inferred on Python 3.8",
     )
     def test_factory_methods_inside_binary_operation(self):
@@ -6588,7 +6587,6 @@ def test_custom_decorators_for_classmethod_and_staticmethods(code, obj, obj_type
     assert inferred.type == obj_type
 
 
-@pytest.mark.skipif(not PY38_PLUS, reason="Needs dataclasses available")
 @pytest.mark.skipif(
     PY39_PLUS,
     reason="Exact inference with dataclasses (replace function) in python3.9",

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -26,7 +26,7 @@ from astroid import (
     transforms,
     util,
 )
-from astroid.const import PY38_PLUS, PY310_PLUS, Context
+from astroid.const import PY310_PLUS, Context
 from astroid.context import InferenceContext
 from astroid.exceptions import (
     AstroidBuildingError,
@@ -48,13 +48,6 @@ from astroid.nodes.scoped_nodes import ClassDef, FunctionDef, GeneratorExp, Modu
 from . import resources
 
 abuilder = builder.AstroidBuilder()
-try:
-    import typed_ast  # pylint: disable=unused-import
-
-    HAS_TYPED_AST = True
-except ImportError:
-    # typed_ast merged in `ast` in Python 3.8
-    HAS_TYPED_AST = PY38_PLUS
 
 
 class AsStringTest(resources.SysPathSetup, unittest.TestCase):
@@ -641,9 +634,6 @@ class ConstNodeTest(unittest.TestCase):
     def test_unicode(self) -> None:
         self._test("a")
 
-    @pytest.mark.skipif(
-        not PY38_PLUS, reason="kind attribute for ast.Constant was added in 3.8"
-    )
     def test_str_kind(self):
         node = builder.extract_node(
             """
@@ -673,7 +663,6 @@ class NameNodeTest(unittest.TestCase):
             builder.parse(code)
 
 
-@pytest.mark.skipif(not PY38_PLUS, reason="needs assignment expressions")
 class TestNamedExprNode:
     """Tests for the NamedExpr node."""
 
@@ -1237,7 +1226,6 @@ def test_unknown() -> None:
     assert isinstance(nodes.Unknown().qname(), str)
 
 
-@pytest.mark.skipif(not HAS_TYPED_AST, reason="requires typed_ast")
 def test_type_comments_with() -> None:
     module = builder.parse(
         """
@@ -1254,7 +1242,6 @@ def test_type_comments_with() -> None:
     assert ignored_node.type_annotation is None
 
 
-@pytest.mark.skipif(not HAS_TYPED_AST, reason="requires typed_ast")
 def test_type_comments_for() -> None:
     module = builder.parse(
         """
@@ -1272,7 +1259,6 @@ def test_type_comments_for() -> None:
     assert ignored_node.type_annotation is None
 
 
-@pytest.mark.skipif(not HAS_TYPED_AST, reason="requires typed_ast")
 def test_type_coments_assign() -> None:
     module = builder.parse(
         """
@@ -1288,7 +1274,6 @@ def test_type_coments_assign() -> None:
     assert ignored_node.type_annotation is None
 
 
-@pytest.mark.skipif(not HAS_TYPED_AST, reason="requires typed_ast")
 def test_type_comments_invalid_expression() -> None:
     module = builder.parse(
         """
@@ -1301,7 +1286,6 @@ def test_type_comments_invalid_expression() -> None:
         assert node.type_annotation is None
 
 
-@pytest.mark.skipif(not HAS_TYPED_AST, reason="requires typed_ast")
 def test_type_comments_invalid_function_comments() -> None:
     module = builder.parse(
         """
@@ -1321,7 +1305,6 @@ def test_type_comments_invalid_function_comments() -> None:
         assert node.type_comment_args is None
 
 
-@pytest.mark.skipif(not HAS_TYPED_AST, reason="requires typed_ast")
 def test_type_comments_function() -> None:
     module = builder.parse(
         """
@@ -1352,7 +1335,6 @@ def test_type_comments_function() -> None:
         assert node.type_comment_returns.as_string() == expected_returns_string
 
 
-@pytest.mark.skipif(not HAS_TYPED_AST, reason="requires typed_ast")
 def test_type_comments_arguments() -> None:
     module = builder.parse(
         """
@@ -1392,9 +1374,6 @@ def test_type_comments_arguments() -> None:
             assert actual_arg.as_string() == expected_arg
 
 
-@pytest.mark.skipif(
-    not PY38_PLUS, reason="needs to be able to parse positional only arguments"
-)
 def test_type_comments_posonly_arguments() -> None:
     module = builder.parse(
         """
@@ -1430,7 +1409,6 @@ def test_type_comments_posonly_arguments() -> None:
                 assert actual_arg.as_string() == expected_arg
 
 
-@pytest.mark.skipif(not HAS_TYPED_AST, reason="requires typed_ast")
 def test_correct_function_type_comment_parent() -> None:
     data = """
         def f(a):
@@ -1512,7 +1490,6 @@ def test_f_string_correct_line_numbering() -> None:
     assert node.last_child().last_child().lineno == 5
 
 
-@pytest.mark.skipif(not PY38_PLUS, reason="needs assignment expressions")
 def test_assignment_expression() -> None:
     code = """
     if __(a := 1):
@@ -1535,7 +1512,6 @@ def test_assignment_expression() -> None:
     assert second.as_string() == "b := test"
 
 
-@pytest.mark.skipif(not PY38_PLUS, reason="needs assignment expressions")
 def test_assignment_expression_in_functiondef() -> None:
     code = """
     def function(param = (assignment := "walrus")):
@@ -1650,7 +1626,6 @@ def test_parse_fstring_debug_mode() -> None:
     assert node.as_string() == "f'3={3!r}'"
 
 
-@pytest.mark.skipif(not HAS_TYPED_AST, reason="requires typed_ast")
 def test_parse_type_comments_with_proper_parent() -> None:
     code = """
     class D: #@

--- a/tests/test_nodes_lineno.py
+++ b/tests/test_nodes_lineno.py
@@ -8,11 +8,11 @@ import pytest
 
 import astroid
 from astroid import builder, nodes
-from astroid.const import IS_PYPY, PY38, PY38_PLUS, PY39_PLUS, PY310_PLUS
+from astroid.const import IS_PYPY, PY38, PY39_PLUS, PY310_PLUS
 
 
 @pytest.mark.skipif(
-    PY38_PLUS and not (PY38 and IS_PYPY),
+    not (PY38 and IS_PYPY),
     reason="end_lineno and end_col_offset were added in PY38",
 )
 class TestEndLinenoNotSet:
@@ -43,7 +43,7 @@ class TestEndLinenoNotSet:
 
 
 @pytest.mark.skipif(
-    not PY38_PLUS or PY38 and IS_PYPY,
+    PY38 and IS_PYPY,
     reason="end_lineno and end_col_offset were added in PY38",
 )
 class TestLinenoColOffset:

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -13,7 +13,7 @@ import pytest
 
 import astroid
 from astroid import extract_node, nodes
-from astroid.const import PY38_PLUS, PY310_PLUS
+from astroid.const import PY310_PLUS
 from astroid.exceptions import InferenceError
 from astroid.manager import AstroidManager
 from astroid.util import Uninferable, UninferableBase
@@ -280,7 +280,6 @@ class ProtocolTests(unittest.TestCase):
         assert parsed.inferred() == [Uninferable]
 
 
-@pytest.mark.skipif(not PY38_PLUS, reason="needs assignment expressions")
 def test_named_expr_inference() -> None:
     code = """
     if (a := 2) == 2:

--- a/tests/test_regrtest.py
+++ b/tests/test_regrtest.py
@@ -11,7 +11,6 @@ import pytest
 
 from astroid import MANAGER, Instance, bases, nodes, parse, test_utils
 from astroid.builder import AstroidBuilder, _extract_single_node, extract_node
-from astroid.const import PY38_PLUS
 from astroid.context import InferenceContext
 from astroid.exceptions import InferenceError
 from astroid.raw_building import build_module
@@ -163,7 +162,6 @@ def test():
         base = next(result._proxied.bases[0].infer())
         self.assertEqual(base.name, "int")
 
-    @pytest.mark.skipif(not PY38_PLUS, reason="needs assignment expressions")
     def test_filter_stmts_nested_if(self) -> None:
         builder = AstroidBuilder()
         data = """

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -30,7 +30,7 @@ from astroid import (
     util,
 )
 from astroid.bases import BoundMethod, Generator, Instance, UnboundMethod
-from astroid.const import IS_PYPY, PY38, PY38_PLUS
+from astroid.const import IS_PYPY, PY38
 from astroid.exceptions import (
     AttributeInferenceError,
     DuplicateBasesError,
@@ -530,7 +530,6 @@ class FunctionNodeTest(ModuleLoader, unittest.TestCase):
             astroid["f"].argnames(), ["a", "b", "args", "c", "d", "kwargs"]
         )
 
-    @unittest.skipUnless(PY38_PLUS, "positional-only argument syntax")
     def test_positional_only_argnames(self) -> None:
         code = "def f(a, b, /, c=None, *args, d, **kwargs): pass"
         astroid = builder.parse(code, __name__)
@@ -1333,7 +1332,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         astroid = builder.parse(data)
         self.assertEqual(astroid["g1"].fromlineno, 4)
         self.assertEqual(astroid["g1"].tolineno, 5)
-        if not PY38_PLUS or PY38 and IS_PYPY:
+        if PY38 and IS_PYPY:
             self.assertEqual(astroid["g2"].fromlineno, 9)
         else:
             self.assertEqual(astroid["g2"].fromlineno, 10)
@@ -1943,7 +1942,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
             cls.mro()
 
     def test_mro_typing_extensions(self):
-        """Regression test for mro() inference on typing_extesnions.
+        """Regression test for mro() inference on typing_extensions.
 
         Regression reported in:
         https://github.com/pylint-dev/astroid/issues/1124
@@ -1973,9 +1972,6 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
             "Protocol",
             "object",
         ]
-        if not PY38_PLUS:
-            class_names.pop(-2)
-
         final_def = module.body[-1]
         self.assertEqual(class_names, sorted(i.name for i in final_def.mro()))
 
@@ -2799,7 +2795,6 @@ def test_slots_duplicate_bases_issue_1089() -> None:
 
 class TestFrameNodes:
     @staticmethod
-    @pytest.mark.skipif(not PY38_PLUS, reason="needs assignment expressions")
     def test_frame_node():
         """Test if the frame of FunctionDef, ClassDef and Module is correctly set."""
         module = builder.parse(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,10 +4,7 @@
 
 import unittest
 
-import pytest
-
 from astroid import Uninferable, builder, extract_node, nodes
-from astroid.const import PY38_PLUS
 from astroid.exceptions import InferenceError
 
 
@@ -33,7 +30,6 @@ class InferenceUtil(unittest.TestCase):
         self.assertEqual(nodes.are_exclusive(xass1, xnames[1]), False)
         self.assertEqual(nodes.are_exclusive(xass1, xnames[2]), False)
 
-    @pytest.mark.skipif(not PY38_PLUS, reason="needs assignment expressions")
     def test_not_exclusive_walrus_operator(self) -> None:
         node_if, node_body, node_or_else = extract_node(
             """
@@ -54,7 +50,6 @@ class InferenceUtil(unittest.TestCase):
         assert nodes.are_exclusive(node_if, node_or_else) is False
         assert nodes.are_exclusive(node_body, node_or_else) is True
 
-    @pytest.mark.skipif(not PY38_PLUS, reason="needs assignment expressions")
     def test_not_exclusive_walrus_multiple(self) -> None:
         node_if, body_1, body_2, or_else_1, or_else_2 = extract_node(
             """
@@ -84,7 +79,6 @@ class InferenceUtil(unittest.TestCase):
         assert nodes.are_exclusive(walruses[1], or_else_1) is False
         assert nodes.are_exclusive(walruses[1], or_else_2) is False
 
-    @pytest.mark.skipif(not PY38_PLUS, reason="needs assignment expressions")
     def test_not_exclusive_walrus_operator_nested(self) -> None:
         node_if, node_body, node_or_else = extract_node(
             """


### PR DESCRIPTION
## Description
Remove `PY38_PLUS` and previously deprecated `BUILTINS` constants.
Also remove `Load`, `Store`, and `Del` constants as those have already been aliases for `Context` enum.