### PR TITLE
[Backport maintenance/2.15.x] Infer user-defined enum classes by checking if the class is a subtype of `enum.Enum`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,10 @@ Release date: TBA
 
   Closes pylint-dev/pylint#8802
 
+* Infer user-defined enum classes by checking if the class is a subtype of ``enum.Enum``.
+
+  Closes pylint-dev/pylint#8897
+
 * Fix inference of functions with ``@functools.lru_cache`` decorators without
   parentheses.
 

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -20,7 +20,6 @@ from astroid.exceptions import (
     AstroidTypeError,
     AstroidValueError,
     InferenceError,
-    MroError,
     UseInferenceDefault,
 )
 from astroid.manager import AstroidManager
@@ -31,14 +30,6 @@ else:
     from typing_extensions import Final
 
 
-ENUM_BASE_NAMES = {
-    "Enum",
-    "IntEnum",
-    "enum.Enum",
-    "enum.IntEnum",
-    "IntFlag",
-    "enum.IntFlag",
-}
 ENUM_QNAME: Final[str] = "enum.Enum"
 TYPING_NAMEDTUPLE_QUALIFIED: Final = {
     "typing.NamedTuple",
@@ -606,14 +597,7 @@ def _get_namedtuple_fields(node: nodes.Call) -> str:
 
 def _is_enum_subclass(cls: astroid.ClassDef) -> bool:
     """Return whether cls is a subclass of an Enum."""
-    try:
-        return any(
-            klass.name in ENUM_BASE_NAMES
-            and getattr(klass.root(), "name", None) == "enum"
-            for klass in cls.mro()
-        )
-    except MroError:
-        return False
+    return cls.is_subtype_of("enum.Enum")
 
 
 AstroidManager().register_transform(


### PR DESCRIPTION
Backport of #2277