### PR TITLE
Test on PyPy 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,6 +191,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+      # We only test on the lowest and highest supported PyPy versions
         python-version: ["pypy3.8", "pypy3.10"]
     steps:
       - name: Check out code from GitHub

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,7 +191,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-      # We only test on the lowest and highest supported PyPy versions
+        # We only test on the lowest and highest supported PyPy versions
         python-version: ["pypy3.8", "pypy3.10"]
     steps:
       - name: Check out code from GitHub

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,7 +191,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.8", "pypy3.9"]
+        python-version: ["pypy3.8", "pypy3.10"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.5.3


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
CI is failing on main and all PRs because `pytest` can't run on the newest PyPy 3.9 image. When the image came out, 3.10 also became available for the first time.

Let's just run on 3.10 to unblock CI. Two PyPy versions is fine?
