### PR TITLE
[sys.argv] Make 'sys.argv' uninferable because it never is

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1062,7 +1062,12 @@ def _infer_attribute(
             if isinstance(owner, (ClassDef, Instance)):
                 frame = owner if isinstance(owner, ClassDef) else owner._proxied
                 context.constraints[node.attrname] = get_constraints(node, frame=frame)
-            yield from owner.igetattr(node.attrname, context)
+            if node.attrname == "argv" and owner.name == "sys":
+                # sys.argv will never be inferable during static analysis
+                # It's value would be the args passed to the linter itself
+                yield util.Uninferable
+            else:
+                yield from owner.igetattr(node.attrname, context)
         except (
             AttributeInferenceError,
             InferenceError,

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7205,3 +7205,18 @@ class TestOldStyleStringFormatting:
         inferred = next(node.infer())
         assert isinstance(inferred, nodes.Const)
         assert inferred.value == "My name is Daniel, I'm 12.00"
+
+
+def test_sys_argv_uninferable() -> None:
+    """Regression test for https://github.com/pylint-dev/pylint/issues/7710."""
+    a: nodes.List = extract_node(
+        textwrap.dedent(
+            """
+    import sys
+
+    sys.argv"""
+        )
+    )
+    sys_argv_value = list(a._infer())
+    assert len(sys_argv_value) == 1
+    assert sys_argv_value[0] is Uninferable


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

It's impossible to infer the value of sys.argv outside of static analysis where it's the linter own value that is irrelevant at run time. Even if we had one of the value during the program execution it can change for each execution of the program.

Refs https://github.com/pylint-dev/pylint/issues/7710 / https://github.com/pylint-dev/pylint/pull/9041

I'm not sure this is generic at all, the implementation is naive and based on the test case I created. I welcome any advice from astroid experts :) 
