### PR TITLE
Move misplaced changelog note

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -207,11 +207,6 @@ Release date: TBA
 
   Refs pylint-dev/pylint#8598
 
-* Fix a regression in 2.12.0 where settings in AstroidManager would be ignored.
-  Most notably this addresses pylint-dev/pylint#7433.
-
-  Refs #2204
-
 
 What's New in astroid 2.15.7?
 =============================
@@ -247,6 +242,11 @@ Release date: 2023-07-08
 * Avoid expensive list/tuple multiplication operations that would result in ``MemoryError``.
 
   Closes pylint-dev/pylint#8748
+
+* Fix a regression in 2.12.0 where settings in AstroidManager would be ignored.
+  Most notably this addresses pylint-dev/pylint#7433.
+
+  Refs #2204
 
 
 What's New in astroid 2.15.5?


### PR DESCRIPTION
This referenced change shipped in 2.15.6, see #2204/#2207