### PR TITLE
Optimize ``qname()`` by catching an exception instead

### DIFF
--- a/astroid/nodes/scoped_nodes/mixin.py
+++ b/astroid/nodes/scoped_nodes/mixin.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypeVar, overload
 
+from astroid.exceptions import ParentMissingError
 from astroid.filter_statements import _filter_stmts
 from astroid.nodes import _base_nodes, scoped_nodes
 from astroid.nodes.scoped_nodes.utils import builtin_lookup
 from astroid.typing import InferenceResult, SuccessfulInferenceResult
-from astroid.exceptions import ParentMissingError
 
 if TYPE_CHECKING:
     from astroid import nodes

--- a/astroid/nodes/scoped_nodes/mixin.py
+++ b/astroid/nodes/scoped_nodes/mixin.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, TypeVar, overload
 
 from astroid.filter_statements import _filter_stmts
-from astroid.nodes import _base_nodes, node_classes, scoped_nodes
+from astroid.nodes import _base_nodes, scoped_nodes
 from astroid.nodes.scoped_nodes.utils import builtin_lookup
 from astroid.typing import InferenceResult, SuccessfulInferenceResult
+from astroid.exceptions import ParentMissingError
 
 if TYPE_CHECKING:
     from astroid import nodes
@@ -38,9 +39,12 @@ class LocalsDictNodeNG(_base_nodes.LookupMixIn):
         :rtype: str
         """
         # pylint: disable=no-member; github.com/pylint-dev/astroid/issues/278
-        if self.parent is None or isinstance(self.parent, node_classes.Unknown):
+        if self.parent is None:
             return self.name
-        return f"{self.parent.frame().qname()}.{self.name}"
+        try:
+            return f"{self.parent.frame().qname()}.{self.name}"
+        except ParentMissingError:
+            return self.name
 
     def scope(self: _T) -> _T:
         """The first parent node defining a new scope.


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

![out2](https://github.com/pylint-dev/astroid/assets/13665637/f88063a9-0684-48c6-9e11-1a9ebe5fb9e4)
On `main` when linting `astroid` we 1,78% of the runtime is caused by `qname`, which makes `403460` calls to `isinstance` which accounts for 0,13% of runtime.

![out](https://github.com/pylint-dev/astroid/assets/13665637/1079a40a-38bf-454a-9507-ec2d6a4dc40c)
This removes all of those calls, bringing down the number to 1,62%.

This was added in https://github.com/pylint-dev/astroid/pull/2130 to make the code type safe, but catching the exception serves the same purpose without paying the performance cost.