### PR TITLE
Disable test_crypt_brain on Python >= 3.13

### DIFF
--- a/astroid/const.py
+++ b/astroid/const.py
@@ -10,6 +10,7 @@ PY39_PLUS = sys.version_info >= (3, 9)
 PY310_PLUS = sys.version_info >= (3, 10)
 PY311_PLUS = sys.version_info >= (3, 11)
 PY312_PLUS = sys.version_info >= (3, 12)
+PY313_PLUS = sys.version_info >= (3, 13)
 
 WIN32 = sys.platform == "win32"
 

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1976,7 +1976,7 @@ def test_oserror_model() -> None:
     assert strerror.value == ""
 
 
-@pytest.mark.skipif(PY313_PLUS, reason="Python >= 3.13")
+@pytest.mark.skipif(PY313_PLUS, reason="Python >= 3.13 no longer has a crypt module")
 def test_crypt_brain() -> None:
     module = MANAGER.ast_from_module_name("crypt")
     dynamic_attrs = [

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1975,6 +1975,7 @@ def test_oserror_model() -> None:
     assert isinstance(strerror, astroid.Const)
     assert strerror.value == ""
 
+
 @pytest.mark.skipif(PY313_PLUS, reason="Python >= 3.13")
 def test_crypt_brain() -> None:
     module = MANAGER.ast_from_module_name("crypt")

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1975,7 +1975,7 @@ def test_oserror_model() -> None:
     assert isinstance(strerror, astroid.Const)
     assert strerror.value == ""
 
-
+@pytest.mark.skipif(sys.hexversion < 51576832, reason="Python >= 3.13")
 def test_crypt_brain() -> None:
     module = MANAGER.ast_from_module_name("crypt")
     dynamic_attrs = [

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -15,7 +15,7 @@ import astroid
 from astroid import MANAGER, builder, nodes, objects, test_utils, util
 from astroid.bases import Instance
 from astroid.brain.brain_namedtuple_enum import _get_namedtuple_fields
-from astroid.const import PY312_PLUS
+from astroid.const import PY312_PLUS, PY313_PLUS
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
@@ -1975,7 +1975,7 @@ def test_oserror_model() -> None:
     assert isinstance(strerror, astroid.Const)
     assert strerror.value == ""
 
-@pytest.mark.skipif(sys.hexversion < 51576832, reason="Python >= 3.13")
+@pytest.mark.skipif(PY313_PLUS, reason="Python >= 3.13")
 def test_crypt_brain() -> None:
     module = MANAGER.ast_from_module_name("crypt")
     dynamic_attrs = [


### PR DESCRIPTION
Resolves #2327 but leaves two failures remaining:

FAILED tests/test_inference.py::test_dataclasses_subscript_inference_recursion_error_39
FAILED tests/brain/test_brain.py::TypingBrain::test_typing_annotated_subscriptable