### PR TITLE
Make `igetattr()` idempotent

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,12 @@ Release date: TBA
 
 * Reduce file system access in ``ast_from_file()``.
 
+* Make ``igetattr()`` idempotent. This addresses some reports of varying results
+  when running pylint with ``--jobs``.
+
+  Closes pylint-dev/pylint#4356
+  Refs #7
+
 * Fix incorrect cache keys for inference results, thereby correctly inferring types
   for calls instantiating types dynamically.
 

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -277,14 +277,6 @@ class BaseInstance(Proxy):
             context = InferenceContext()
         try:
             context.lookupname = name
-            # avoid recursively inferring the same attr on the same class
-            if context.push(self._proxied):
-                raise InferenceError(
-                    message="Cannot infer the same attribute again",
-                    node=self,
-                    context=context,
-                )
-
             # XXX frame should be self._proxied, or not ?
             get_attr = self.getattr(name, context, lookupclass=False)
             yield from _infer_stmts(


### PR DESCRIPTION


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

See regression test. The second time an instance's attribute is inferred with the same context (which pylint has legitimate use cases for, see existing test that was improved!), we still need to be able to get a successful inference result. Instead, we were getting Uninferable due to a performance optimization added in 2d7a87b.

This addresses some reports of varying results when running pylint with ``--jobs``. 


  Closes pylint-dev/pylint#4356
  Refs #7

## More info

The original inconsistency added in 2d7a87b targeted a report in #7, but we have no source for the original code being tested.

I attempted to guess what the bug report in #7 was. I came up with the following based on https://github.com/pylint-dev/astroid/issues/7#issuecomment-163117779, and it lints fine:

```python
class A:
    def __init__(self) -> None:
        self.transaction = self.one() or self.two() or self.three() or self.four() or self.five()
        self.transaction #@

    def one(self):
        self.transaction = trans
        trans = self.transaction

    def two(self):
        self.transaction = trans
        trans = self.transaction

    def three(self):
        self.transaction = trans
        trans = self.transaction

    def four(self):
        self.transaction = trans
        trans = self.transaction

    def five(self):
        self.transaction = trans
        trans = self.transaction
```

I don't want to commit this file to the tests, though, because it's a wild guess.