### PR TITLE
Set parent when inferring __name__ as __main__

### DIFF
--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -355,7 +355,9 @@ class Module(LocalsDictNodeNG):
         if name in self.special_attributes and not ignore_locals and not name_in_locals:
             result = [self.special_attributes.lookup(name)]
             if name == "__name__":
-                result.append(const_factory("__main__"))
+                str_node = const_factory("__main__")
+                str_node.parent = self
+                result.append(str_node)
         elif not ignore_locals and name_in_locals:
             result = self.locals[name]
         elif self.package:

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -84,6 +84,7 @@ class ModuleNodeTest(ModuleLoader, unittest.TestCase):
         self.assertEqual(self.module.getattr("__name__")[0].value, "data.module")
         self.assertIsInstance(self.module.getattr("__name__")[1], nodes.Const)
         self.assertEqual(self.module.getattr("__name__")[1].value, "__main__")
+        self.assertIs(self.module.getattr("__name__")[1].parent, self.module)
         self.assertEqual(len(self.module.getattr("__doc__")), 1)
         self.assertIsInstance(self.module.getattr("__doc__")[0], nodes.Const)
         self.assertEqual(


### PR DESCRIPTION
Follow-up to a110905. Fixes pylint failures with `StatementMissing` because there was no parent.