### PR TITLE
Optimize exception handling in import_module()

### DIFF
--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -445,6 +445,10 @@ class Module(LocalsDictNodeNG):
             # skip here
             if relative_only:
                 raise
+            # Don't repeat the same operation, e.g. for missing modules
+            # like "_winapi" or "nt" on POSIX systems.
+            if modname == absmodname:
+                raise
         return AstroidManager().ast_from_module_name(modname)
 
     def relative_to_absolute_name(self, modname: str, level: int | None) -> str:

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -449,7 +449,7 @@ class Module(LocalsDictNodeNG):
             # like "_winapi" or "nt" on POSIX systems.
             if modname == absmodname:
                 raise
-        return AstroidManager().ast_from_module_name(modname)
+        return AstroidManager().ast_from_module_name(modname, use_cache=use_cache)
 
     def relative_to_absolute_name(self, modname: str, level: int | None) -> str:
         """Get the absolute module name for a relative import.


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
Small performance boost. Don't repeat the same import operation for modules like `ntpath` that only exist on certain platforms (e.g. windows).