### PR TITLE
Bump astroid to 3.0.2, update changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,9 +9,15 @@ Release date: TBA
 
 
 
-What's New in astroid 3.0.2?
+What's New in astroid 3.0.3?
 ============================
 Release date: TBA
+
+
+
+What's New in astroid 3.0.2?
+============================
+Release date: 2023-12-12
 
 * Avoid duplicate inference results for some uses of ``typing.X`` constructs like
   ``Tuple[Optional[int], ...]``. This was causing pylint to occasionally omit

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.1.0-dev0"
+__version__ = "3.0.2"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.1.0-dev0"
+current = "3.0.2"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 3.0.2?
============================
Release date: 2023-12-12

* Avoid duplicate inference results for some uses of ``typing.X`` constructs like
  ``Tuple[Optional[int], ...]``. This was causing pylint to occasionally omit
  messages like ``deprecated-typing-alias``.
  Closes pylint-dev/pylint#9220