### PR TITLE
Restore `AssignAttr.infer_lhs()`

### DIFF
--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -6329,9 +6329,8 @@ def test_infer_assign_attr() -> None:
             self.count += 1  #@
     """
     node = extract_node(code)
-    # A refactor caused this to raise AttributeError
-    with pytest.raises(InferenceError):
-        next(node.infer())
+    inferred = next(node.infer())
+    assert inferred.value == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -6331,7 +6331,7 @@ def test_infer_assign_attr() -> None:
     node = extract_node(code)
     # A refactor caused this to raise AttributeError
     with pytest.raises(InferenceError):
-        next(node.target.infer())
+        next(node.infer())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -6319,6 +6319,21 @@ def test_infer_exception_instance_attributes() -> None:
     assert isinstance(index[0], nodes.AssignAttr)
 
 
+def test_infer_assign_attr() -> None:
+    code = """
+    class Counter:
+        def __init__(self):
+            self.count = 0
+
+        def increment(self):
+            self.count += 1  #@
+    """
+    node = extract_node(code)
+    # A refactor caused this to raise AttributeError
+    with pytest.raises(InferenceError):
+        next(node.target.infer())
+
+
 @pytest.mark.parametrize(
     "code,instance_name",
     [


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Regression in 65df5e8efcc8dab41269be4252b22d21f634a2ae.

Here is the kind of "helper function" I was referring to when I said I would remove the mixins added in #2171. (Three of them removed in #2231.) One method went missing during that latter PR.

I got tricked into thinking I didn't need that method, but it was just because both the pylint and astroid unit tests didn't cover it. Only the pylint stdlib primer suite caught it.

Closes pylint-dev/pylint#8823