### PR TITLE
Remove references to removed OperationError shims

### DIFF
--- a/doc/api/astroid.exceptions.rst
+++ b/doc/api/astroid.exceptions.rst
@@ -3,14 +3,6 @@ Exceptions
 
 .. automodule:: astroid.exceptions
 
-   .. rubric:: Classes
-
-   .. autosummary::
-
-      BinaryOperationError
-      OperationError
-      UnaryOperationError
-
    .. rubric:: Exceptions
 
    .. autosummary::


### PR DESCRIPTION
These classes were moved to `util` and renamed, and the shims in the exceptions module were removed in 420e97d7158679acf051b52d98b6c48f31ec2173 (3.0), so just cleaning up the docs.