### PR TITLE
Complete cache key for inference tip

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,13 @@ Release date: TBA
 
 * Reduce file system access in ``ast_from_file()``.
 
+* Fix incorrect cache keys for inference results, thereby correctly inferring types
+  for calls instantiating types dynamically.
+
+  Closes #1828
+  Closes pylint-dev/pylint#7464
+  Closes pylint-dev/pylint#8074
+
 * ``nodes.FunctionDef`` no longer inherits from ``nodes.Lambda``.
   This is a breaking change but considered a bug fix as the nodes did not share the same
   API and were not interchangeable.

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -152,6 +152,18 @@ class InferenceContext:
         yield
         self.path = path
 
+    def is_empty(self) -> bool:
+        return (
+            not self.path
+            and not self.nodes_inferred
+            and not self.callcontext
+            and not self.boundnode
+            and not self.lookupname
+            and not self.callcontext
+            and not self.extra_context
+            and not self.constraints
+        )
+
     def __str__(self) -> str:
         state = (
             f"{field}={pprint.pformat(getattr(self, field), width=80 - len(field))}"

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -152,31 +152,6 @@ class InferenceContext:
         yield
         self.path = path
 
-    def __hash__(self) -> int:
-        """Deliberately omit nodes_inferred and constraints.
-
-        TODO: determine the performance upside of omitting more."""
-        return hash(
-            (
-                ((id(node), name) for node, name in self.path),
-                self.callcontext,
-                self.boundnode,
-                self.lookupname,
-                tuple(self.extra_context.items()),
-            )
-        )
-
-    def __eq__(self, other) -> bool:
-        return (
-            self.path == other.path
-            and self.nodes_inferred == other.nodes_inferred
-            and self.callcontext == other.callcontext
-            and self.boundnode == other.boundnode
-            and self.lookupname == other.lookupname
-            and self.extra_context == other.extra_context
-            and self.constraints == other.constraints
-        )
-
     def __str__(self) -> str:
         state = (
             f"{field}={pprint.pformat(getattr(self, field), width=80 - len(field))}"

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -154,7 +154,7 @@ class InferenceContext:
 
     def __hash__(self) -> int:
         """Deliberately omit nodes_inferred and constraints.
-        
+
         TODO: determine the performance upside of omitting more."""
         return hash(
             (

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -162,7 +162,7 @@ class InferenceContext:
                 self.callcontext,
                 self.boundnode,
                 self.lookupname,
-                tuple(**self.extra_context),
+                tuple(self.extra_context.items()),
             )
         )
 

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -152,16 +152,29 @@ class InferenceContext:
         yield
         self.path = path
 
-    def is_empty(self) -> bool:
+    def __hash__(self) -> int:
+        """Deliberately omit nodes_inferred and constraints.
+        
+        TODO: determine the performance upside of omitting more."""
+        return hash(
+            (
+                ((id(node), name) for node, name in self.path),
+                self.callcontext,
+                self.boundnode,
+                self.lookupname,
+                tuple(**self.extra_context),
+            )
+        )
+
+    def __eq__(self, other) -> bool:
         return (
-            not self.path
-            and not self.nodes_inferred
-            and not self.callcontext
-            and not self.boundnode
-            and not self.lookupname
-            and not self.callcontext
-            and not self.extra_context
-            and not self.constraints
+            self.path == other.path
+            and self.nodes_inferred == other.nodes_inferred
+            and self.callcontext == other.callcontext
+            and self.boundnode == other.boundnode
+            and self.lookupname == other.lookupname
+            and self.extra_context == other.extra_context
+            and self.constraints == other.constraints
         )
 
     def __str__(self) -> str:

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -35,7 +35,7 @@ def _inference_tip_cached(
     def inner(*args: _P.args, **kwargs: _P.kwargs) -> Iterator[InferenceResult]:
         node = args[0]
         context = args[1]
-        if context.is_empty():
+        if context is not None and context.is_empty():
             # Fresh, empty contexts will defeat the cache.
             context = None
         try:

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -35,6 +35,9 @@ def _inference_tip_cached(
     def inner(*args: _P.args, **kwargs: _P.kwargs) -> Iterator[InferenceResult]:
         node = args[0]
         context = args[1]
+        if context.is_empty():
+            # Fresh, empty contexts will defeat the cache.
+            context = None
         try:
             result = _cache[func, node, context]
             # If through recursion we end up trying to infer the same

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -41,11 +41,15 @@ def _inference_tip_cached(
         if partial_cache_key in _CURRENTLY_INFERRING:
             # If through recursion we end up trying to infer the same
             # func + node we raise here.
-            raise UseInferenceDefault()
+            raise UseInferenceDefault
         try:
             return _cache[func, node, context]
         except KeyError:
             # Recursion guard with a partial cache key.
+            # Using the full key causes a recursion error on PyPy.
+            # It's a pragmatic compromise to avoid so much recursive inference
+            # with slightly different contexts while still passing the simple
+            # test cases included with this commit.
             _CURRENTLY_INFERRING.add(partial_cache_key)
             result = _cache[func, node, context] = list(func(*args, **kwargs))
             assert result

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -52,7 +52,6 @@ def _inference_tip_cached(
             # test cases included with this commit.
             _CURRENTLY_INFERRING.add(partial_cache_key)
             result = _cache[func, node, context] = list(func(*args, **kwargs))
-            assert result
             # Remove recursion guard.
             _CURRENTLY_INFERRING.remove(partial_cache_key)
 

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -31,15 +31,16 @@ def _inference_tip_cached(
 
     def inner(*args: _P.args, **kwargs: _P.kwargs) -> Iterator[InferenceResult]:
         node = args[0]
+        context = args[1]
         try:
-            result = _cache[func, node]
+            result = _cache[func, node, context]
             # If through recursion we end up trying to infer the same
             # func + node we raise here.
             if result is None:
                 raise UseInferenceDefault()
         except KeyError:
-            _cache[func, node] = None
-            result = _cache[func, node] = list(func(*args, **kwargs))
+            _cache[func, node, context] = None
+            result = _cache[func, node, context] = list(func(*args, **kwargs))
             assert result
         return iter(result)
 

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -22,7 +22,7 @@ else:
 _P = ParamSpec("_P")
 
 _cache: dict[
-    tuple[InferFn, NodeNG, InferenceContext | None], list[InferenceResult] | None
+    tuple[InferFn, NodeNG, InferenceContext | None], list[InferenceResult]
 ] = {}
 
 _CURRENTLY_INFERRING: set[tuple[InferFn, NodeNG]] = set()

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -35,9 +35,6 @@ def _inference_tip_cached(
     def inner(*args: _P.args, **kwargs: _P.kwargs) -> Iterator[InferenceResult]:
         node = args[0]
         context = args[1]
-        if context is not None and context.is_empty():
-            # Fresh, empty contexts will defeat the cache.
-            context = None
         try:
             result = _cache[func, node, context]
             # If through recursion we end up trying to infer the same

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -10,13 +10,16 @@ from collections.abc import Callable, Iterator
 
 from typing_extensions import ParamSpec
 
+from astroid.context import InferenceContext
 from astroid.exceptions import InferenceOverwriteError, UseInferenceDefault
 from astroid.nodes import NodeNG
 from astroid.typing import InferenceResult, InferFn
 
 _P = ParamSpec("_P")
 
-_cache: dict[tuple[InferFn, NodeNG], list[InferenceResult] | None] = {}
+_cache: dict[
+    tuple[InferFn, NodeNG, InferenceContext | None], list[InferenceResult] | None
+] = {}
 
 
 def clear_inference_tip_cache() -> None:

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -930,13 +930,7 @@ class TypingBrain(unittest.TestCase):
         assert inferred.value == 42
 
     def test_typing_cast_multiple_inference_calls(self) -> None:
-        """Inference of an outer function should not store the result for cast.
-
-        https://github.com/pylint-dev/pylint/issues/8074
-
-        Possible solution caused RecursionErrors with Python 3.8 and CPython + PyPy.
-        https://github.com/pylint-dev/astroid/pull/1982
-        """
+        """Inference of an outer function should not store the result for cast."""
         ast_nodes = builder.extract_node(
             """
         from typing import TypeVar, cast
@@ -954,7 +948,7 @@ class TypingBrain(unittest.TestCase):
 
         i1 = next(ast_nodes[1].infer())
         assert isinstance(i1, nodes.Const)
-        assert i1.value == 2  # should be "Hello"!
+        assert i1.value == "Hello"
 
 
 class ReBrainTest(unittest.TestCase):

--- a/tests/test_regrtest.py
+++ b/tests/test_regrtest.py
@@ -336,6 +336,27 @@ def test(val):
         assert isinstance(inferred, Instance)
         assert inferred.qname() == ".A"
 
+    def test_inference_context_consideration(self) -> None:
+        """https://github.com/PyCQA/astroid/issues/1828"""
+        code = """
+        class Base:
+            def return_type(self):
+                return type(self)()
+        class A(Base):
+            def method(self):
+                return self.return_type()
+        class B(Base):
+            def method(self):
+                return self.return_type()
+        A().method() #@
+        B().method() #@
+        """
+        node1, node2 = extract_node(code)
+        inferred1 = next(node1.infer())
+        assert inferred1.qname() == ".A"
+        inferred2 = next(node2.infer())
+        assert inferred2.qname() == ".B"
+
 
 class Whatever:
     a = property(lambda x: x, lambda x: x)  # type: ignore[misc]

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -1771,9 +1771,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
                 "FinalClass",
                 "ClassB",
                 "MixinB",
-                # We don't recognize what 'cls' is at time of .format() call, only
-                # what it is at the end.
-                # "strMixin",
+                "strMixin",
                 "ClassA",
                 "MixinA",
                 "intMixin",


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
As identified by @kriek in #1828, part of the cache key (context) was missing.

Alternative to #1832, which removes the cache, this just adds the missing part of the key.

Closes #1828
Closes pylint-dev/pylint#7464
Closes pylint-dev/pylint#8074

Refs #1982 (reverted)

## Pylint test
The following diff in pylint will (almost) pass the test suite with this change. ~PR shortly.~ PR once I can debug the remaining failures with `deprecated_typing_alias`.

```diff
diff --git a/pylint/checkers/design_analysis.py b/pylint/checkers/design_analysis.py
index 701615d89..d605aed76 100644
--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -166,6 +166,8 @@ STDLIB_CLASSES_IGNORE_ANCESTOR = frozenset(
         "typing.AsyncContextManager",
         "typing.Hashable",
         "typing.Sized",
+        TYPING_NAMEDTUPLE,
+        TYPING_TYPEDDICT,
     )
 )
```