### PR TITLE
Use the python source for the datetime module in Python 3.12+

### DIFF
--- a/astroid/brain/brain_datetime.py
+++ b/astroid/brain/brain_datetime.py
@@ -2,8 +2,6 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-import textwrap
-
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
 from astroid.const import PY312_PLUS
@@ -11,20 +9,9 @@ from astroid.manager import AstroidManager
 
 
 def datetime_transform():
-    """The datetime module was C-accelerated in Python 3.12, so we
-    lack a Python source."""
-    return AstroidBuilder(AstroidManager()).string_build(
-        textwrap.dedent(
-            """
-    class date: ...
-    class time: ...
-    class datetime(date): ...
-    class timedelta: ...
-    class tzinfo: ...
-    class timezone(tzinfo): ...
-    """
-        )
-    )
+    """The datetime module was C-accelerated in Python 3.12, so use the
+    Python source."""
+    return AstroidBuilder(AstroidManager()).string_build("from _pydatetime import *")
 
 
 if PY312_PLUS:

--- a/tests/brain/test_dateutil.py
+++ b/tests/brain/test_dateutil.py
@@ -26,4 +26,4 @@ class DateutilBrainTest(unittest.TestCase):
         """
         )
         d_type = next(module["d"].infer())
-        self.assertEqual(d_type.qname(), "datetime.datetime")
+        self.assertIn(d_type.qname(), {"_pydatetime.datetime", "datetime.datetime"})


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes pylint-dev/pylint#8852