### PR TITLE
Avoid expensive list/tuple multiplication operations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -189,6 +189,10 @@ Release date: TBA
 
   Closes pylint-dev/pylint#8749
 
+* Avoid expensive list/tuple multiplication operations that would result in ``MemoryError``.
+
+  Closes pylint-dev/pylint#8748
+
 
 What's New in astroid 2.15.5?
 =============================

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -167,7 +167,7 @@ def _multiply_seq_by_int(
     context: InferenceContext,
 ) -> _TupleListNodeT:
     node = self.__class__(parent=opnode)
-    if other.value > 1e8:
+    if isinstance(other.value, int) and other.value > 1e8:
         node.elts = [nodes.Const(NotImplemented)]
         return node
     filtered_elts = (

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -168,7 +168,7 @@ def _multiply_seq_by_int(
 ) -> _TupleListNodeT:
     node = self.__class__(parent=opnode)
     if isinstance(other.value, int) and other.value > 1e8:
-        node.elts = [nodes.Const(NotImplemented)]
+        node.elts = [util.Uninferable]
         return node
     filtered_elts = (
         helpers.safe_infer(elt, context) or util.Uninferable

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -230,7 +230,7 @@ def tl_infer_binary_op(
         as_index = helpers.class_instance_as_index(other)
         if not as_index:
             yield util.Uninferable
-        elif not isinstance(as_index.value, int):
+        elif not isinstance(as_index.value, int):  # pragma: no cover
             # already checked by class_instance_as_index() but faster than casting
             raise AssertionError("Please open a bug report.")
         else:

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -167,6 +167,9 @@ def _multiply_seq_by_int(
     context: InferenceContext,
 ) -> _TupleListNodeT:
     node = self.__class__(parent=opnode)
+    if other.value > 1e8:
+        node.elts = [nodes.Const(NotImplemented)]
+        return node
     filtered_elts = (
         helpers.safe_infer(elt, context) or util.Uninferable
         for elt in self.elts

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -163,11 +163,11 @@ nodes.Const.infer_binary_op = const_infer_binary_op
 def _multiply_seq_by_int(
     self: _TupleListNodeT,
     opnode: nodes.AugAssign | nodes.BinOp,
-    other: nodes.Const,
+    value: int,
     context: InferenceContext,
 ) -> _TupleListNodeT:
     node = self.__class__(parent=opnode)
-    if isinstance(other.value, int) and other.value > 1e8:
+    if value > 1e8:
         node.elts = [util.Uninferable]
         return node
     filtered_elts = (
@@ -175,7 +175,7 @@ def _multiply_seq_by_int(
         for elt in self.elts
         if not isinstance(elt, util.UninferableBase)
     )
-    node.elts = list(filtered_elts) * other.value
+    node.elts = list(filtered_elts) * value
     return node
 
 
@@ -224,14 +224,17 @@ def tl_infer_binary_op(
         if not isinstance(other.value, int):
             yield not_implemented
             return
-        yield _multiply_seq_by_int(self, opnode, other, context)
+        yield _multiply_seq_by_int(self, opnode, other.value, context)
     elif isinstance(other, bases.Instance) and operator == "*":
         # Verify if the instance supports __index__.
         as_index = helpers.class_instance_as_index(other)
         if not as_index:
             yield util.Uninferable
+        elif not isinstance(as_index.value, int):
+            # already checked by class_instance_as_index() but faster than casting
+            raise AssertionError("Please open a bug report.")
         else:
-            yield _multiply_seq_by_int(self, opnode, as_index, context)
+            yield _multiply_seq_by_int(self, opnode, as_index.value, context)
     else:
         yield not_implemented
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -284,7 +284,7 @@ class ProtocolTests(unittest.TestCase):
         """Attempting to calculate the result is prohibitively expensive."""
         parsed = extract_node("[0] * 123456789")
         element = parsed.inferred()[0].elts[0]
-        assert element.value is NotImplemented
+        assert element.value is Uninferable
 
 
 def test_named_expr_inference() -> None:

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -279,6 +279,13 @@ class ProtocolTests(unittest.TestCase):
         parsed = extract_node("None ** 2")
         assert parsed.inferred() == [Uninferable]
 
+    @staticmethod
+    def test_uninferable_list_multiplication() -> None:
+        """Attempting to calculate the result is prohibitively expensive."""
+        parsed = extract_node("[0] * 123456789")
+        element = parsed.inferred()[0].elts[0]
+        assert element.value is NotImplemented
+
 
 def test_named_expr_inference() -> None:
     code = """


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes pylint-dev/pylint#8748

Similar approach to #1610, instead of adding this guard to `safe_infer`, since it seems better to catch this as close to the source as possible instead of all of the places that call `infer()`.
