### PR TITLE
Fix a crash when inferring a `typing.TypeVar` call.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -207,7 +207,7 @@ Release date: TBA
 
 What's New in astroid 2.15.6?
 =============================
-Release date: TBA
+Release date: 2023-07-08
 
 * Harden ``get_module_part()`` against ``"."``.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -31,10 +31,6 @@ Release date: TBA
 
 * Move ``safe_infer()`` from ``helpers`` to ``util``. This avoids some circular imports.
 
-* Fix a crash when inferring a `typing.TypeVar` call.
-
-  Closes pylint-dev/pylint#8802
-
 * Reduce file system access in ``ast_from_file()``.
 
 * Reduce time to ``import astroid`` by delaying ``astroid_bootstrapping()`` until
@@ -207,6 +203,10 @@ Release date: TBA
 * Harden ``get_module_part()`` against ``"."``.
 
   Closes pylint-dev/pylint#8749
+
+* Fix a crash when inferring a `typing.TypeVar` call.
+
+  Closes pylint-dev/pylint#8802
 
 * Avoid expensive list/tuple multiplication operations that would result in ``MemoryError``.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -31,6 +31,10 @@ Release date: TBA
 
 * Move ``safe_infer()`` from ``helpers`` to ``util``. This avoids some circular imports.
 
+* Fix a crash when inferring a `typing.TypeVar` call.
+
+  Closes pylint-dev/pylint#8802
+
 * Reduce file system access in ``ast_from_file()``.
 
 * Reduce time to ``import astroid`` by delaying ``astroid_bootstrapping()`` until

--- a/ChangeLog
+++ b/ChangeLog
@@ -196,6 +196,15 @@ Release date: TBA
   Refs #2204
 
 
+What's New in astroid 2.15.7?
+=============================
+Release date: TBA
+
+* Fix a crash when inferring a ``typing.TypeVar`` call.
+
+  Closes pylint-dev/pylint#8802
+
+
 What's New in astroid 2.15.6?
 =============================
 Release date: TBA
@@ -203,10 +212,6 @@ Release date: TBA
 * Harden ``get_module_part()`` against ``"."``.
 
   Closes pylint-dev/pylint#8749
-
-* Fix a crash when inferring a `typing.TypeVar` call.
-
-  Closes pylint-dev/pylint#8802
 
 * Avoid expensive list/tuple multiplication operations that would result in ``MemoryError``.
 

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -118,7 +118,9 @@ def looks_like_typing_typevar_or_newtype(node) -> bool:
     return False
 
 
-def infer_typing_typevar_or_newtype(node, context_itton=None):
+def infer_typing_typevar_or_newtype(
+    node: Call, context_itton: context.InferenceContext | None = None
+) -> Iterator[ClassDef]:
     """Infer a typing.TypeVar(...) or typing.NewType(...) call."""
     try:
         func = next(node.func.infer(context=context_itton))

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -134,7 +134,14 @@ def infer_typing_typevar_or_newtype(node, context_itton=None):
         raise UseInferenceDefault
 
     typename = node.args[0].as_string().strip("'")
-    node = extract_node(TYPING_TYPE_TEMPLATE.format(typename))
+    node = ClassDef(
+        name=typename,
+        lineno=node.lineno,
+        col_offset=node.col_offset,
+        parent=node.parent,
+        end_lineno=node.end_lineno,
+        end_col_offset=node.end_col_offset,
+    )
     return node.infer(context=context_itton)
 
 

--- a/tests/brain/test_typing.py
+++ b/tests/brain/test_typing.py
@@ -1,7 +1,6 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
-import pytest
 
 from astroid import builder, nodes
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,3 +1,6 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 import pytest
 
 from astroid import builder, nodes

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,22 @@
+import pytest
+
+from astroid import builder, nodes
+
+
+def test_infer_typevar() -> None:
+    """
+    Regression test for: https://github.com/pylint-dev/pylint/issues/8802
+
+    Test that an inferred `typing.TypeVar()` call produces a `nodes.ClassDef`
+    node.
+    """
+    assign_node = builder.extract_node(
+        """
+    from typing import TypeVar
+    MyType = TypeVar('My.Type')
+    """
+    )
+    call = assign_node.value
+    inferred = next(call.infer())
+    assert isinstance(inferred, nodes.ClassDef)
+    assert inferred.name == "My.Type"


### PR DESCRIPTION
Closes pylint-dev/pylint#8802

<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes https://github.com/pylint-dev/pylint/issues/8802
