### PR TITLE
Delay `astroid_bootstrapping()` until instantiating `AstroidBuilder`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,11 @@ Release date: TBA
 
 * Reduce file system access in ``ast_from_file()``.
 
+* Reduce time to ``import astroid`` by delaying ``astroid_bootstrapping()`` until
+  the first instantiation of ``AstroidBuilder``.
+
+  Closes #2161
+
 * Fix incorrect cache keys for inference results, thereby correctly inferring types
   for calls instantiating types dynamically.
 
@@ -31,7 +36,7 @@ Release date: TBA
   We have tried to minimize the amount of breaking changes caused by this change
   but some are unavoidable.
 
-* ``infer_call_result`` now shares the same interface across all implemenations. Namely:
+* ``infer_call_result`` now shares the same interface across all implementations. Namely:
   ```python
   def infer_call_result(
                 self,

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -129,12 +129,14 @@ def _extend_builtins(class_transforms):
         transform(builtin_ast[class_name])
 
 
-_extend_builtins(
-    {
-        "bytes": partial(_extend_string_class, code=BYTES_CLASS, rvalue="b''"),
-        "str": partial(_extend_string_class, code=STR_CLASS, rvalue="''"),
-    }
-)
+def on_bootstrap():
+    """Called by astroid_bootstrapping()."""
+    _extend_builtins(
+        {
+            "bytes": partial(_extend_string_class, code=BYTES_CLASS, rvalue="b''"),
+            "str": partial(_extend_string_class, code=STR_CLASS, rvalue="''"),
+        }
+    )
 
 
 def _builtin_filter_predicate(node, builtin_name) -> bool:

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -69,6 +69,8 @@ class AstroidBuilder(raw_building.InspectBuilder):
     ) -> None:
         super().__init__(manager)
         self._apply_transforms = apply_transforms
+        if not raw_building.InspectBuilder.bootstrapped:
+            raw_building._astroid_bootstrapping()
 
     def module_build(
         self, module: types.ModuleType, modname: str | None = None

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -427,6 +427,8 @@ class InspectBuilder:
     FunctionDef and ClassDef nodes and some others as guessed.
     """
 
+    bootstrapped: bool = False
+
     def __init__(self, manager_instance: AstroidManager | None = None) -> None:
         self._manager = manager_instance or AstroidManager()
         self._done: dict[types.ModuleType | type, nodes.Module | nodes.ClassDef] = {}
@@ -725,5 +727,11 @@ def _astroid_bootstrapping() -> None:
             builder.object_build(klass, _type)
             astroid_builtin[_type.__name__] = klass
 
+    InspectBuilder.bootstrapped = True
 
-_astroid_bootstrapping()
+    # pylint: disable-next=import-outside-toplevel
+    from astroid.brain.brain_builtin_inference import on_bootstrap
+
+    # Instantiates an AstroidBuilder(), which is where
+    # InspectBuilder.bootstrapped is checked, so place after bootstrapped=True.
+    on_bootstrap()


### PR DESCRIPTION
## Type of Changes


|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Reduce time to ``import astroid`` by delaying ``astroid_bootstrapping()`` until the first instantiation of ``AstroidBuilder``.

Closes #2161

## Benchmark
```python
python3 -X importtime -c 'import astroid'
```

**main@** 44933994d5ef3354ead572b645169bd3d4591047
```
import time:     34604 |     315816 | astroid
```

**pr**
```
import time:     14397 |      75213 | astroid
```
