### PR TITLE
Allow ``AsStringVisitor`` to visit ``objects.PartialFunction``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -230,6 +230,10 @@ Release date: 2023-07-08
 
   Closes pylint-dev/pylint#8749
 
+* Allow ``AsStringVisitor`` to visit ``objects.PartialFunction``.
+
+  Closes pylint-dev/pylint#8881
+
 * Avoid expensive list/tuple multiplication operations that would result in ``MemoryError``.
 
   Closes pylint-dev/pylint#8748

--- a/astroid/nodes/as_string.py
+++ b/astroid/nodes/as_string.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from astroid import nodes
 
 if TYPE_CHECKING:
+    from astroid import objects
     from astroid.nodes import Const
     from astroid.nodes.node_classes import (
         Match,
@@ -323,7 +324,7 @@ class AsStringVisitor:
             result += ":" + node.format_spec.accept(self)[2:-1]
         return "{%s}" % result
 
-    def handle_functiondef(self, node, keyword) -> str:
+    def handle_functiondef(self, node: nodes.FunctionDef, keyword: str) -> str:
         """return a (possibly async) function definition node as string"""
         decorate = node.decorators.accept(self) if node.decorators else ""
         docs = self._docs_dedent(node.doc_node)
@@ -343,11 +344,11 @@ class AsStringVisitor:
             self._stmt_list(node.body),
         )
 
-    def visit_functiondef(self, node) -> str:
+    def visit_functiondef(self, node: nodes.FunctionDef) -> str:
         """return an astroid.FunctionDef node as string"""
         return self.handle_functiondef(node, "def")
 
-    def visit_asyncfunctiondef(self, node) -> str:
+    def visit_asyncfunctiondef(self, node: nodes.AsyncFunctionDef) -> str:
         """return an astroid.AsyncFunction node as string"""
         return self.handle_functiondef(node, "async def")
 
@@ -440,6 +441,10 @@ class AsStringVisitor:
     def visit_pass(self, node) -> str:
         """return an astroid.Pass node as string"""
         return "pass"
+
+    def visit_partialfunction(self, node: objects.PartialFunction) -> str:
+        """Return an objects.PartialFunction as string."""
+        return self.visit_functiondef(node)
 
     def visit_raise(self, node) -> str:
         """return an astroid.Raise node as string"""

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -233,7 +233,7 @@ class NodeNG:
             "id": id(self),
         }
 
-    def accept(self, visitor):
+    def accept(self, visitor: AsStringVisitor) -> str:
         """Visit this node using the given visitor."""
         func = getattr(visitor, "visit_" + self.__class__.__name__.lower())
         return func(self)

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1787,6 +1787,7 @@ class TestFunctoolsPartial:
         assert len(inferred) == 1
         partial = inferred[0]
         assert isinstance(partial, objects.PartialFunction)
+        assert isinstance(partial.as_string(), str)
         assert isinstance(partial.doc_node, nodes.Const)
         assert partial.doc_node.value == "Docstring"
         assert partial.lineno == 3


### PR DESCRIPTION


## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes https://github.com/pylint-dev/pylint/issues/8881

Also added some annotations. Let's not back port as we are nearing the release of the version.