### PR TITLE
Yield directly from `_explicit_inference` in `NodeNG.infer()`

### DIFF
--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -149,11 +149,12 @@ class NodeNG:
         if self._explicit_inference is not None:
             # explicit_inference is not bound, give it self explicitly
             try:
-                # pylint: disable=not-callable
-                results = list(self._explicit_inference(self, context, **kwargs))
-                if context is not None:
-                    context.nodes_inferred += len(results)
-                yield from results
+                if context is None:
+                    yield from self._explicit_inference(self, context, **kwargs)
+                    return
+                for result in self._explicit_inference(self, context, **kwargs):
+                    context.nodes_inferred += 1
+                    yield result
                 return
             except UseInferenceDefault:
                 pass


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
Given the number of calls to `infer()`, it's worth optimizing it. We shouldn't let incrementing a counter (`nodes_inferred`) interfere with yielding directly from a generator (or rechecking that things are not None).

## Benchmark
```python
from timeit import timeit
from astroid import extract_node
node = extract_node("""
if True:
    x = 1
else:
    x = 2
x #@""")
timeit(node.inferred, globals=globals())
```

On my M1 mac, Python 3.11.2:
**main** (aba2587):
3.59-3.62
**PR**:
3.57-3.59

Looks like a 1% improvement for this extremely simple benchmark; ideally we'd see more substantial results in more substantial cases.

Also profiled linting the astroid package, and although the entire time to lint the package fluctuated, the `tottime` spent in `infer()`(i.e. itself) reliably reduced from .559s to .499s.