### PR TITLE
Fix urllib3 tests following the release of v2.0.0

### DIFF
--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -9,5 +9,5 @@ python-dateutil
 PyQt6
 regex
 six
-urllib3
+urllib3>1,<2
 typing_extensions>=4.4.0

--- a/tests/test_modutils.py
+++ b/tests/test_modutils.py
@@ -28,9 +28,9 @@ from . import resources
 try:
     import urllib3  # type: ignore[import]  # pylint: disable=unused-import
 
-    HAS_URLLIB3 = True
+    HAS_URLLIB3_V1 = urllib3.__version__.startswith("1")
 except ImportError:
-    HAS_URLLIB3 = False
+    HAS_URLLIB3_V1 = False
 
 
 def _get_file_from_object(obj) -> str:
@@ -547,8 +547,9 @@ class ExtensionPackageWhitelistTest(unittest.TestCase):
         )
 
 
-@pytest.mark.skipif(not HAS_URLLIB3, reason="This test requires urllib3.")
+@pytest.mark.skipif(not HAS_URLLIB3_V1, reason="This test requires urllib3 < 2.")
 def test_file_info_from_modpath__SixMetaPathImporter() -> None:
+    """Six is not backported anymore in urllib3 v2.0.0+"""
     assert modutils.file_info_from_modpath(["urllib3.packages.six.moves.http_client"])
 
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Found this while trying to run the full test suite after installing with ``pip3 install -r requirements_full.txt``. It seems astroid is never tested with all requirements installed in CI, not even on a single interpreter.
