### PR TITLE
Visit PEP 695 nodes in `get_children()`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,16 +7,16 @@ What's New in astroid 3.1.0?
 ============================
 Release date: TBA
 
+* Include PEP 695 (Python 3.12) generic type syntax nodes in ``get_children()``,
+  allowing checkers to visit them.
+
+  Refs pylint-dev/pylint#9193
 
 
 What's New in astroid 3.0.2?
 ============================
 Release date: TBA
 
-* Include PEP 695 (Python 3.12) generic type syntax nodes in ``get_children()``,
-  allowing checkers to visit them.
-
-  Refs pylint-dev/pylint#9193
 
 
 What's New in astroid 3.0.1?

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,9 +13,10 @@ What's New in astroid 3.0.2?
 ============================
 Release date: TBA
 
-* Fix crashes linting code using PEP 695 (Python 3.12) generic type syntax.
+* Include PEP 695 (Python 3.12) generic type syntax nodes in ``get_children()``,
+  allowing checkers to visit them.
 
-  Closes pylint-dev/pylint#9098
+  Refs pylint-dev/pylint#9193
 
 
 What's New in astroid 3.0.1?

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1667,6 +1667,7 @@ class FunctionDef(
 
         if self.returns is not None:
             yield self.returns
+        yield from self.type_params
 
         yield from self.body
 
@@ -2936,6 +2937,8 @@ class ClassDef(  # pylint: disable=too-many-instance-attributes
         yield from self.bases
         if self.keywords is not None:
             yield from self.keywords
+        yield from self.type_params
+
         yield from self.body
 
     @cached_property

--- a/tests/test_type_params.py
+++ b/tests/test_type_params.py
@@ -71,3 +71,13 @@ def test_type_param() -> None:
     assert isinstance(class_node.type_params[0], TypeVar)
     assert class_node.type_params[0].name.name == "T"
     assert class_node.type_params[0].bound is None
+
+
+def test_get_children() -> None:
+    func_node = extract_node("def func[T]() -> T: ...")
+    func_children = tuple(func_node.get_children())
+    assert isinstance(func_children[2], TypeVar)
+
+    class_node = extract_node("class MyClass[T]: ...")
+    class_children = tuple(class_node.get_children())
+    assert isinstance(class_children[0], TypeVar)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |

## Description

<!-- If this PR references an issue without fixing it: -->

Refs pylint-dev/pylint#9193

Noticed that without this PR, we don't check these nodes for `invalid-name`.