### PR TITLE
Adopt "future" behavior of `statement()` and `frame()`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -150,6 +150,8 @@ Release date: TBA
   missing parents regardless of the value of the ``future`` argument (which gave this behavior
   already).
 
+  The ``future`` argument to each method is deprecated and will be removed in astroid 4.0.
+
   Refs #1217
 
 * Remove deprecated ``Ellipsis``, ``ExtSlice``, ``Index`` nodes.

--- a/ChangeLog
+++ b/ChangeLog
@@ -146,6 +146,12 @@ Release date: TBA
 
   Refs #2141
 
+* ``frame()`` raises ``ParentMissingError`` and ``statement()`` raises ``StatementMissing`` for
+  missing parents regardless of the value of the ``future`` argument (which gave this behavior
+  already).
+
+  Refs #1217
+
 * Remove deprecated ``Ellipsis``, ``ExtSlice``, ``Index`` nodes.
 
   Refs #2152

--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -211,7 +211,7 @@ class CallSite:
                     return positional[0].infer(context=context)
                 if boundnode is None:
                     # XXX can do better ?
-                    boundnode = funcnode.parent.frame(future=True)
+                    boundnode = funcnode.parent.frame()
 
                 if isinstance(boundnode, nodes.ClassDef):
                     # Verify that we're accessing a method

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -430,7 +430,7 @@ class UnboundMethod(Proxy):
 
     def __repr__(self) -> str:
         assert self._proxied.parent, "Expected a parent node"
-        frame = self._proxied.parent.frame(future=True)
+        frame = self._proxied.parent.frame()
         return "<{} {} of {} at 0x{}".format(
             self.__class__.__name__, self._proxied.name, frame.qname(), id(self)
         )
@@ -472,7 +472,7 @@ class UnboundMethod(Proxy):
         # instance of the class given as first argument.
         if self._proxied.name == "__new__":
             assert self._proxied.parent, "Expected a parent node"
-            qname = self._proxied.parent.frame(future=True).qname()
+            qname = self._proxied.parent.frame().qname()
             # Avoid checking builtins.type: _infer_type_new_call() does more validation
             if qname.startswith("builtins.") and qname != "builtins.type":
                 return self._infer_builtin_new(caller, context or InferenceContext())

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -482,7 +482,7 @@ def _looks_like_dataclass_field_call(
     If check_scope is False, skips checking the statement and body.
     """
     if check_scope:
-        stmt = node.statement(future=True)
+        stmt = node.statement()
         scope = stmt.scope()
         if not (
             isinstance(stmt, nodes.AnnAssign)

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -406,7 +406,7 @@ def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
             if any(not isinstance(value, nodes.AssignName) for value in values):
                 continue
 
-            stmt = values[0].statement(future=True)
+            stmt = values[0].statement()
             if isinstance(stmt, nodes.Assign):
                 if isinstance(stmt.targets[0], nodes.Tuple):
                     targets = stmt.targets[0].itered()

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -233,7 +233,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
         from astroid import objects  # pylint: disable=import-outside-toplevel
 
         try:
-            frame = node.frame(future=True)
+            frame = node.frame()
             for inferred in node.expr.infer():
                 if isinstance(inferred, util.UninferableBase):
                     continue
@@ -268,7 +268,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
                 if (
                     frame.name == "__init__"
                     and values
-                    and values[0].frame(future=True).name != "__init__"
+                    and values[0].frame().name != "__init__"
                 ):
                     values.insert(0, node)
                 else:

--- a/astroid/filter_statements.py
+++ b/astroid/filter_statements.py
@@ -18,7 +18,7 @@ from astroid.typing import SuccessfulInferenceResult
 def _get_filtered_node_statements(
     base_node: nodes.NodeNG, stmt_nodes: list[nodes.NodeNG]
 ) -> list[tuple[nodes.NodeNG, nodes.Statement]]:
-    statements = [(node, node.statement(future=True)) for node in stmt_nodes]
+    statements = [(node, node.statement()) for node in stmt_nodes]
     # Next we check if we have ExceptHandlers that are parent
     # of the underlying variable, in which case the last one survives
     if len(statements) > 1 and all(
@@ -83,16 +83,12 @@ def _filter_stmts(
         #
         # def test(b=1):
         #     ...
-        if (
-            base_node.parent
-            and base_node.statement(future=True) is myframe
-            and myframe.parent
-        ):
+        if base_node.parent and base_node.statement() is myframe and myframe.parent:
             myframe = myframe.parent.frame()
 
     mystmt: nodes.Statement | None = None
     if base_node.parent:
-        mystmt = base_node.statement(future=True)
+        mystmt = base_node.statement()
 
     # line filtering if we are in the same frame
     #

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -266,7 +266,7 @@ def object_len(node, context: InferenceContext | None = None):
 
     # prevent self referential length calls from causing a recursion error
     # see https://github.com/pylint-dev/astroid/issues/777
-    node_frame = node.frame(future=True)
+    node_frame = node.frame()
     if (
         isinstance(node_frame, scoped_nodes.FunctionDef)
         and node_frame.name == "__len__"

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -1264,7 +1264,7 @@ def infer_functiondef(
     # of the wrapping frame. This means that every time we infer a property, the locals
     # are mutated with a new instance of the property. To avoid this, we detect this
     # scenario and avoid passing the `parent` argument to the constructor.
-    parent_frame = self.parent.frame(future=True)
+    parent_frame = self.parent.frame()
     property_already_in_parent_locals = self.name in parent_frame.locals and any(
         isinstance(val, objects.Property) for val in parent_frame.locals[self.name]
     )

--- a/astroid/nodes/_base_nodes.py
+++ b/astroid/nodes/_base_nodes.py
@@ -68,7 +68,7 @@ class FilterStmtsBaseNode(NodeNG):
 
     def _get_filtered_stmts(self, _, node, _stmts, mystmt: Statement | None):
         """Method used in _filter_stmts to get statements and trigger break."""
-        if self.statement(future=True) is mystmt:
+        if self.statement() is mystmt:
             # original node's statement is the assignment, only keep
             # current node (gen exp, list comp)
             return [node], True
@@ -88,7 +88,7 @@ class AssignTypeNode(NodeNG):
         """Method used in filter_stmts."""
         if self is mystmt:
             return _stmts, True
-        if self.statement(future=True) is mystmt:
+        if self.statement() is mystmt:
             # original node's statement is the assignment, only keep
             # current node (gen exp, list comp)
             return [node], True

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1528,7 +1528,7 @@ class Comprehension(NodeNG):
             if isinstance(lookup_node, (Const, Name)):
                 return [lookup_node], True
 
-        elif self.statement(future=True) is mystmt:
+        elif self.statement() is mystmt:
             # original node's statement is the assignment, only keeps
             # current node (gen exp, list comp)
 
@@ -3823,9 +3823,9 @@ class NamedExpr(_base_nodes.AssignTypeNode):
                 raise ParentMissingError(target=self.parent)
             if not self.parent.parent.parent:
                 raise ParentMissingError(target=self.parent.parent)
-            return self.parent.parent.parent.frame(future=True)
+            return self.parent.parent.parent.frame()
 
-        return self.parent.frame(future=True)
+        return self.parent.frame()
 
     def scope(self) -> LocalsDictNodeNG:
         """The first parent node defining a new scope.
@@ -3857,7 +3857,7 @@ class NamedExpr(_base_nodes.AssignTypeNode):
 
         :param stmt: The statement that defines the given name.
         """
-        self.frame(future=True).set_local(name, stmt)
+        self.frame().set_local(name, stmt)
 
 
 class Unknown(_base_nodes.AssignTypeNode):

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3814,6 +3814,12 @@ class NamedExpr(_base_nodes.AssignTypeNode):
 
         :returns: The first parent frame node.
         """
+        if future is not None:
+            warnings.warn(
+                "The future arg will be removed in astroid 4.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if not self.parent:
             raise ParentMissingError(target=self)
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -288,39 +288,15 @@ class NodeNG:
         """
         return any(self is parent for parent in node.node_ancestors())
 
-    @overload
-    def statement(self, *, future: None = ...) -> nodes.Statement | nodes.Module:
-        ...
-
-    @overload
-    def statement(self, *, future: Literal[True]) -> nodes.Statement:
-        ...
-
-    def statement(
-        self, *, future: Literal[None, True] = None
-    ) -> nodes.Statement | nodes.Module:
+    def statement(self, *, future: Literal[None, True] = None) -> nodes.Statement:
         """The first parent node, including self, marked as statement node.
 
-        TODO: Deprecate the future parameter and only raise StatementMissing and return
-        nodes.Statement
-
-        :raises AttributeError: If self has no parent attribute
-        :raises StatementMissing: If self has no parent attribute and future is True
+        :raises StatementMissing: If self has no parent attribute.
         """
         if self.is_statement:
             return cast("nodes.Statement", self)
         if not self.parent:
-            if future:
-                raise StatementMissing(target=self)
-            warnings.warn(
-                "In astroid 3.0.0 NodeNG.statement() will return either a nodes.Statement "
-                "or raise a StatementMissing exception. AttributeError will no longer be raised. "
-                "This behaviour can already be triggered "
-                "by passing 'future=True' to a statement() call.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            raise AttributeError(f"{self} object has no attribute 'parent'")
+            raise StatementMissing(target=self)
         return self.parent.statement(future=future)
 
     def frame(
@@ -332,20 +308,10 @@ class NodeNG:
         :class:`ClassDef` or :class:`Lambda`.
 
         :returns: The first parent frame node.
+        :raises ParentMissingError: If self has no parent attribute.
         """
         if self.parent is None:
-            if future:
-                raise ParentMissingError(target=self)
-            warnings.warn(
-                "In astroid 3.0.0 NodeNG.frame() will return either a Frame node, "
-                "or raise ParentMissingError. AttributeError will no longer be raised. "
-                "This behaviour can already be triggered "
-                "by passing 'future=True' to a frame() call.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            raise AttributeError(f"{self} object has no attribute 'parent'")
-
+            raise ParentMissingError(target=self)
         return self.parent.frame(future=future)
 
     def scope(self) -> nodes.LocalsDictNodeNG:

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -297,7 +297,7 @@ class NodeNG:
             return cast("nodes.Statement", self)
         if not self.parent:
             raise StatementMissing(target=self)
-        return self.parent.statement(future=future)
+        return self.parent.statement()
 
     def frame(
         self, *, future: Literal[None, True] = None

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -293,6 +293,12 @@ class NodeNG:
 
         :raises StatementMissing: If self has no parent attribute.
         """
+        if future is not None:
+            warnings.warn(
+                "The future arg will be removed in astroid 4.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if self.is_statement:
             return cast("nodes.Statement", self)
         if not self.parent:
@@ -310,6 +316,12 @@ class NodeNG:
         :returns: The first parent frame node.
         :raises ParentMissingError: If self has no parent attribute.
         """
+        if future is not None:
+            warnings.warn(
+                "The future arg will be removed in astroid 4.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if self.parent is None:
             raise ParentMissingError(target=self)
         return self.parent.frame(future=future)

--- a/astroid/nodes/scoped_nodes/mixin.py
+++ b/astroid/nodes/scoped_nodes/mixin.py
@@ -41,7 +41,7 @@ class LocalsDictNodeNG(node_classes.LookupMixIn):
         # pylint: disable=no-member; github.com/pylint-dev/astroid/issues/278
         if self.parent is None or isinstance(self.parent, node_classes.Unknown):
             return self.name
-        return f"{self.parent.frame(future=True).qname()}.{self.name}"
+        return f"{self.parent.frame().qname()}.{self.name}"
 
     def scope(self: _T) -> _T:
         """The first parent node defining a new scope.

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -382,6 +382,12 @@ class Module(LocalsDictNodeNG):
 
         When called on a :class:`Module` this raises a StatementMissing.
         """
+        if future is not None:
+            warnings.warn(
+                "The future arg will be removed in astroid 4.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         raise StatementMissing(target=self)
 
     def previous_sibling(self):

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -16,7 +16,7 @@ import os
 import warnings
 from collections.abc import Generator, Iterable, Iterator, Sequence
 from functools import cached_property, lru_cache
-from typing import TYPE_CHECKING, ClassVar, Literal, NoReturn, TypeVar, overload
+from typing import TYPE_CHECKING, ClassVar, Literal, NoReturn, TypeVar
 
 from astroid import bases, util
 from astroid.const import IS_PYPY, PY38, PY39_PLUS, PYPY_7_3_11_PLUS
@@ -377,34 +377,12 @@ class Module(LocalsDictNodeNG):
         """
         return self.file is not None and self.file.endswith(".py")
 
-    @overload
-    def statement(self, *, future: None = ...) -> Module:
-        ...
-
-    @overload
-    def statement(self, *, future: Literal[True]) -> NoReturn:
-        ...
-
-    def statement(self, *, future: Literal[None, True] = None) -> Module | NoReturn:
+    def statement(self, *, future: Literal[None, True] = None) -> NoReturn:
         """The first parent node, including self, marked as statement node.
 
-        When called on a :class:`Module` with the future parameter this raises an error.
-
-        TODO: Deprecate the future parameter and only raise StatementMissing
-
-        :raises StatementMissing: If no self has no parent attribute and future is True
+        When called on a :class:`Module` this raises a StatementMissing.
         """
-        if future:
-            raise StatementMissing(target=self)
-        warnings.warn(
-            "In astroid 3.0.0 NodeNG.statement() will return either a nodes.Statement "
-            "or raise a StatementMissing exception. nodes.Module will no longer be "
-            "considered a statement. This behaviour can already be triggered "
-            "by passing 'future=True' to a statement() call.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self
+        raise StatementMissing(target=self)
 
     def previous_sibling(self):
         """The previous sibling statement.

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -969,7 +969,7 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
         if (self.args.defaults and node in self.args.defaults) or (
             self.args.kw_defaults and node in self.args.kw_defaults
         ):
-            frame = self.parent.frame(future=True)
+            frame = self.parent.frame()
             # line offset to avoid that def func(f=func) resolve the default
             # value to the defined function
             offset = -1
@@ -1111,7 +1111,7 @@ class FunctionDef(
             parent=parent,
         )
         if parent and not isinstance(parent, Unknown):
-            frame = parent.frame(future=True)
+            frame = parent.frame()
             frame.set_local(name, self)
 
     def postinit(
@@ -1161,7 +1161,7 @@ class FunctionDef(
         The property will return all the callables that are used for
         decoration.
         """
-        frame = self.parent.frame(future=True)
+        frame = self.parent.frame()
         if not isinstance(frame, ClassDef):
             return []
 
@@ -1188,7 +1188,7 @@ class FunctionDef(
                         # original method.
                         if (
                             isinstance(meth, FunctionDef)
-                            and assign_node.frame(future=True) == frame
+                            and assign_node.frame() == frame
                         ):
                             decorators.append(assign.value)
         return decorators
@@ -1259,7 +1259,7 @@ class FunctionDef(
             if decorator.func.name in BUILTIN_DESCRIPTORS:
                 return decorator.func.name
 
-        frame = self.parent.frame(future=True)
+        frame = self.parent.frame()
         type_name = "function"
         if isinstance(frame, ClassDef):
             if self.name == "__new__":
@@ -1373,9 +1373,7 @@ class FunctionDef(
         """
         # check we are defined in a ClassDef, because this is usually expected
         # (e.g. pylint...) when is_method() return True
-        return self.type != "function" and isinstance(
-            self.parent.frame(future=True), ClassDef
-        )
+        return self.type != "function" and isinstance(self.parent.frame(), ClassDef)
 
     def decoratornames(self, context: InferenceContext | None = None) -> set[str]:
         """Get the qualified names of each of the decorators on this function.
@@ -1586,14 +1584,14 @@ class FunctionDef(
             # if any methods in a class body refer to either __class__ or super.
             # In our case, we want to be able to look it up in the current scope
             # when `__class__` is being used.
-            frame = self.parent.frame(future=True)
+            frame = self.parent.frame()
             if isinstance(frame, ClassDef):
                 return self, [frame]
 
         if (self.args.defaults and node in self.args.defaults) or (
             self.args.kw_defaults and node in self.args.kw_defaults
         ):
-            frame = self.parent.frame(future=True)
+            frame = self.parent.frame()
             # line offset to avoid that def func(f=func) resolve the default
             # value to the defined function
             offset = -1
@@ -1708,12 +1706,12 @@ def get_wrapping_class(node):
     :rtype: ClassDef or None
     """
 
-    klass = node.frame(future=True)
+    klass = node.frame()
     while klass is not None and not isinstance(klass, ClassDef):
         if klass.parent is None:
             klass = None
         else:
-            klass = klass.parent.frame(future=True)
+            klass = klass.parent.frame()
     return klass
 
 
@@ -1811,7 +1809,7 @@ class ClassDef(
             parent=parent,
         )
         if parent and not isinstance(parent, Unknown):
-            parent.frame(future=True).set_local(name, self)
+            parent.frame().set_local(name, self)
 
         for local_name, node in self.implicit_locals():
             self.add_local_node(node, local_name)
@@ -2086,7 +2084,7 @@ class ClassDef(
             # class A(name.Name):
             #     def name(self): ...
 
-            frame = self.parent.frame(future=True)
+            frame = self.parent.frame()
             # line offset to avoid that class A(A) resolve the ancestor to
             # the defined class
             offset = -1
@@ -2304,7 +2302,7 @@ class ClassDef(
         # Remove AnnAssigns without value, which are not attributes in the purest sense.
         for value in values.copy():
             if isinstance(value, node_classes.AssignName):
-                stmt = value.statement(future=True)
+                stmt = value.statement()
                 if isinstance(stmt, node_classes.AnnAssign) and stmt.value is None:
                     values.pop(values.index(value))
 

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -462,7 +462,7 @@ def arguments_assigned_stmts(
             callee = callee._proxied
     else:
         return _arguments_infer_argname(self, node_name, context)
-    if node and getattr(callee, "name", None) == node.frame(future=True).name:
+    if node and getattr(callee, "name", None) == node.frame().name:
         # reset call context/name
         callcontext = context.callcontext
         context = copy_context(context)
@@ -755,7 +755,7 @@ def starred_assigned_stmts(  # noqa: C901
                 lookups.append((index, len(element.itered())))
                 _determine_starred_iteration_lookups(starred, element, lookups)
 
-    stmt = self.statement(future=True)
+    stmt = self.statement()
     if not isinstance(stmt, (nodes.Assign, nodes.For)):
         raise InferenceError(
             "Statement {stmt!r} enclosing {node!r} must be an Assign or For node.",

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -756,7 +756,7 @@ class FileBuildTest(unittest.TestCase):
         self.assertEqual(module.fromlineno, 0)
         self.assertIsNone(module.parent)
         self.assertEqual(module.frame(), module)
-        self.assertEqual(module.frame(future=True), module)
+        self.assertEqual(module.frame(), module)
         self.assertEqual(module.root(), module)
         self.assertEqual(module.file, os.path.abspath(resources.find("data/module.py")))
         self.assertEqual(module.pure_python, 1)
@@ -766,7 +766,7 @@ class FileBuildTest(unittest.TestCase):
             self.assertEqual(module.statement(), module)
             assert len(records) == 1
         with self.assertRaises(StatementMissing):
-            module.statement(future=True)
+            module.statement()
 
     def test_module_locals(self) -> None:
         """Test the 'locals' dictionary of an astroid module."""
@@ -800,8 +800,8 @@ class FileBuildTest(unittest.TestCase):
         self.assertTrue(function.parent)
         self.assertEqual(function.frame(), function)
         self.assertEqual(function.parent.frame(), module)
-        self.assertEqual(function.frame(future=True), function)
-        self.assertEqual(function.parent.frame(future=True), module)
+        self.assertEqual(function.frame(), function)
+        self.assertEqual(function.parent.frame(), module)
         self.assertEqual(function.root(), module)
         self.assertEqual([n.name for n in function.args.args], ["key", "val"])
         self.assertEqual(function.type, "function")
@@ -824,8 +824,8 @@ class FileBuildTest(unittest.TestCase):
         self.assertTrue(klass.parent)
         self.assertEqual(klass.frame(), klass)
         self.assertEqual(klass.parent.frame(), module)
-        self.assertEqual(klass.frame(future=True), klass)
-        self.assertEqual(klass.parent.frame(future=True), module)
+        self.assertEqual(klass.frame(), klass)
+        self.assertEqual(klass.parent.frame(), module)
         self.assertEqual(klass.root(), module)
         self.assertEqual(klass.basenames, [])
         self.assertTrue(klass.newstyle)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -762,9 +762,10 @@ class FileBuildTest(unittest.TestCase):
         self.assertEqual(module.pure_python, 1)
         self.assertEqual(module.package, 0)
         self.assertFalse(module.is_statement)
-        with pytest.warns(DeprecationWarning) as records:
-            self.assertEqual(module.statement(), module)
-            assert len(records) == 1
+        with self.assertRaises(StatementMissing):
+            with pytest.warns(DeprecationWarning) as records:
+                self.assertEqual(module.statement(future=True), module)
+                assert len(records) == 1
         with self.assertRaises(StatementMissing):
             module.statement()
 

--- a/tests/test_filter_statements.py
+++ b/tests/test_filter_statements.py
@@ -11,7 +11,5 @@ def test_empty_node() -> None:
     enum_mod = extract_node("import enum")
     empty = EmptyNode(parent=enum_mod)
     empty.is_statement = True
-    filtered_statements = _filter_stmts(
-        empty, [empty.statement(future=True)], empty.frame(future=True), 0
-    )
+    filtered_statements = _filter_stmts(empty, [empty.statement()], empty.frame(), 0)
     assert filtered_statements[0] is empty

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -315,7 +315,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(meth1, UnboundMethod)
         self.assertEqual(meth1.name, "meth1")
         self.assertEqual(meth1.parent.frame().name, "C")
-        self.assertEqual(meth1.parent.frame(future=True).name, "C")
+        self.assertEqual(meth1.parent.frame().name, "C")
         self.assertRaises(StopIteration, partial(next, inferred))
 
     def test_bound_method_inference(self) -> None:
@@ -324,7 +324,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(meth1, BoundMethod)
         self.assertEqual(meth1.name, "meth1")
         self.assertEqual(meth1.parent.frame().name, "C")
-        self.assertEqual(meth1.parent.frame(future=True).name, "C")
+        self.assertEqual(meth1.parent.frame().name, "C")
         self.assertRaises(StopIteration, partial(next, inferred))
 
     def test_args_default_inference1(self) -> None:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -321,12 +321,12 @@ class AstroidManagerTest(
         ast = self.manager.ast_from_class(int)
         self.assertEqual(ast.name, "int")
         self.assertEqual(ast.parent.frame().name, "builtins")
-        self.assertEqual(ast.parent.frame(future=True).name, "builtins")
+        self.assertEqual(ast.parent.frame().name, "builtins")
 
         ast = self.manager.ast_from_class(object)
         self.assertEqual(ast.name, "object")
         self.assertEqual(ast.parent.frame().name, "builtins")
-        self.assertEqual(ast.parent.frame(future=True).name, "builtins")
+        self.assertEqual(ast.parent.frame().name, "builtins")
         self.assertIn("__setattr__", ast)
 
     def test_ast_from_class_with_module(self) -> None:
@@ -334,12 +334,12 @@ class AstroidManagerTest(
         ast = self.manager.ast_from_class(int, int.__module__)
         self.assertEqual(ast.name, "int")
         self.assertEqual(ast.parent.frame().name, "builtins")
-        self.assertEqual(ast.parent.frame(future=True).name, "builtins")
+        self.assertEqual(ast.parent.frame().name, "builtins")
 
         ast = self.manager.ast_from_class(object, object.__module__)
         self.assertEqual(ast.name, "object")
         self.assertEqual(ast.parent.frame().name, "builtins")
-        self.assertEqual(ast.parent.frame(future=True).name, "builtins")
+        self.assertEqual(ast.parent.frame().name, "builtins")
         self.assertIn("__setattr__", ast)
 
     def test_ast_from_class_attr_error(self) -> None:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -546,14 +546,14 @@ class ConstNodeTest(unittest.TestCase):
                 node.statement()
                 assert len(records) == 1
         with self.assertRaises(StatementMissing):
-            node.statement(future=True)
+            node.statement()
 
         with self.assertRaises(AttributeError):
             with pytest.warns(DeprecationWarning) as records:
                 node.frame()
                 assert len(records) == 1
         with self.assertRaises(ParentMissingError):
-            node.frame(future=True)
+            node.frame()
 
     def test_none(self) -> None:
         self._test(None)
@@ -641,35 +641,35 @@ class TestNamedExprNode:
         )
         function = module.body[0]
         assert function.args.frame() == function
-        assert function.args.frame(future=True) == function
+        assert function.args.frame() == function
 
         function_two = module.body[1]
         assert function_two.args.args[0].frame() == function_two
-        assert function_two.args.args[0].frame(future=True) == function_two
+        assert function_two.args.args[0].frame() == function_two
         assert function_two.args.args[1].frame() == function_two
-        assert function_two.args.args[1].frame(future=True) == function_two
+        assert function_two.args.args[1].frame() == function_two
         assert function_two.args.defaults[0].frame() == module
-        assert function_two.args.defaults[0].frame(future=True) == module
+        assert function_two.args.defaults[0].frame() == module
 
         inherited_class = module.body[3]
         assert inherited_class.keywords[0].frame() == inherited_class
-        assert inherited_class.keywords[0].frame(future=True) == inherited_class
+        assert inherited_class.keywords[0].frame() == inherited_class
         assert inherited_class.keywords[0].value.frame() == module
-        assert inherited_class.keywords[0].value.frame(future=True) == module
+        assert inherited_class.keywords[0].value.frame() == module
 
         lambda_assignment = module.body[4].value
         assert lambda_assignment.args.args[0].frame() == lambda_assignment
-        assert lambda_assignment.args.args[0].frame(future=True) == lambda_assignment
+        assert lambda_assignment.args.args[0].frame() == lambda_assignment
         assert lambda_assignment.args.defaults[0].frame() == module
-        assert lambda_assignment.args.defaults[0].frame(future=True) == module
+        assert lambda_assignment.args.defaults[0].frame() == module
 
         lambda_named_expr = module.body[5].args.defaults[0]
         assert lambda_named_expr.value.args.defaults[0].frame() == module
-        assert lambda_named_expr.value.args.defaults[0].frame(future=True) == module
+        assert lambda_named_expr.value.args.defaults[0].frame() == module
 
         comprehension = module.body[6].value
         assert comprehension.generators[0].ifs[0].frame() == module
-        assert comprehension.generators[0].ifs[0].frame(future=True) == module
+        assert comprehension.generators[0].ifs[0].frame() == module
 
     @staticmethod
     def test_scope() -> None:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -541,16 +541,16 @@ class ConstNodeTest(unittest.TestCase):
         self.assertIs(node.value, value)
         self.assertTrue(node._proxied.parent)
         self.assertEqual(node._proxied.root().name, value.__class__.__module__)
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(StatementMissing):
             with pytest.warns(DeprecationWarning) as records:
-                node.statement()
+                node.statement(future=True)
                 assert len(records) == 1
         with self.assertRaises(StatementMissing):
             node.statement()
 
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(ParentMissingError):
             with pytest.warns(DeprecationWarning) as records:
-                node.frame()
+                node.frame(future=True)
                 assert len(records) == 1
         with self.assertRaises(ParentMissingError):
             node.frame()

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -368,7 +368,7 @@ class FunctionNodeTest(ModuleLoader, unittest.TestCase):
     def test_navigation(self) -> None:
         function = self.module["global_access"]
         self.assertEqual(function.statement(), function)
-        self.assertEqual(function.statement(future=True), function)
+        self.assertEqual(function.statement(), function)
         l_sibling = function.previous_sibling()
         # check taking parent if child is not a stmt
         self.assertIsInstance(l_sibling, nodes.Assign)
@@ -1053,7 +1053,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
     def test_navigation(self) -> None:
         klass = self.module["YO"]
         self.assertEqual(klass.statement(), klass)
-        self.assertEqual(klass.statement(future=True), klass)
+        self.assertEqual(klass.statement(), klass)
         l_sibling = klass.previous_sibling()
         self.assertTrue(isinstance(l_sibling, nodes.FunctionDef), l_sibling)
         self.assertEqual(l_sibling.name, "global_access")
@@ -2813,24 +2813,24 @@ class TestFrameNodes:
         )
         function = module.body[0]
         assert function.frame() == function
-        assert function.frame(future=True) == function
+        assert function.frame() == function
         assert function.body[0].frame() == function
-        assert function.body[0].frame(future=True) == function
+        assert function.body[0].frame() == function
 
         class_node = module.body[1]
         assert class_node.frame() == class_node
-        assert class_node.frame(future=True) == class_node
+        assert class_node.frame() == class_node
         assert class_node.body[0].frame() == class_node
-        assert class_node.body[0].frame(future=True) == class_node
+        assert class_node.body[0].frame() == class_node
         assert class_node.body[1].frame() == class_node.body[1]
-        assert class_node.body[1].frame(future=True) == class_node.body[1]
+        assert class_node.body[1].frame() == class_node.body[1]
 
         lambda_assignment = module.body[2].value
         assert lambda_assignment.args.args[0].frame() == lambda_assignment
-        assert lambda_assignment.args.args[0].frame(future=True) == lambda_assignment
+        assert lambda_assignment.args.args[0].frame() == lambda_assignment
 
         assert module.frame() == module
-        assert module.frame(future=True) == module
+        assert module.frame() == module
 
     @staticmethod
     def test_non_frame_node():
@@ -2843,7 +2843,7 @@ class TestFrameNodes:
         """
         )
         assert module.body[0].frame() == module
-        assert module.body[0].frame(future=True) == module
+        assert module.body[0].frame() == module
 
         assert module.body[1].value.locals["x"][0].frame() == module
-        assert module.body[1].value.locals["x"][0].frame(future=True) == module
+        assert module.body[1].value.locals["x"][0].frame() == module


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
As promised, adopt the "future" behavior of `statement()` and `frame()`.

Refs #1217