### PR TITLE
Deprecate `rec` argument to `find_argname()`

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -509,6 +509,7 @@ class Name(_base_nodes.NoChildrenNode, LookupMixIn):
 
 DEPRECATED_ARGUMENT_DEFAULT = object()
 
+
 class Arguments(_base_nodes.AssignTypeNode):
     """Class representing an :class:`ast.arguments` node.
 
@@ -855,9 +856,9 @@ class Arguments(_base_nodes.AssignTypeNode):
         """
         if rec is not DEPRECATED_ARGUMENT_DEFAULT:
             warnings.warn(
-                'The rec argument will be removed in a future version.',
+                "The rec argument will be removed in a future version.",
                 DeprecationWarning,
-                stacklevel=2
+                stacklevel=2,
             )
         if self.arguments:
             return _find_arg(argname, self.arguments)

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -854,9 +854,9 @@ class Arguments(_base_nodes.AssignTypeNode):
         :returns: The index and node for the argument.
         :rtype: tuple(str or None, AssignName or None)
         """
-        if rec is not DEPRECATED_ARGUMENT_DEFAULT:
+        if rec is not DEPRECATED_ARGUMENT_DEFAULT:  # pragma: no cover
             warnings.warn(
-                "The rec argument will be removed in a future version.",
+                "The rec argument will be removed in astroid 3.1.",
                 DeprecationWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
Follow-up to
3db2bdd6ebfc49db5ed7f379a7c8388849b97262.

(More unreachable code to remove, and avoid unnecessary isinstance tuple checks.)