### PR TITLE
Fix annotations for statement method

### DIFF
--- a/astroid/filter_statements.py
+++ b/astroid/filter_statements.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 def _get_filtered_node_statements(
     base_node: nodes.NodeNG, stmt_nodes: list[nodes.NodeNG]
-) -> list[tuple[nodes.NodeNG, nodes.Statement]]:
+) -> list[tuple[nodes.NodeNG, _base_nodes.Statement]]:
     statements = [(node, node.statement()) for node in stmt_nodes]
     # Next we check if we have ExceptHandlers that are parent
     # of the underlying variable, in which case the last one survives
@@ -90,7 +90,7 @@ def _filter_stmts(
         if base_node.parent and base_node.statement() is myframe and myframe.parent:
             myframe = myframe.parent.frame()
 
-    mystmt: nodes.Statement | None = None
+    mystmt: _base_nodes.Statement | None = None
     if base_node.parent:
         mystmt = base_node.statement()
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -46,6 +46,7 @@ else:
 
 if TYPE_CHECKING:
     from astroid import nodes
+    from astroid.nodes import _base_nodes
 
 
 # Types for 'NodeNG.nodes_of_class()'
@@ -278,7 +279,7 @@ class NodeNG:
         """
         return any(self is parent for parent in node.node_ancestors())
 
-    def statement(self, *, future: Literal[None, True] = None) -> nodes.Statement:
+    def statement(self, *, future: Literal[None, True] = None) -> _base_nodes.Statement:
         """The first parent node, including self, marked as statement node.
 
         :raises StatementMissing: If self has no parent attribute.
@@ -290,7 +291,7 @@ class NodeNG:
                 stacklevel=2,
             )
         if self.is_statement:
-            return cast("nodes.Statement", self)
+            return cast("_base_nodes.Statement", self)
         if not self.parent:
             raise StatementMissing(target=self)
         return self.parent.statement()


### PR DESCRIPTION
## Description
`Statement` isn't exported form `astroid.nodes` (anymore ?). All other annotations were updated to use `_base_nodes.Statement`. It seems these two were missed.

--
_Side note_
Any particular reason the `base_nodes` module should be considered private, i.e. prefixed with `_`? Probably missed that discussion.