### PR TITLE
Remove `restore_path()` decorator

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,10 @@ What's New in astroid 3.0.1?
 ============================
 Release date: TBA
 
+* Prevent unraisable ``ValueError`` exceptions in generator cleanup by removing
+  ``context.restore_path()`` decorator.
+
+  Refs pylint-dev/pylint#9138
 
 
 What's New in astroid 3.0.0?

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,16 +7,16 @@ What's New in astroid 3.1.0?
 ============================
 Release date: TBA
 
+* Reduce unraisable ``ValueError`` exceptions in generator cleanup by removing
+  ``context.restore_path()`` decorator.
+
+  Refs pylint-dev/pylint#9138
 
 
 What's New in astroid 3.0.1?
 ============================
 Release date: TBA
 
-* Prevent unraisable ``ValueError`` exceptions in generator cleanup by removing
-  ``context.restore_path()`` decorator.
-
-  Refs pylint-dev/pylint#9138
 
 
 What's New in astroid 3.0.0?

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -6,9 +6,7 @@
 
 from __future__ import annotations
 
-import contextlib
 import pprint
-from collections.abc import Iterator
 from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple
 
 from astroid.typing import InferenceResult, SuccessfulInferenceResult
@@ -133,12 +131,6 @@ class InferenceContext:
         clone.extra_context = self.extra_context
         clone.constraints = self.constraints.copy()
         return clone
-
-    @contextlib.contextmanager
-    def restore_path(self) -> Iterator[None]:
-        path = set(self.path)
-        yield
-        self.path = path
 
     def is_empty(self) -> bool:
         return (

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2236,31 +2236,30 @@ class ClassDef(  # pylint: disable=too-many-instance-attributes
             return
 
         for stmt in self.bases:
-            with context.restore_path():
-                try:
-                    for baseobj in stmt.infer(context):
-                        if not isinstance(baseobj, ClassDef):
-                            if isinstance(baseobj, bases.Instance):
-                                baseobj = baseobj._proxied
-                            else:
-                                continue
-                        if not baseobj.hide:
-                            if baseobj in yielded:
-                                continue
-                            yielded.add(baseobj)
-                            yield baseobj
-                        if not recurs:
+            try:
+                for baseobj in stmt.infer(context):
+                    if not isinstance(baseobj, ClassDef):
+                        if isinstance(baseobj, bases.Instance):
+                            baseobj = baseobj._proxied
+                        else:
                             continue
-                        for grandpa in baseobj.ancestors(recurs=True, context=context):
-                            if grandpa is self:
-                                # This class is the ancestor of itself.
-                                break
-                            if grandpa in yielded:
-                                continue
-                            yielded.add(grandpa)
-                            yield grandpa
-                except InferenceError:
-                    continue
+                    if not baseobj.hide:
+                        if baseobj in yielded:
+                            continue
+                        yielded.add(baseobj)
+                        yield baseobj
+                    if not recurs:
+                        continue
+                    for grandpa in baseobj.ancestors(recurs=True, context=context):
+                        if grandpa is self:
+                            # This class is the ancestor of itself.
+                            break
+                        if grandpa in yielded:
+                            continue
+                        yielded.add(grandpa)
+                        yield grandpa
+            except InferenceError:
+                continue
 
     def local_attr_ancestors(self, name, context: InferenceContext | None = None):
         """Iterate over the parents that define the given name.


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Reverts 0d4f73d.
Refs pylint-dev/pylint#9138: reduces number of unraisable `ValueError` exceptions in the python 3.12 pylint primer from 3 to 1. (see [result](https://github.com/jacobtylerwalls/pylint/actions/runs/6520082681)) (EDIT: turns out this "result" is a little indeterminate, though...)

There's been churn around this decorator before, but I'm in favor of removing some indirection.