### PR TITLE
Improve typing of inference functions

### DIFF
--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -254,7 +254,6 @@ def infer_name(
     return bases._infer_stmts(stmts, context, frame)
 
 
-# pylint: disable=no-value-for-parameter
 # The order of the decorators here is important
 # See https://github.com/pylint-dev/astroid/commit/0a8a75db30da060a24922e05048bc270230f5
 nodes.Name._infer = decorators.raise_if_nothing_inferred(

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -6,18 +6,21 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable, Iterator
+from typing import cast
 
 from astroid.context import InferenceContext
 from astroid.exceptions import InferenceOverwriteError, UseInferenceDefault
 from astroid.nodes import NodeNG
-from astroid.typing import (
-    _P,
-    InferenceResult,
-    InferFn,
-    InferFnExplicit,
-    InferFnTransform,
-)
+from astroid.typing import InferenceResult, InferFn, InferFnExplicit, InferFnTransform
+
+if sys.version_info >= (3, 11):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
+
+_P = ParamSpec("_P")
 
 _cache: dict[
     tuple[InferFn, NodeNG, InferenceContext | None], list[InferenceResult]
@@ -39,8 +42,8 @@ def _inference_tip_cached(
     def inner(
         *args: _P.args, **kwargs: _P.kwargs
     ) -> Iterator[InferenceResult] | list[InferenceResult]:
-        node: NodeNG = args[0]
-        context: InferenceContext | None = args[1]
+        node = cast(NodeNG, args[0])
+        context = cast(InferenceContext | None, args[1])
 
         partial_cache_key = (func, node)
         if partial_cache_key in _CURRENTLY_INFERRING:

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
+from typing import Any
 
 from astroid.context import InferenceContext
 from astroid.exceptions import InferenceOverwriteError, UseInferenceDefault
@@ -31,7 +32,7 @@ def _inference_tip_cached(
     """Cache decorator used for inference tips."""
 
     def inner(
-        node: NodeNG, context: InferenceContext | None
+        node: NodeNG, context: InferenceContext | None, **kwargs: Any,
     ) -> Iterator[InferenceResult] | list[InferenceResult]:
         partial_cache_key = (func, node)
         if partial_cache_key in _CURRENTLY_INFERRING:
@@ -47,7 +48,7 @@ def _inference_tip_cached(
             # with slightly different contexts while still passing the simple
             # test cases included with this commit.
             _CURRENTLY_INFERRING.add(partial_cache_key)
-            result = _cache[func, node, context] = list(func(node, context))
+            result = _cache[func, node, context] = list(func(node, context, **kwargs))
             # Remove recursion guard.
             _CURRENTLY_INFERRING.remove(partial_cache_key)
 

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -40,11 +40,8 @@ def _inference_tip_cached(
     def inner(
         *args: _P.args, **kwargs: _P.kwargs
     ) -> Iterator[InferenceResult] | list[InferenceResult]:
-        node = args[0]
-        context = args[1]
-        if TYPE_CHECKING:
-            assert isinstance(node, NodeNG)
-            assert context is None or isinstance(context, InferenceContext)
+        node: NodeNG = args[0]
+        context: InferenceContext | None = args[1]
 
         partial_cache_key = (func, node)
         if partial_cache_key in _CURRENTLY_INFERRING:

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
-from typing import TYPE_CHECKING
 
 from astroid.context import InferenceContext
 from astroid.exceptions import InferenceOverwriteError, UseInferenceDefault

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Callable, Iterator
-from typing import cast
+from typing import Optional, cast
 
 from astroid.context import InferenceContext
 from astroid.exceptions import InferenceOverwriteError, UseInferenceDefault
@@ -43,7 +43,7 @@ def _inference_tip_cached(
         *args: _P.args, **kwargs: _P.kwargs
     ) -> Iterator[InferenceResult] | list[InferenceResult]:
         node = cast(NodeNG, args[0])
-        context = cast(InferenceContext | None, args[1])
+        context = cast(Optional[InferenceContext], args[1])
 
         partial_cache_key = (func, node)
         if partial_cache_key in _CURRENTLY_INFERRING:

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -26,9 +26,7 @@ def clear_inference_tip_cache() -> None:
     _cache.clear()
 
 
-def _inference_tip_cached(
-    func: Callable[[NodeNG, InferenceContext | None], Iterator[InferenceResult]],
-) -> InferFnExplicit:
+def _inference_tip_cached(func: InferFn) -> InferFnExplicit:
     """Cache decorator used for inference tips."""
 
     def inner(

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -32,7 +32,9 @@ def _inference_tip_cached(
     """Cache decorator used for inference tips."""
 
     def inner(
-        node: NodeNG, context: InferenceContext | None, **kwargs: Any,
+        node: NodeNG,
+        context: InferenceContext | None,
+        **kwargs: Any,
     ) -> Iterator[InferenceResult] | list[InferenceResult]:
         partial_cache_key = (func, node)
         if partial_cache_key in _CURRENTLY_INFERRING:

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -55,11 +55,11 @@ def _inference_tip_cached(func: InferFn[_NodesT]) -> InferFn[_NodesT]:
             # with slightly different contexts while still passing the simple
             # test cases included with this commit.
             _CURRENTLY_INFERRING.add(partial_cache_key)
-            _cache[func, node, context] = list(func(node, context, **kwargs))
+            result = _cache[func, node, context] = list(func(node, context, **kwargs))
             # Remove recursion guard.
             _CURRENTLY_INFERRING.remove(partial_cache_key)
 
-        yield from _cache[func, node, context]
+        yield from result
 
     return inner
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -144,9 +144,17 @@ class NodeNG:
             # explicit_inference is not bound, give it self explicitly
             try:
                 if context is None:
-                    yield from self._explicit_inference(self, context, **kwargs)
+                    yield from self._explicit_inference(
+                        self,  # type: ignore[arg-type]
+                        context,
+                        **kwargs,
+                    )
                     return
-                for result in self._explicit_inference(self, context, **kwargs):
+                for result in self._explicit_inference(
+                    self,  # type: ignore[arg-type]
+                    context,
+                    **kwargs,
+                ):
                     context.nodes_inferred += 1
                     yield result
                 return

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import pprint
+import sys
 import warnings
 from collections.abc import Generator, Iterator
 from functools import cached_property
@@ -35,7 +36,13 @@ from astroid.manager import AstroidManager
 from astroid.nodes.as_string import AsStringVisitor
 from astroid.nodes.const import OP_PRECEDENCE
 from astroid.nodes.utils import Position
-from astroid.typing import InferenceErrorInfo, InferenceResult, InferFnExplicit
+from astroid.typing import InferenceErrorInfo, InferenceResult, InferFn
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 
 if TYPE_CHECKING:
     from astroid import nodes
@@ -80,7 +87,7 @@ class NodeNG:
     _other_other_fields: ClassVar[tuple[str, ...]] = ()
     """Attributes that contain AST-dependent fields."""
     # instance specific inference function infer(node, context)
-    _explicit_inference: InferFnExplicit | None = None
+    _explicit_inference: InferFn[Self] | None = None
 
     def __init__(
         self,

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -35,7 +35,7 @@ from astroid.manager import AstroidManager
 from astroid.nodes.as_string import AsStringVisitor
 from astroid.nodes.const import OP_PRECEDENCE
 from astroid.nodes.utils import Position
-from astroid.typing import InferenceErrorInfo, InferenceResult, InferFn
+from astroid.typing import InferenceErrorInfo, InferenceResult, InferFnExplicit
 
 if TYPE_CHECKING:
     from astroid import nodes
@@ -80,7 +80,7 @@ class NodeNG:
     _other_other_fields: ClassVar[tuple[str, ...]] = ()
     """Attributes that contain AST-dependent fields."""
     # instance specific inference function infer(node, context)
-    _explicit_inference: InferFn | None = None
+    _explicit_inference: InferFnExplicit | None = None
 
     def __init__(
         self,

--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar, Union, cast, overload
 
 from astroid.context import _invalidate_cache
-from astroid.typing import SuccessfulInferenceResult
+from astroid.typing import SuccessfulInferenceResult, TransformFn
 
 if TYPE_CHECKING:
     from astroid import nodes
@@ -17,9 +17,6 @@ if TYPE_CHECKING:
     _SuccessfulInferenceResultT = TypeVar(
         "_SuccessfulInferenceResultT", bound=SuccessfulInferenceResult
     )
-    _Transform = Callable[
-        [_SuccessfulInferenceResultT], Optional[SuccessfulInferenceResult]
-    ]
     _Predicate = Optional[Callable[[_SuccessfulInferenceResultT], bool]]
 
 _Vistables = Union[
@@ -52,7 +49,7 @@ class TransformVisitor:
             type[SuccessfulInferenceResult],
             list[
                 tuple[
-                    _Transform[SuccessfulInferenceResult],
+                    TransformFn[SuccessfulInferenceResult],
                     _Predicate[SuccessfulInferenceResult],
                 ]
             ],
@@ -123,7 +120,7 @@ class TransformVisitor:
     def register_transform(
         self,
         node_class: type[_SuccessfulInferenceResultT],
-        transform: _Transform[_SuccessfulInferenceResultT],
+        transform: TransformFn[_SuccessfulInferenceResultT],
         predicate: _Predicate[_SuccessfulInferenceResultT] | None = None,
     ) -> None:
         """Register `transform(node)` function to be applied on the given node.
@@ -139,7 +136,7 @@ class TransformVisitor:
     def unregister_transform(
         self,
         node_class: type[_SuccessfulInferenceResultT],
-        transform: _Transform[_SuccessfulInferenceResultT],
+        transform: TransformFn[_SuccessfulInferenceResultT],
         predicate: _Predicate[_SuccessfulInferenceResultT] | None = None,
     ) -> None:
         """Unregister the given transform."""

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -9,6 +9,7 @@ from typing import (
     Callable,
     Generator,
     Iterator,
+    List,
     Optional,
     TypedDict,
     TypeVar,
@@ -77,6 +78,6 @@ InferBinaryOp = Callable[
 InferFn = Callable[[_NodesT, Optional["InferenceContext"]], Iterator[InferenceResult]]
 InferFnExplicit = Callable[
     [_NodesT, Optional["InferenceContext"]],
-    Union[Iterator[InferenceResult], list[InferenceResult]],
+    Union[Iterator[InferenceResult], List[InferenceResult]],
 ]
 InferFnTransform = Callable[[_NodesT, InferFn], _NodesT]

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -85,7 +85,7 @@ class InferFn(Protocol, Generic[_SuccessfulInferenceResultT_contra]):
         context: InferenceContext | None = None,
         **kwargs: Any,
     ) -> Generator[InferenceResult, None, None]:
-        ...
+        ...  # pragma: no cover
 
 
 class TransformFn(Protocol, Generic[_SuccessfulInferenceResultT]):
@@ -94,4 +94,4 @@ class TransformFn(Protocol, Generic[_SuccessfulInferenceResultT]):
         node: _SuccessfulInferenceResultT,
         infer_function: InferFn[_SuccessfulInferenceResultT] = ...,
     ) -> _SuccessfulInferenceResultT | None:
-        ...
+        ...  # pragma: no cover

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -88,16 +88,6 @@ class InferFn(Protocol, Generic[_SuccessfulInferenceResultT_contra]):
         ...
 
 
-class SuccessfulInferFn(Protocol, Generic[_SuccessfulInferenceResultT_contra]):
-    def __call__(
-        self,
-        node: _SuccessfulInferenceResultT_contra,
-        context: InferenceContext | None = None,
-        **kwargs: Any,
-    ) -> Generator[SuccessfulInferenceResult, None, None]:
-        ...
-
-
 class TransformFn(Protocol, Generic[_SuccessfulInferenceResultT]):
     def __call__(
         self,

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -80,6 +80,5 @@ InferBinaryOp = Callable[
 ]
 
 InferFn = Callable[..., Iterator[InferenceResult]]
-# pylint: disable-next=unsupported-binary-operation
-InferFnExplicit = Callable[_P, Iterator[InferenceResult] | list[InferenceResult]]
+InferFnExplicit = Callable[_P, Union[Iterator[InferenceResult], list[InferenceResult]]]
 InferFnTransform = Callable[[_NodesT, InferFn], _NodesT]

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from astroid.context import InferenceContext
     from astroid.interpreter._import import spec
 
+
 _NodesT = TypeVar("_NodesT", bound="nodes.NodeNG")
 
 

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-import sys
 from typing import (
     TYPE_CHECKING,
     Callable,
     Generator,
     Iterator,
+    Optional,
     TypedDict,
     TypeVar,
     Union,
@@ -20,12 +20,6 @@ if TYPE_CHECKING:
     from astroid.context import InferenceContext
     from astroid.interpreter._import import spec
 
-if sys.version_info >= (3, 11):
-    from typing import ParamSpec
-else:
-    from typing_extensions import ParamSpec
-
-_P = ParamSpec("_P")
 _NodesT = TypeVar("_NodesT", bound="nodes.NodeNG")
 
 
@@ -79,6 +73,9 @@ InferBinaryOp = Callable[
     Generator[InferenceResult, None, None],
 ]
 
-InferFn = Callable[..., Iterator[InferenceResult]]
-InferFnExplicit = Callable[_P, Union[Iterator[InferenceResult], list[InferenceResult]]]
+InferFn = Callable[[_NodesT, Optional["InferenceContext"]], Iterator[InferenceResult]]
+InferFnExplicit = Callable[
+    [_NodesT, Optional["InferenceContext"]],
+    Union[Iterator[InferenceResult], list[InferenceResult]],
+]
 InferFnTransform = Callable[[_NodesT, InferFn], _NodesT]

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -4,14 +4,28 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Generator, TypedDict, TypeVar, Union
+import sys
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Generator,
+    Iterator,
+    TypedDict,
+    TypeVar,
+    Union,
+)
 
 if TYPE_CHECKING:
     from astroid import bases, exceptions, nodes, transforms, util
     from astroid.context import InferenceContext
     from astroid.interpreter._import import spec
 
+if sys.version_info >= (3, 11):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
 
+_P = ParamSpec("_P")
 _NodesT = TypeVar("_NodesT", bound="nodes.NodeNG")
 
 
@@ -22,9 +36,6 @@ class InferenceErrorInfo(TypedDict):
 
     node: nodes.NodeNG
     context: InferenceContext | None
-
-
-InferFn = Callable[..., Any]
 
 
 class AstroidManagerBrain(TypedDict):
@@ -67,3 +78,8 @@ InferBinaryOp = Callable[
     ],
     Generator[InferenceResult, None, None],
 ]
+
+InferFn = Callable[..., Iterator[InferenceResult]]
+# pylint: disable-next=unsupported-binary-operation
+InferFnExplicit = Callable[_P, Iterator[InferenceResult] | list[InferenceResult]]
+InferFnTransform = Callable[[_NodesT, InferFn], _NodesT]


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |


## Description
Follow-up to #2158.

Before, this was quite vague:
```python
InferFn = Callable[..., Any]
```