### PR TITLE
Optimize `_compute_mro()`

### DIFF
--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2806,6 +2806,9 @@ class ClassDef(
                 yield from baseobj.bases
 
     def _compute_mro(self, context: InferenceContext | None = None):
+        if self.qname() == "builtins.object":
+            return [self]
+
         inferred_bases = list(self._inferred_bases(context=context))
         bases_mro = []
         for base in inferred_bases:


### PR DESCRIPTION
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
- Optimize `clean_duplicates_mro()`
- Short-circuit in `_compute_mro()` for "builtins.object"

Performance improvement is more noticeable in projects making heavy use of inheritance. For the project `music21` from the pylint primer:

#### Benchmark
```
from pylint.lint import Run
Run(['music21'], exit=False)  # using project's own rcfile
```
**main**

```
452811674 function calls (383785563 primitive calls) in 161.566 seconds
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
...
427785/97707    0.934    0.000   10.187    0.000 scoped_nodes.py:2808(_compute_mro)
```
**PR**
```
450362344 function calls (381157337 primitive calls) in 157.018 seconds
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
...
427785/97707    0.692    0.000    8.160    0.000 scoped_nodes.py:2808(_compute_mro)
```

That's ~2s saved out of ~160s, or 1.25%.