### PR TITLE
Use the inference cache when no context is provided

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -51,6 +51,14 @@ Release date: TBA
   Closes pylint-dev/pylint#7464
   Closes pylint-dev/pylint#8074
 
+* Use the global inference cache when inferring, even without an explicit
+  ``InferenceContext``. This is a significant performance improvement given how
+  often methods default to ``None`` for the context argument. (Linting ``astroid``
+  itself now takes ~5% less time on Python 3.12; other projects requiring more
+  complex inference calculations will see greater speedups.)
+
+  Refs #529
+
 * Fix interrupted ``InferenceContext`` call chains, thereby addressing performance
   problems when linting ``sqlalchemy``.
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -138,18 +138,13 @@ class NodeNG:
         :returns: The inferred values.
         :rtype: iterable
         """
-        if context is not None:
+        if context is None:
+            context = InferenceContext()
+        else:
             context = context.extra_context.get(self, context)
         if self._explicit_inference is not None:
             # explicit_inference is not bound, give it self explicitly
             try:
-                if context is None:
-                    yield from self._explicit_inference(
-                        self,  # type: ignore[arg-type]
-                        context,
-                        **kwargs,
-                    )
-                    return
                 for result in self._explicit_inference(
                     self,  # type: ignore[arg-type]
                     context,
@@ -160,11 +155,6 @@ class NodeNG:
                 return
             except UseInferenceDefault:
                 pass
-
-        if not context:
-            # nodes_inferred?
-            yield from self._infer(context=context, **kwargs)
-            return
 
         key = (self, context.lookupname, context.callcontext, context.boundnode)
         if key in context.inferred:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -6157,6 +6157,24 @@ def test_igetattr_idempotent() -> None:
     assert util.Uninferable not in instance.igetattr("item", context_to_be_used_twice)
 
 
+@patch("astroid.nodes.Call._infer")
+def test_cache_usage_without_explicit_context(mock) -> None:
+    code = """
+    class InferMeTwice:
+        item = 10
+
+    InferMeTwice()
+    """
+    call = extract_node(code)
+    mock.return_value = [Uninferable]
+
+    # no explicit InferenceContext
+    call.inferred()
+    call.inferred()
+
+    mock.assert_called_once()
+
+
 def test_infer_context_manager_with_unknown_args() -> None:
     code = """
     class client_log(object):


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
Previously, without an explicit `InferenceContext` instance, no checks were done against the global inference cache, and no entries were stored in it. This is a problem given how often the default `context=None` is used.

Refs #529. The third point of #529 muses about some sort of global inference cache, which was added later in cf6528cbc158097c4903f0cab68242ff14bb591b. This current PR just finishes the job. I'll leave remarks on #529 about the remaining possible improvements.

There will be one change needed in pylint where the checker depends on retroengineering a particular inference path being traveled twice, but I've already got a patch for it.