### PR TITLE
Infer function parameter types using annotations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,11 @@ What's New in astroid 3.0.0?
 =============================
 Release date: TBA
 
+* Use type annotations for type inference.
+
+  Closes pylint-dev/pylint#4813
+  Closes pylint-dev/pylint#8781
+
 * Remove support for Python 3.7.
 
   Refs #2137

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -4488,6 +4488,24 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         with self.assertRaises(InferenceError):
             _ = next(node.infer())
 
+    def test_infer_parameters_from_type_hints(self) -> None:
+        node = extract_node(
+            """
+        class Logger:
+            def info(self, msg: str) -> None:
+                ...
+
+        class MyClassThatLogs:
+            def __init__(self, logger: Logger) -> None:
+                self.logger = logger
+
+        my_class_that_logs = MyClassThatLogs(Logger())
+        my_class_that_logs.logger
+        """
+        )
+        inferred = list(node.infer())
+        assert isinstance(inferred[1], Instance)
+
 
 class GetattrTest(unittest.TestCase):
     def test_yes_when_unknown(self) -> None:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [X] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |

## Description

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Fixes https://github.com/pylint-dev/pylint/issues/4813
Fixes https://github.com/pylint-dev/pylint/issues/8781

Type annotations are not currently used for inferencing, which means that, for example, functions with parameter typed as a `logging.Logger` would not receive relevant pylint warnings such as `logging-fstring-interpolation`. 

To make use of these type annotations, we now modify `infer_assign` to add yield additional `Instance`s if an `AssignName` is being processed whose `parent` is an `Arguments` with annotations for the `AssignName`.

cc: @Pierre-Sassoulas 