### PR TITLE
Optimize root by not calling ``root()`` itself

### DIFF
--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -332,9 +332,12 @@ class NodeNG:
 
         :returns: The root node.
         """
-        if self.parent:
-            return self.parent.root()
-        return self  # type: ignore[return-value] # Only 'Module' does not have a parent node.
+        if not (parent := self.parent):
+            return self  # type: ignore[return-value] # Only 'Module' does not have a parent node.
+
+        while parent.parent:
+            parent = parent.parent
+        return parent  # type: ignore[return-value] # Only 'Module' does not have a parent node.
 
     def child_sequence(self, child):
         """Search for the sequence that contains this child.


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

We tend to call `root()` quite often. When linting `astroid` on `main` we spent 0.63% of our execution time in the `root()` function according to:
```python -m cProfile -o output.pstats -s cumtime -m pylint astroid && gprof2dot -f pstats output.pstats | dot -Tsvg -o out.svg```:
![out2](https://github.com/pylint-dev/astroid/assets/13665637/7c123a32-e756-44c6-8526-970a189f0817)


On this branch the function doesn't even show up in the svg because it doesn't meet the default threshold.
![out](https://github.com/pylint-dev/astroid/assets/13665637/cda47139-9b5f-4fe6-b846-6bd9a8535269)

<img width="264" alt="Scherm­afbeelding 2023-08-05 om 14 14 35" src="https://github.com/pylint-dev/astroid/assets/13665637/3d477595-be14-4941-a4f6-68a4698cb72c">
As can be seen from this crop, we mostly call this function recursively so it no longer showing up in the profile after removing that makes sense.