### PR TITLE
Improve performance of `looks_like_numpy_member()`

### DIFF
--- a/astroid/brain/brain_numpy_core_function_base.py
+++ b/astroid/brain/brain_numpy_core_function_base.py
@@ -6,7 +6,10 @@
 
 import functools
 
-from astroid.brain.brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
+from astroid.brain.brain_numpy_utils import (
+    infer_numpy_member,
+    attribute_looks_like_numpy_member,
+)
 from astroid.inference_tip import inference_tip
 from astroid.manager import AstroidManager
 from astroid.nodes.node_classes import Attribute
@@ -25,5 +28,5 @@ for func_name, func_src in METHODS_TO_BE_INFERRED.items():
     AstroidManager().register_transform(
         Attribute,
         inference_tip(inference_function),
-        functools.partial(looks_like_numpy_member, func_name),
+        functools.partial(attribute_looks_like_numpy_member, func_name),
     )

--- a/astroid/brain/brain_numpy_core_function_base.py
+++ b/astroid/brain/brain_numpy_core_function_base.py
@@ -7,8 +7,8 @@
 import functools
 
 from astroid.brain.brain_numpy_utils import (
-    infer_numpy_member,
     attribute_looks_like_numpy_member,
+    infer_numpy_member,
 )
 from astroid.inference_tip import inference_tip
 from astroid.manager import AstroidManager

--- a/astroid/brain/brain_numpy_core_multiarray.py
+++ b/astroid/brain/brain_numpy_core_multiarray.py
@@ -7,8 +7,8 @@
 import functools
 
 from astroid.brain.brain_numpy_utils import (
-    infer_numpy_member,
     attribute_looks_like_numpy_member,
+    infer_numpy_member,
     name_looks_like_numpy_member,
 )
 from astroid.brain.helpers import register_module_extender

--- a/astroid/brain/brain_numpy_core_multiarray.py
+++ b/astroid/brain/brain_numpy_core_multiarray.py
@@ -6,7 +6,11 @@
 
 import functools
 
-from astroid.brain.brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
+from astroid.brain.brain_numpy_utils import (
+    infer_numpy_member,
+    attribute_looks_like_numpy_member,
+    name_looks_like_numpy_member,
+)
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.inference_tip import inference_tip
@@ -91,10 +95,10 @@ for method_name, function_src in METHODS_TO_BE_INFERRED.items():
     AstroidManager().register_transform(
         Attribute,
         inference_tip(inference_function),
-        functools.partial(looks_like_numpy_member, method_name),
+        functools.partial(attribute_looks_like_numpy_member, method_name),
     )
     AstroidManager().register_transform(
         Name,
         inference_tip(inference_function),
-        functools.partial(looks_like_numpy_member, method_name),
+        functools.partial(name_looks_like_numpy_member, method_name),
     )

--- a/astroid/brain/brain_numpy_core_numeric.py
+++ b/astroid/brain/brain_numpy_core_numeric.py
@@ -6,7 +6,10 @@
 
 import functools
 
-from astroid.brain.brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
+from astroid.brain.brain_numpy_utils import (
+    infer_numpy_member,
+    attribute_looks_like_numpy_member,
+)
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.inference_tip import inference_tip
@@ -42,5 +45,5 @@ for method_name, function_src in METHODS_TO_BE_INFERRED.items():
     AstroidManager().register_transform(
         Attribute,
         inference_tip(inference_function),
-        functools.partial(looks_like_numpy_member, method_name),
+        functools.partial(attribute_looks_like_numpy_member, method_name),
     )

--- a/astroid/brain/brain_numpy_core_numeric.py
+++ b/astroid/brain/brain_numpy_core_numeric.py
@@ -7,8 +7,8 @@
 import functools
 
 from astroid.brain.brain_numpy_utils import (
-    infer_numpy_member,
     attribute_looks_like_numpy_member,
+    infer_numpy_member,
 )
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse

--- a/astroid/brain/brain_numpy_utils.py
+++ b/astroid/brain/brain_numpy_utils.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from astroid.builder import extract_node
 from astroid.context import InferenceContext
-from astroid.nodes.node_classes import Attribute, Import, Name, NodeNG
+from astroid.nodes.node_classes import Attribute, Import, Name
 
 # Class subscript is available in numpy starting with version 1.20.0
 NUMPY_VERSION_TYPE_HINTS_SUPPORT = ("1", "20", "0")

--- a/astroid/brain/brain_numpy_utils.py
+++ b/astroid/brain/brain_numpy_utils.py
@@ -61,26 +61,21 @@ def _is_a_numpy_module(node: Name) -> bool:
     )
 
 
-def looks_like_numpy_member(member_name: str, node: NodeNG) -> bool:
+def name_looks_like_numpy_member(member_name: str, node: Name) -> bool:
     """
-    Returns True if the node is a member of numpy whose
+    Returns True if the Name is a member of numpy whose
     name is member_name.
-
-    :param member_name: name of the member
-    :param node: node to test
-    :return: True if the node is a member of numpy
     """
-    if (
-        isinstance(node, Attribute)
-        and node.attrname == member_name
+    return node.name == member_name and node.root().name.startswith("numpy")
+
+
+def attribute_looks_like_numpy_member(member_name: str, node: Attribute) -> bool:
+    """
+    Returns True if the Attribute is a member of numpy whose
+    name is member_name.
+    """
+    return (
+        node.attrname == member_name
         and isinstance(node.expr, Name)
         and _is_a_numpy_module(node.expr)
-    ):
-        return True
-    if (
-        isinstance(node, Name)
-        and node.name == member_name
-        and node.root().name.startswith("numpy")
-    ):
-        return True
-    return False
+    )


### PR DESCRIPTION

## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
This method is the hottest path in astroid by number of primitive calls(!) Every name and attribute goes through it, multiplied by the number of numpy method names we compare against.

We already know whether we have a `Name` or `Attribute` when registering the transform, so avoiding re-checking the type here saves 32% of the calls to `isinstance()` when linting the entire astroid package.

## Benchmark
for `pylint astroid` on my M1 mac running python 3.11.2, a savings of 0.4s out of 16.7s, or about 2.5% wall time:

**main**
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
 12602852    0.658    0.000    0.717    0.000 {built-in method builtins.isinstance}
  2056140    0.426    0.000    0.581    0.000 brain_numpy_utils.py:64(looks_like_numpy_member)
```

**PR**
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  8491012    0.510    0.000    0.568    0.000 {built-in method builtins.isinstance}
  1534080    0.101    0.000    0.101    0.000 brain_numpy_utils.py:64(name_looks_like_numpy_member)
...
   522000    0.034    0.000    0.038    0.000 brain_numpy_utils.py:72(attribute_looks_like_numpy_member)
```