### PR TITLE
Fix interrupted `InferenceContext` call chains

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,11 @@ Release date: TBA
   Closes pylint-dev/pylint#7464
   Closes pylint-dev/pylint#8074
 
+* Fix interrupted ``InferenceContext`` call chains, thereby addressing performance
+  problems when linting ``sqlalchemy``.
+
+  Closes pylint-dev/pylint#8150
+
 * ``nodes.FunctionDef`` no longer inherits from ``nodes.Lambda``.
   This is a breaking change but considered a bug fix as the nodes did not share the same
   API and were not interchangeable.

--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -215,7 +215,7 @@ class CallSite:
                     # `cls.metaclass_method`. In this case, the
                     # first argument is always the class.
                     method_scope = funcnode.parent.scope()
-                    if method_scope is boundnode.metaclass():
+                    if method_scope is boundnode.metaclass(context=context):
                         return iter((boundnode,))
 
                 if funcnode.type == "method":


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Description

`ClassDef.getitem()` and `infer_argument()` both had interrupted call chains where the InferenceContext wasn't passed all the way through to `infer()`. This caused performance problems in packages such as `sqlalchemy` needing these features.

Closes pylint-dev/pylint#8150


Linting the example from pylint-dev/pylint#8150 now takes half as much time.