### PR TITLE
Fix inference involving `@functools.lru_cache` decorator

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -211,6 +211,11 @@ Release date: TBA
 
   Closes pylint-dev/pylint#8802
 
+* Fix inference of functions with ``@functools.lru_cache`` decorators without
+  parentheses.
+
+  Closes pylint-dev/pylint#8868
+
 
 What's New in astroid 2.15.6?
 =============================

--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -134,15 +134,17 @@ def _looks_like_lru_cache(node) -> bool:
     if not node.decorators:
         return False
     for decorator in node.decorators.nodes:
-        if not isinstance(decorator, Call):
+        if not isinstance(decorator, (Attribute, Call)):
             continue
         if _looks_like_functools_member(decorator, "lru_cache"):
             return True
     return False
 
 
-def _looks_like_functools_member(node, member) -> bool:
-    """Check if the given Call node is a functools.partial call."""
+def _looks_like_functools_member(node: Attribute | Call, member: str) -> bool:
+    """Check if the given Call node is the wanted member of functools."""
+    if isinstance(node, Attribute):
+        return node.attrname == member
     if isinstance(node.func, Name):
         return node.func.name == member
     if isinstance(node.func, Attribute):

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -833,13 +833,13 @@ class TestExceptionInstanceModel:
         assert not args.elts
 
 
-class LruCacheModelTest(unittest.TestCase):
-    def test_lru_cache(self) -> None:
-        ast_nodes = builder.extract_node(
-            """
+@pytest.mark.parametrize("parentheses", (True, False))
+def test_lru_cache(parentheses) -> None:
+    ast_nodes = builder.extract_node(
+        f"""
         import functools
         class Foo(object):
-            @functools.lru_cache()
+            @functools.lru_cache{"()" if parentheses else ""}
             def foo():
                 pass
         f = Foo()
@@ -847,12 +847,12 @@ class LruCacheModelTest(unittest.TestCase):
         f.foo.__wrapped__ #@
         f.foo.cache_info() #@
         """
-        )
-        assert isinstance(ast_nodes, list)
-        cache_clear = next(ast_nodes[0].infer())
-        self.assertIsInstance(cache_clear, astroid.BoundMethod)
-        wrapped = next(ast_nodes[1].infer())
-        self.assertIsInstance(wrapped, astroid.FunctionDef)
-        self.assertEqual(wrapped.name, "foo")
-        cache_info = next(ast_nodes[2].infer())
-        self.assertIsInstance(cache_info, astroid.Instance)
+    )
+    assert isinstance(ast_nodes, list)
+    cache_clear = next(ast_nodes[0].infer())
+    assert isinstance(cache_clear, astroid.BoundMethod)
+    wrapped = next(ast_nodes[1].infer())
+    assert isinstance(wrapped, astroid.FunctionDef)
+    assert wrapped.name == "foo"
+    cache_info = next(ast_nodes[2].infer())
+    assert isinstance(cache_info, astroid.Instance)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Closes pylint-dev/pylint#8868