### PR TITLE
Raise when a name is inferred twice with the same context

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -570,6 +570,7 @@ class Name(_base_nodes.LookupMixIn, _base_nodes.NoChildrenNode):
         for child_node in self.get_children():
             yield from child_node._get_name_nodes()
 
+    @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
         self, context: InferenceContext | None = None, **kwargs: Any

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1473,7 +1473,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
     def test_name_repeat_inference(self) -> None:
         node = extract_node("print")
         context = InferenceContext()
-        _inferred = next(node.infer(context=context))
+        _ = next(node.infer(context=context))
         with pytest.raises(InferenceError):
             next(node.infer(context=context))
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1470,6 +1470,13 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         assert len(results) == 2
         assert all(isinstance(result, nodes.Dict) for result in results)
 
+    def test_name_repeat_inference(self) -> None:
+        node = extract_node("print")
+        context = InferenceContext()
+        _inferred = next(node.infer(context=context))
+        with pytest.raises(InferenceError):
+            next(node.infer(context=context))
+
     def test_python25_no_relative_import(self) -> None:
         ast = resources.build_file("data/package/absimport.py")
         self.assertTrue(ast.absolute_import_activated(), True)


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Fixes #2237 
Regression in 082774ad. "sort of" unreleased, caused in an alpha pre-release (3.0.0a6), so no backport needed.

This was one of the fragile parts I was a little worried about when doing #2171, so I'm not surprised that it regressed. 

When trying to assess if this functionality was common enough for a mixin, I was trying to work through whether `_infer` and `_infer_lhs` really needed the same decorators or not, and in the process I missed this decorator.

Not sure if we need a whole alpha for this; I'll take the PR upgrading astroid in pylint, pin it to this commit, and see if there's a reasonable primer result. If there's no more work, we can release this fix with the #1867 in 3.0.0a7. If there is more work, then we should bump #1867 to 3.0.0a8 and focus 3.0.0a7 on fixing primer-detected issues. More soon.