### PR TITLE
Create ``infer_object``

### DIFF
--- a/tests/test_regrtest.py
+++ b/tests/test_regrtest.py
@@ -444,7 +444,7 @@ def test_max_inferred_for_complicated_class_hierarchy() -> None:
 
 
 @mock.patch(
-    "astroid.nodes.ImportFrom._infer",
+    "astroid.inference.infer_import_from",
     side_effect=RecursionError,
 )
 def test_recursion_during_inference(mocked) -> None:


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description

Perhaps I should have created an issue for this, but:

This is my proposal to remove the import hell from `astroid` and the method assignment we do for the `inference.py` file.
Instead of calling `node.infer()` we would now just call `infer_object(node)`.
This decouples the nodes and their meta-information from the actual `astroid` magic that needs and uses that information. Next steps would be to change calls in the `astroid` code base and remove `_infer` everywhere.
The migration in `pylint` seems rather straightforward as there are not that many calls to `infer()` actually.

I haven't made a news fragment as I'd like to do this after we have finalised the internal transition.

Let me know what you think guys!