### PR TITLE
Bump astroid to 3.0.3, update changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,9 +9,10 @@ Release date: TBA
 
 
 
+
 What's New in astroid 3.0.3?
 ============================
-Release date: TBA
+Release date: 2024-02-04
 
 
 * Fix type of ``UnicodeDecodeError.object`` inferred as ``str`` instead of ``bytes``.

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.0.2"
+__version__ = "3.0.3"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.0.2"
+current = "3.0.3"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION

* Fix type of ``UnicodeDecodeError.object`` inferred as ``str`` instead of ``bytes``.

  Closes pylint-dev/pylint#9342

* Fix ``no-member`` false positives for ``args`` and ``kwargs`` on ``ParamSpec`` under Python 3.12.

  Closes pylint-dev/pylint#9401


