### PR TITLE
Prevent cache misses in do_import_module()

### DIFF
--- a/astroid/nodes/_base_nodes.py
+++ b/astroid/nodes/_base_nodes.py
@@ -130,8 +130,11 @@ class ImportNode(FilterStmtsBaseNode, NoChildrenNode, Statement):
         # If the module ImportNode is importing is a module with the same name
         # as the file that contains the ImportNode we don't want to use the cache
         # to make sure we use the import system to get the correct module.
-        # pylint: disable-next=no-member # pylint doesn't recognize type of mymodule
-        if mymodule.relative_to_absolute_name(modname, level) == mymodule.name:
+        if (
+            modname
+            # pylint: disable-next=no-member # pylint doesn't recognize type of mymodule
+            and mymodule.relative_to_absolute_name(modname, level) == mymodule.name
+        ):
             use_cache = False
         else:
             use_cache = True


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
If the `modname` argument is None, which it is a lot, since it's the default, it's okay to use the cache; there's no point in recreating the requested module every time.

Closes #2041

See discussion on #2041 and duplicate issue #2124 for how this was sourced to #1747.

Not suggesting a backport or changelog; there's an argument that the astroid cache is public, but not a slam-dunk one, hence, this is really just a performance optimization I'd suggest just describing with all the 3.0 changes.