### PR TITLE
[Backport maintenance/2.15.x] Make `sys.argv` uninferable because it never is (#2244)

### DIFF
--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -369,7 +369,12 @@ def infer_attribute(
                 context.constraints[self.attrname] = constraint.get_constraints(
                     self, frame=frame
                 )
-            yield from owner.igetattr(self.attrname, context)
+            if self.attrname == "argv" and owner.name == "sys":
+                # sys.argv will never be inferable during static analysis
+                # It's value would be the args passed to the linter itself
+                yield util.Uninferable
+            else:
+                yield from owner.igetattr(self.attrname, context)
         except (
             AttributeInferenceError,
             InferenceError,

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7116,4 +7116,4 @@ def test_sys_argv_uninferable() -> None:
     )
     sys_argv_value = list(a._infer())
     assert len(sys_argv_value) == 1
-    assert sys_argv_value[0] is Uninferable
+    assert sys_argv_value[0] is util.Uninferable

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7102,3 +7102,18 @@ class TestOldStyleStringFormatting:
         inferred = next(node.infer())
         assert isinstance(inferred, nodes.Const)
         assert inferred.value == "My name is Daniel, I'm 12.00"
+
+
+def test_sys_argv_uninferable() -> None:
+    """Regression test for https://github.com/pylint-dev/pylint/issues/7710."""
+    a: nodes.List = extract_node(
+        textwrap.dedent(
+            """
+    import sys
+
+    sys.argv"""
+        )
+    )
+    sys_argv_value = list(a._infer())
+    assert len(sys_argv_value) == 1
+    assert sys_argv_value[0] is Uninferable


### PR DESCRIPTION
Backport of #2244