### PR TITLE
Suppress exception context describing a cache miss

### DIFF
--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -65,6 +65,9 @@ def _inference_tip_cached(func: InferFn[_NodesT]) -> InferFn[_NodesT]:
                 result = _cache[func, node, context] = list(
                     func(node, context, **kwargs)
                 )
+            except Exception as e:
+                # Suppress the KeyError from the cache miss.
+                raise e from None
             finally:
                 # Remove recursion guard.
                 try:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :Refactor         |

## Description
Having the KeyError from a cache miss in a traceback about an `AstroidError` is a red herring that can confuse reporters and maintainers. Suppress it.

Refs pylint-dev/pylint-django#399

No changelog