### PR TITLE
Fix deprecation of `rec` argument to `find_argname()`

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -600,7 +600,7 @@ class Name(_base_nodes.LookupMixIn, _base_nodes.NoChildrenNode):
         return _infer_stmts(stmts, context, frame)
 
 
-DEPRECATED_ARGUMENT_DEFAULT = object()
+DEPRECATED_ARGUMENT_DEFAULT = "DEPRECATED_ARGUMENT_DEFAULT"
 
 
 class Arguments(_base_nodes.AssignTypeNode):
@@ -947,7 +947,7 @@ class Arguments(_base_nodes.AssignTypeNode):
         :returns: The index and node for the argument.
         :rtype: tuple(str or None, AssignName or None)
         """
-        if rec is not DEPRECATED_ARGUMENT_DEFAULT:  # pragma: no cover
+        if rec != DEPRECATED_ARGUMENT_DEFAULT:  # pragma: no cover
             warnings.warn(
                 "The rec argument will be removed in astroid 3.1.",
                 DeprecationWarning,


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Tested this in pylint, and saw I was incorrectly getting deprecation warnings. When using objects, they compare unidentical because astroid's copy of astroid is not pylint's copy of astroid. Using a string avoids this.

Follow-up to
698a376ff50a23958688d6cc4b9c8f7511a8c794.

Skip news.
