### PR TITLE
Update type annotations of PEP 695 nodes

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3381,8 +3381,8 @@ class ParamSpec(_base_nodes.AssignTypeNode):
         col_offset: int,
         parent: NodeNG,
         *,
-        end_lineno: int | None,
-        end_col_offset: int | None,
+        end_lineno: int,
+        end_col_offset: int,
     ) -> None:
         super().__init__(
             lineno=lineno,
@@ -4068,8 +4068,8 @@ class TypeAlias(_base_nodes.AssignTypeNode, _base_nodes.Statement):
         col_offset: int,
         parent: NodeNG,
         *,
-        end_lineno: int | None,
-        end_col_offset: int | None,
+        end_lineno: int,
+        end_col_offset: int,
     ) -> None:
         super().__init__(
             lineno=lineno,
@@ -4128,8 +4128,8 @@ class TypeVar(_base_nodes.AssignTypeNode):
         col_offset: int,
         parent: NodeNG,
         *,
-        end_lineno: int | None,
-        end_col_offset: int | None,
+        end_lineno: int,
+        end_col_offset: int,
     ) -> None:
         super().__init__(
             lineno=lineno,
@@ -4168,8 +4168,8 @@ class TypeVarTuple(_base_nodes.AssignTypeNode):
         col_offset: int,
         parent: NodeNG,
         *,
-        end_lineno: int | None,
-        end_col_offset: int | None,
+        end_lineno: int,
+        end_col_offset: int,
     ) -> None:
         super().__init__(
             lineno=lineno,


### PR DESCRIPTION

<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Closes #2253

These attributes cannot be none in real-world situations, see https://github.com/python/cpython/issues/106145.

@DanielNoord they were already required; we're just changing the type annotations, yes? It's not enforced anywhere in the code.