### PR TITLE
Include modname in AST warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,9 @@ Release date: TBA
   to the ``PartialFunction`` and ``Property`` constructors have been removed (call
   ``postinit(doc_node=...)`` instead.)
 
+* Include modname in AST warnings. Useful for ``invalid escape sequence`` warnings
+  with Python 3.12.
+
 
 
 What's New in astroid 3.0.3?

--- a/astroid/_ast.py
+++ b/astroid/_ast.py
@@ -22,7 +22,11 @@ class ParserModule(NamedTuple):
     bin_op_classes: dict[type[ast.operator], str]
     context_classes: dict[type[ast.expr_context], Context]
 
-    def parse(self, string: str, type_comments: bool = True) -> ast.Module:
+    def parse(
+        self, string: str, type_comments: bool = True, filename: str | None = None
+    ) -> ast.Module:
+        if filename:
+            return ast.parse(string, filename=filename, type_comments=type_comments)
         return ast.parse(string, type_comments=type_comments)
 
 

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -173,7 +173,9 @@ class AstroidBuilder(raw_building.InspectBuilder):
     ) -> tuple[nodes.Module, rebuilder.TreeRebuilder]:
         """Build tree node from data and add some informations."""
         try:
-            node, parser_module = _parse_string(data, type_comments=True)
+            node, parser_module = _parse_string(
+                data, type_comments=True, modname=modname
+            )
         except (TypeError, ValueError, SyntaxError) as exc:
             raise AstroidSyntaxError(
                 "Parsing Python code failed:\n{error}",
@@ -466,11 +468,13 @@ def _extract_single_node(code: str, module_name: str = "") -> nodes.NodeNG:
 
 
 def _parse_string(
-    data: str, type_comments: bool = True
+    data: str, type_comments: bool = True, modname: str | None = None
 ) -> tuple[ast.Module, ParserModule]:
     parser_module = get_parser_module(type_comments=type_comments)
     try:
-        parsed = parser_module.parse(data + "\n", type_comments=type_comments)
+        parsed = parser_module.parse(
+            data + "\n", type_comments=type_comments, filename=modname
+        )
     except SyntaxError as exc:
         # If the type annotations are misplaced for some reason, we do not want
         # to fail the entire parsing of the file, so we need to retry the parsing without

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -416,6 +416,16 @@ class BuilderTest(unittest.TestCase):
         with self.assertRaises(AstroidSyntaxError):
             self.builder.string_build('"\\x1"')
 
+    def test_data_build_error_filename(self) -> None:
+        """Check that error filename is set to modname if given."""
+        with pytest.raises(AstroidSyntaxError, match="invalid escape sequence") as ctx:
+            self.builder.string_build("'\\d+\\.\\d+'")
+        assert ctx.value.error.filename == "<unknown>"
+
+        with pytest.raises(AstroidSyntaxError, match="invalid escape sequence") as ctx:
+            self.builder.string_build("'\\d+\\.\\d+'", modname="mymodule")
+        assert ctx.value.error.filename == "mymodule"
+
     def test_missing_newline(self) -> None:
         """Check that a file with no trailing new line is parseable."""
         resources.build_file("data/noendingnewline.py")

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -420,10 +420,12 @@ class BuilderTest(unittest.TestCase):
         """Check that error filename is set to modname if given."""
         with pytest.raises(AstroidSyntaxError, match="invalid escape sequence") as ctx:
             self.builder.string_build("'\\d+\\.\\d+'")
+        assert isinstance(ctx.value.error, SyntaxError)
         assert ctx.value.error.filename == "<unknown>"
 
         with pytest.raises(AstroidSyntaxError, match="invalid escape sequence") as ctx:
             self.builder.string_build("'\\d+\\.\\d+'", modname="mymodule")
+        assert isinstance(ctx.value.error, SyntaxError)
         assert ctx.value.error.filename == "mymodule"
 
     def test_missing_newline(self) -> None:


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description
Python 3.12 change the DeprecationWarning for `invalid escape sequence` to a `SyntaxWarning`. These are now printed when the module is imported / the ast tree build. An example

```
# currently
<unknown>:158: SyntaxWarning: invalid escape sequence '\.'

# with this change
plexapi.base:158: SyntaxWarning: invalid escape sequence '\.'
```

Usually it's an actual filename for warnings and not just the modname. However, it should be good enough for now.

Long term it might make sense to adjust the warnings filter for astroid to make all `SyntaxWarnings` -> `SyntaxErrors` which would get re-raised. Thus it would be possible to add a `pylint: disable` (but only because the whole import isn't analyzed at all / skipped after the error).

For know this will at least help debug where the warning is coming from. Users can still choose to ignore them
```bash
python -Wignore:invalid\ escape\ sequence:SyntaxWarning -m pylint ...
```