### PR TITLE
Remove all references to ``_infer``

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3932,10 +3932,6 @@ class Unknown(_base_nodes.AssignTypeNode):
     def qname(self) -> Literal["Unknown"]:
         return "Unknown"
 
-    def _infer(self, context: InferenceContext | None = None, **kwargs):
-        """Inference on an Unknown node immediately terminates."""
-        yield util.Uninferable
-
 
 class EvaluatedObject(NodeNG):
     """Contains an object that has already been inferred
@@ -3962,11 +3958,6 @@ class EvaluatedObject(NodeNG):
             end_lineno=self.original.end_lineno,
             end_col_offset=self.original.end_col_offset,
         )
-
-    def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
-    ) -> Generator[NodeNG | util.UninferableBase, None, None]:
-        yield self.value
 
 
 # Pattern matching #######################################################

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -26,14 +26,13 @@ from astroid import util
 from astroid.context import InferenceContext
 from astroid.exceptions import (
     AstroidError,
-    InferenceError,
     ParentMissingError,
     StatementMissing,
 )
 from astroid.nodes.as_string import AsStringVisitor
 from astroid.nodes.const import OP_PRECEDENCE
 from astroid.nodes.utils import Position
-from astroid.typing import InferenceErrorInfo, InferenceResult, InferFn
+from astroid.typing import InferenceResult, InferFn
 
 if TYPE_CHECKING:
     from astroid import nodes
@@ -536,15 +535,6 @@ class NodeNG:
     def _infer_name(self, frame, name):
         # overridden for ImportFrom, Import, Global, TryExcept, TryStar and Arguments
         pass
-
-    def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
-    ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
-        """We don't know how to resolve a statement by default."""
-        # this method is overridden by most concrete classes
-        raise InferenceError(
-            "No inference function for {node!r}.", node=self, context=context
-        )
 
     def inferred(self):
         """Get a list of the inferred values.

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -13,9 +13,9 @@ leads to an inferred FrozenSet:
 
 from __future__ import annotations
 
-from collections.abc import Generator, Iterator
+from collections.abc import Iterator
 from functools import cached_property
-from typing import Any, Literal, NoReturn, TypeVar
+from typing import Literal, NoReturn, TypeVar
 
 from astroid import bases, decorators, util
 from astroid.context import InferenceContext
@@ -38,9 +38,6 @@ class FrozenSet(node_classes.BaseContainer):
 
     def pytype(self) -> Literal["builtins.frozenset"]:
         return "builtins.frozenset"
-
-    def _infer(self, context: InferenceContext | None = None, **kwargs: Any):
-        yield self
 
     @cached_property
     def _proxied(self):  # pylint: disable=method-hidden
@@ -83,9 +80,6 @@ class Super(node_classes.NodeNG):
             end_lineno=scope.end_lineno,
             end_col_offset=scope.end_col_offset,
         )
-
-    def _infer(self, context: InferenceContext | None = None, **kwargs: Any):
-        yield self
 
     def super_mro(self):
         """Get the MRO which will be used to lookup attributes in this super."""
@@ -366,8 +360,3 @@ class Property(scoped_nodes.FunctionDef):
         context: InferenceContext | None = None,
     ) -> NoReturn:
         raise InferenceError("Properties are not callable")
-
-    def _infer(
-        self: _T, context: InferenceContext | None = None, **kwargs: Any
-    ) -> Generator[_T, None, None]:
-        yield self

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -40,6 +40,7 @@ from astroid.exceptions import (
     NotFoundError,
 )
 from astroid.inference import infer_end as inference_infer_end
+from astroid.inference import infer_object
 from astroid.objects import ExceptionInstance
 
 from . import resources
@@ -7022,7 +7023,7 @@ def test_recursion_on_inference_tip() -> None:
 def test_function_def_cached_generator() -> None:
     """Regression test for https://github.com/pylint-dev/astroid/issues/817."""
     funcdef: nodes.FunctionDef = extract_node("def func(): pass")
-    next(funcdef._infer())
+    next(infer_object(funcdef))
 
 
 class TestOldStyleStringFormatting:

--- a/tests/test_regrtest.py
+++ b/tests/test_regrtest.py
@@ -444,7 +444,7 @@ def test_max_inferred_for_complicated_class_hierarchy() -> None:
 
 
 @mock.patch(
-    "astroid.nodes.ImportFrom._infer",
+    "astroid.inference.infer_import_from",
     side_effect=RecursionError,
 )
 def test_recursion_during_inference(mocked) -> None:


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Blocked by https://github.com/pylint-dev/astroid/pull/2167.

This would be the next step towards the new way of doing `inference`. We no longer have any internal references to `_infer()` or assignments to it.
Since this is private API we don't need a news entry.

Next step would be to start transitioning some of the calls to `infer()` to be `infer_object`.



## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
