### PR TITLE
Add a bound to the inference tips cache (and fix regressions from #2158)

### DIFF
--- a/astroid/context.py
+++ b/astroid/context.py
@@ -140,6 +140,18 @@ class InferenceContext:
         yield
         self.path = path
 
+    def is_empty(self) -> bool:
+        return (
+            not self.path
+            and not self.nodes_inferred
+            and not self.callcontext
+            and not self.boundnode
+            and not self.lookupname
+            and not self.callcontext
+            and not self.extra_context
+            and not self.constraints
+        )
+
     def __str__(self) -> str:
         state = (
             f"{field}={pprint.pformat(getattr(self, field), width=80 - len(field))}"

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -75,7 +75,8 @@ def _inference_tip_cached(func: InferFn[_NodesT]) -> InferFn[_NodesT]:
                 if len(_cache) > 64:
                     _cache.popitem(last=False)
 
-        yield from result
+        # https://github.com/pylint-dev/pylint/issues/8686
+        yield from result  # pylint: disable=used-before-assignment
 
     return inner
 

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -46,6 +46,9 @@ def _inference_tip_cached(func: InferFn[_NodesT]) -> InferFn[_NodesT]:
             # func + node we raise here.
             _CURRENTLY_INFERRING.remove(partial_cache_key)
             raise UseInferenceDefault
+        if context is not None and context.is_empty():
+            # Fresh, empty contexts will defeat the cache.
+            context = None
         try:
             yield from _cache[func, node, context]
             return

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -31,7 +31,7 @@ from astroid import decorators as decoratorsmod
 from astroid.arguments import CallSite
 from astroid.bases import BoundMethod, Instance, UnboundMethod, UnionType
 from astroid.builder import AstroidBuilder, _extract_single_node, extract_node, parse
-from astroid.const import PY39_PLUS, PY310_PLUS
+from astroid.const import IS_PYPY, PY39_PLUS, PY310_PLUS
 from astroid.context import CallContext, InferenceContext
 from astroid.exceptions import (
     AstroidTypeError,
@@ -6976,6 +6976,9 @@ def test_imported_module_var_inferable3() -> None:
     assert i_w_val.as_string() == "['w', 'v']"
 
 
+@pytest.mark.skipif(
+    IS_PYPY, reason="Test run with coverage on PyPy sometimes raises a RecursionError"
+)
 def test_recursion_on_inference_tip() -> None:
     """Regression test for recursion in inference tip.
 


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Overview
Fix some performance regressions from #2158 (**1** and **2** below), and then improve on the status quo by adding a bound to the inference tips cache (**3**).

Closes #2180

## Description
**1**
Not every exit path was removing the recursion guard, so this "cache" meant to always return to empty after recursion concluded was not doing so: 6bdd92d1006ae73bd5747d7c3714e10de81f1818.

**2**
Add an `isEmpty()` method on `InferenceContext` so that `None` can be used as the portion of the cache key for any empty contexts instead of fresh, distinct `InferenceContext` instances: c807c03c48aea8e458a7db3df7f7b35e1cdffc6b.

**3**
Add a bound to the inference tips cache: 4757af207d96fa5ee50a453d452e35af083d49a4.

#### Benchmark for (3.)
Benchmark: `pylint home-assistant/core/homeassistant/helpers`
test code:
```diff
diff --git a/astroid/inference_tip.py b/astroid/inference_tip.py
index c0e121c5..7a484bf6 100644
--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -19,6 +19,8 @@ from astroid.typing import (
     TransformFn,
 )
 
+hits = 0
+misses = 0
 _cache: OrderedDict[
     tuple[InferFn[Any], NodeNG, InferenceContext | None], list[InferenceResult]
 ] = OrderedDict()
@@ -52,6 +54,9 @@ def _inference_tip_cached(func: InferFn[_NodesT]) -> InferFn[_NodesT]:
             context = None
         try:
             yield from _cache[func, node, context]
+            global hits
+            hits += 1
+            print("HITS: ", hits)
             return
         except KeyError:
             # Recursion guard with a partial cache key.
@@ -65,6 +70,9 @@ def _inference_tip_cached(func: InferFn[_NodesT]) -> InferFn[_NodesT]:
                 result = _cache[func, node, context] = list(
                     func(node, context, **kwargs)
                 )
+                global misses
+                misses += 1
+                print("MISSES: ", misses)
             finally:
                 # Remove recursion guard.
                 _CURRENTLY_INFERRING.remove(partial_cache_key)
```
|maxsize|hits|misses|
|--------|----|-------|
|2|5279|4452|
|64|5946|3533|
|512|5979|3480|

Those are some pretty impressive results for a maxsize of 2! 😱 (I saw the same with several projects.)

For now, I decided to stick with 64.

### Future work
In a subsequent PR we could exploring going all the way down to a cache size of 1 (🙀), and then be able to throw away the ugly code we have here for managing dictionary entries, and just store `last_inference_tip`.