### PR TITLE
fix default_value for kwonlyargs with no default

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -947,8 +947,10 @@ class Arguments(
         ]
 
         index = _find_arg(argname, self.kwonlyargs)[0]
-        if index is not None and self.kw_defaults[index] is not None:
-            return self.kw_defaults[index]
+        if (index is not None) and (len(self.kw_defaults) > index):
+            if self.kw_defaults[index] is not None:
+                return self.kw_defaults[index]
+            raise NoDefault(func=self.parent, name=argname)
 
         index = _find_arg(argname, args)[0]
         if index is not None:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -38,6 +38,7 @@ from astroid.exceptions import (
     AstroidTypeError,
     AttributeInferenceError,
     InferenceError,
+    NoDefault,
     NotFoundError,
 )
 from astroid.objects import ExceptionInstance
@@ -145,6 +146,21 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         """
 
     ast = parse(CODE, __name__)
+
+    def test_arg_keyword_no_default_value(self):
+        node = extract_node(
+            """
+        class Sensor:
+            def __init__(self, *, description): #@
+                self._id = description.key
+        """
+        )
+        with self.assertRaises(NoDefault):
+            node.args.default_value("description")
+
+        node = extract_node("def apple(color, *args, name: str, **kwargs): ...")
+        with self.assertRaises(NoDefault):
+            node.args.default_value("name")
 
     def test_infer_abstract_property_return_values(self) -> None:
         module = parse(


### PR DESCRIPTION
Refs #2213.

Requesting the default value for a kwonlyarg with no default would fail with an IndexError, it now correctly raises a NoDefault exception. This issue arised after changes in PR #2240.