### PR TITLE
Fix Arguments.arguments so it actually returns all arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,11 @@ What's New in astroid 3.0.0?
 =============================
 Release date: TBA
 
+* Return all existing arguments when calling ``Arguments.arguments()``. This also means ``find_argname`` will now
+  use the whole list of arguments for its search.
+
+  Closes #2213
+
 * Add support for Python 3.12, including PEP 695 type parameter syntax.
 
   Closes #2201

--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -181,7 +181,13 @@ class CallSite:
 
         positional = self.positional_arguments[: len(funcnode.args.args)]
         vararg = self.positional_arguments[len(funcnode.args.args) :]
-        argindex = funcnode.args.find_argname(name)[0]
+
+        # preserving previous behavior, when vararg and kwarg were not included in find_argname results
+        if name in [funcnode.args.vararg, funcnode.args.kwarg]:
+            argindex = None
+        else:
+            argindex = funcnode.args.find_argname(name)[0]
+
         kwonlyargs = {arg.name for arg in funcnode.args.kwonlyargs}
         kwargs = {
             key: value

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -780,7 +780,13 @@ class Arguments(_base_nodes.AssignTypeNode):
 
     @cached_property
     def arguments(self):
-        """Get all the arguments for this node, including positional only and positional and keyword"""
+        """Get all the arguments for this node. This includes:
+        * Positional only arguments
+        * Positional arguments
+        * Keyword arguments
+        * Variable arguments (.e.g *args)
+        * Keyword only arguments (e.g **kwargs)
+        """
         retval = list(itertools.chain((self.posonlyargs or ()), (self.args or ())))
         if self.vararg:
             retval.append(

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -706,19 +706,19 @@ class Arguments(
     kwargannotation: NodeNG | None
     """The type annotation for the variable length keyword arguments."""
 
-    vararg_node: NodeNG | None
+    vararg_node: AssignName | None
     """The node for variable length arguments"""
 
-    kwarg_node: NodeNG | None
-    """The node for keyword arguments"""
+    kwarg_node: AssignName | None
+    """The node for variable keyword arguments"""
 
     def __init__(
         self,
         vararg: str | None,
         kwarg: str | None,
         parent: NodeNG,
-        vararg_node: NodeNG | None = None,
-        kwarg_node: NodeNG | None = None,
+        vararg_node: AssignName | None = None,
+        kwarg_node: AssignName | None = None,
     ) -> None:
         """Almost all attributes can be None for living objects where introspection failed."""
         super().__init__(
@@ -803,7 +803,7 @@ class Arguments(
         * Positional arguments
         * Keyword arguments
         * Variable arguments (.e.g *args)
-        * Keyword only arguments (e.g **kwargs)
+        * Variable keyword arguments (e.g **kwargs)
         """
         retval = list(itertools.chain((self.posonlyargs or ()), (self.args or ())))
         if self.vararg_node:
@@ -970,11 +970,7 @@ class Arguments(
             return True
         if name == self.kwarg:
             return True
-        return (
-            self.find_argname(name)[1] is not None
-            or self.kwonlyargs
-            and _find_arg(name, self.kwonlyargs)[1] is not None
-        )
+        return self.find_argname(name)[1] is not None
 
     def find_argname(self, argname, rec=DEPRECATED_ARGUMENT_DEFAULT):
         """Get the index and :class:`AssignName` node for given name.
@@ -993,7 +989,7 @@ class Arguments(
             )
         if self.arguments:
             index, argument = _find_arg(argname, self.arguments)
-            if argument and argument.name not in [self.vararg, self.kwarg]:
+            if argument:
                 return index, argument
         return None, None
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -963,11 +963,7 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
             names = [elt.name for elt in self.args.arguments]
         else:
             names = []
-        if self.args.vararg:
-            names.append(self.args.vararg)
-        names += [elt.name for elt in self.args.kwonlyargs]
-        if self.args.kwarg:
-            names.append(self.args.kwarg)
+
         return names
 
     def infer_call_result(
@@ -1280,11 +1276,7 @@ class FunctionDef(
             names = [elt.name for elt in self.args.arguments]
         else:
             names = []
-        if self.args.vararg:
-            names.append(self.args.vararg)
-        names += [elt.name for elt in self.args.kwonlyargs]
-        if self.args.kwarg:
-            names.append(self.args.kwarg)
+
         return names
 
     def getattr(

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -356,13 +356,11 @@ def _arguments_infer_argname(
         yield util.Uninferable
         return
 
-    filtered_args = list(
-        filter(lambda arg: not isinstance(arg, nodes.Name), self.arguments)
-    )
+    args = [arg for arg in self.arguments if arg.lineno >= 0]
     functype = self.parent.type
     # first argument of instance/class method
     if (
-        filtered_args
+        args
         and getattr(self.arguments[0], "name", None) == name
         and functype != "staticmethod"
     ):
@@ -391,7 +389,7 @@ def _arguments_infer_argname(
     if name == self.vararg:
         vararg = nodes.const_factory(())
         vararg.parent = self
-        if not filtered_args and self.parent.name == "__init__":
+        if not args and self.parent.name == "__init__":
             cls = self.parent.parent.scope()
             vararg.elts = [cls.instantiate_class()]
         yield vararg

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -356,7 +356,7 @@ def _arguments_infer_argname(
         yield util.Uninferable
         return
 
-    args = [arg for arg in self.arguments if arg.lineno >= 0]
+    args = [arg for arg in self.arguments if arg.name not in [self.vararg, self.kwarg]]
     functype = self.parent.type
     # first argument of instance/class method
     if (

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -352,14 +352,17 @@ def _arguments_infer_argname(
     # more
     from astroid import arguments  # pylint: disable=import-outside-toplevel
 
-    if not (self.arguments or self.vararg or self.kwarg):
+    if not self.arguments:
         yield util.Uninferable
         return
 
+    filtered_args = list(
+        filter(lambda arg: not isinstance(arg, nodes.Name), self.arguments)
+    )
     functype = self.parent.type
     # first argument of instance/class method
     if (
-        self.arguments
+        filtered_args
         and getattr(self.arguments[0], "name", None) == name
         and functype != "staticmethod"
     ):
@@ -388,7 +391,7 @@ def _arguments_infer_argname(
     if name == self.vararg:
         vararg = nodes.const_factory(())
         vararg.parent = self
-        if not self.arguments and self.parent.name == "__init__":
+        if not filtered_args and self.parent.name == "__init__":
             cls = self.parent.parent.scope()
             vararg.elts = [cls.instantiate_class()]
         yield vararg

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -21,6 +21,7 @@ from astroid._ast import ParserModule, get_parser_module, parse_function_type_co
 from astroid.const import IS_PYPY, PY38, PY39_PLUS, PY312_PLUS, Context
 from astroid.manager import AstroidManager
 from astroid.nodes import NodeNG
+from astroid.nodes.node_classes import AssignName
 from astroid.nodes.utils import Position
 from astroid.typing import InferenceResult
 
@@ -561,10 +562,33 @@ class TreeRebuilder:
         """Visit an Arguments node by returning a fresh instance of it."""
         vararg: str | None = None
         kwarg: str | None = None
+        vararg_node = node.vararg
+        kwarg_node = node.kwarg
+
         newnode = nodes.Arguments(
             node.vararg.arg if node.vararg else None,
             node.kwarg.arg if node.kwarg else None,
             parent,
+            AssignName(
+                vararg_node.arg,
+                vararg_node.lineno,
+                vararg_node.col_offset,
+                parent,
+                end_lineno=vararg_node.end_lineno,
+                end_col_offset=vararg_node.end_col_offset,
+            )
+            if vararg_node
+            else None,
+            AssignName(
+                kwarg_node.arg,
+                kwarg_node.lineno,
+                kwarg_node.col_offset,
+                parent,
+                end_lineno=kwarg_node.end_lineno,
+                end_col_offset=kwarg_node.end_col_offset,
+            )
+            if kwarg_node
+            else None,
         )
         args = [self.visit(child, newnode) for child in node.args]
         defaults = [self.visit(child, newnode) for child in node.defaults]

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -43,7 +43,6 @@ from astroid.nodes.node_classes import (
     AssignName,
     Attribute,
     Call,
-    Const,
     ImportFrom,
     Tuple,
 )
@@ -2008,7 +2007,7 @@ def test_arguments_default_value():
     node = extract_node(
         "def fruit(eat='please', *, peel='no', trim='yes', **kwargs): ..."
     )
-    assert isinstance(node.args.default_value("eat"), Const)
+    assert node.args.default_value("eat").value == "please"
 
     node = extract_node("def fruit(seeds, flavor='good', *, peel='maybe'): ...")
-    assert isinstance(node.args.default_value("flavor"), Const)
+    assert node.args.default_value("flavor").value == "good"

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -22,6 +22,7 @@ from astroid import (
     Uninferable,
     bases,
     builder,
+    extract_node,
     nodes,
     parse,
     test_utils,
@@ -42,6 +43,7 @@ from astroid.nodes.node_classes import (
     AssignName,
     Attribute,
     Call,
+    Const,
     ImportFrom,
     Tuple,
 )
@@ -1975,3 +1977,38 @@ def test_str_repr_no_warnings(node):
     test_node = node(**args)
     str(test_node)
     repr(test_node)
+
+
+def test_arguments_contains_all():
+    """Ensure Arguments.arguments actually returns all available arguments"""
+
+    def manually_get_args(arg_node) -> set:
+        names = set()
+        if arg_node.args.vararg:
+            names.add(arg_node.args.vararg)
+        if arg_node.args.kwarg:
+            names.add(arg_node.args.kwarg)
+
+        names.update([x.name for x in arg_node.args.args])
+        names.update([x.name for x in arg_node.args.kwonlyargs])
+
+        return names
+
+    node = extract_node("""def a(fruit: str, *args, b=None, c=None, **kwargs): ...""")
+    assert manually_get_args(node) == {x.name for x in node.args.arguments}
+
+    node = extract_node("""def a(mango: int, b="banana", c=None, **kwargs): ...""")
+    assert manually_get_args(node) == {x.name for x in node.args.arguments}
+
+    node = extract_node("""def a(self, num = 10, *args): ...""")
+    assert manually_get_args(node) == {x.name for x in node.args.arguments}
+
+
+def test_arguments_default_value():
+    node = extract_node(
+        "def fruit(eat='please', *, peel='no', trim='yes', **kwargs): ..."
+    )
+    assert isinstance(node.args.default_value("eat"), Const)
+
+    node = extract_node("def fruit(seeds, flavor='good', *, peel='maybe'): ...")
+    assert isinstance(node.args.default_value("flavor"), Const)


### PR DESCRIPTION
Closes #2213.

Arguments.arguments() has been modified so that it returns all arguments as it should (according to its own doc). A test case was also added to verify this.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
