### PR TITLE
Avoid duplicate inference results for `List[int]`

### DIFF
--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -316,6 +316,9 @@ def infer_typing_alias(
         # This is an issue in cases where the aliased class implements it,
         # but the typing alias isn't subscriptable. E.g., `typing.ByteString` for PY39+
         _forbid_class_getitem_access(class_def)
+
+    # Avoid re-instantiating this class every time it's seen
+    node._explicit_inference = lambda node, context: iter([class_def])
     return iter([class_def])
 
 

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -650,6 +650,16 @@ class TypingBrain(unittest.TestCase):
         assert isinstance(slots[0], nodes.Const)
         assert slots[0].value == "value"
 
+    @test_utils.require_version(minver="3.9")
+    def test_typing_no_duplicates(self):
+        node = builder.extract_node(
+            """
+        from typing import List
+        List[int]
+        """
+        )
+        assert len(node.inferred()) == 1
+
     def test_collections_generic_alias_slots(self):
         """Test slots for a class which is a subclass of a generic alias type."""
         node = builder.extract_node(


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Fix a regression in 3.0.0.a3 that became necessary once we fixed the cache key in 0740a0dd5e9cb48bb1a400aded498e4db1fcfca9.

If we re-run the inference function for inferring a slice like `List[int]`, we risk creating so many duplicates, especially if used in several files, that we hit the limit for max inference and end up introducing an `Uninferable`, which can cause some pylint checks to not fire.

This explains (and resolves!) the failures seen in https://github.com/pylint-dev/pylint/pull/8685#issuecomment-1546980683, which we were only seeing when running the test suite as a whole.

Skipping news because we're not writing changelogs specific to each alpha.

This should unblock https://github.com/pylint-dev/pylint/pull/8685.