### PR TITLE
Add `TypeAlias.assigned_stmts()`

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -19,6 +19,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    ClassVar,
     Literal,
     Optional,
     Union,
@@ -4057,6 +4058,18 @@ class TypeAlias(_base_nodes.AssignTypeNode, _base_nodes.Statement):
         self, context: InferenceContext | None = None, **kwargs: Any
     ) -> Iterator[TypeAlias]:
         yield self
+
+    assigned_stmts: ClassVar[
+        Callable[
+            [
+                TypeAlias,
+                AssignName,
+                InferenceContext | None,
+                None,
+            ],
+            Generator[NodeNG, None, None],
+        ]
+    ] = protocols.assign_assigned_stmts
 
 
 class TypeVar(_base_nodes.AssignTypeNode):

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -441,7 +441,7 @@ def arguments_assigned_stmts(
 
 @decorators.raise_if_nothing_inferred
 def assign_assigned_stmts(
-    self: nodes.AugAssign | nodes.Assign | nodes.AnnAssign,
+    self: nodes.AugAssign | nodes.Assign | nodes.AnnAssign | nodes.TypeAlias,
     node: node_classes.AssignedStmtsPossibleNode = None,
     context: InferenceContext | None = None,
     assign_path: list[int] | None = None,

--- a/tests/test_type_params.py
+++ b/tests/test_type_params.py
@@ -37,6 +37,9 @@ def test_type_alias() -> None:
 
     assert node.statement() is node
 
+    assigned = next(node.assigned_stmts())
+    assert assigned is node.value
+
 
 def test_type_param_spec() -> None:
     node = extract_node("type Alias[**P] = Callable[P, int]")


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |

## Description
This partially reverts commit a82384a61df2ea026f527d511e29d0ed9c4fb794. (I wasn't ready to add this until I knew what it was and whether the other two nodes needed it 😄 .) Only the TypeAlias can assign a name in the current scope.

Prevents this failure in pylint:

```py
type X = float
if X:
    print(X)
```

```pyt
  File "/Users/<user>/astroid/astroid/protocols.py", line 345, in assend_assigned_stmts
    return self.parent.assigned_stmts(node=self, context=context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'TypeAlias' object has no attribute 'assigned_stmts'
```