### PR TITLE
Remove AstroidBuildingException (predecessor of AstroidBuildingError)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,8 @@ Release date: TBA
   to the ``PartialFunction`` and ``Property`` constructors have been removed (call
   ``postinit(doc_node=...)`` instead.)
 
+* Following a deprecation announced in astroid 1.5.0, the alias ``AstroidBuildingException`` is removed in favor of ``AstroidBuildingError``.
+
 * Include modname in AST warnings. Useful for ``invalid escape sequence`` warnings
   with Python 3.12.
 

--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -47,7 +47,6 @@ from astroid.builder import extract_node, parse
 from astroid.const import PY310_PLUS, Context
 from astroid.exceptions import (
     AstroidBuildingError,
-    AstroidBuildingException,
     AstroidError,
     AstroidImportError,
     AstroidIndexError,

--- a/astroid/exceptions.py
+++ b/astroid/exceptions.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 
 __all__ = (
     "AstroidBuildingError",
-    "AstroidBuildingException",
     "AstroidError",
     "AstroidImportError",
     "AstroidIndexError",
@@ -415,4 +414,3 @@ class StatementMissing(ParentMissingError):
 SuperArgumentTypeError = SuperError
 UnresolvableName = NameInferenceError
 NotFoundError = AttributeInferenceError
-AstroidBuildingException = AstroidBuildingError

--- a/doc/api/astroid.exceptions.rst
+++ b/doc/api/astroid.exceptions.rst
@@ -8,7 +8,6 @@ Exceptions
    .. autosummary::
 
       AstroidBuildingError
-      AstroidBuildingException
       AstroidError
       AstroidImportError
       AstroidIndexError


### PR DESCRIPTION
astroid 1.5 announced that this name would be removed in 2.0:

https://github.com/pylint-dev/astroid/blob/41d9196b8f766e3e5d6013c423cd763cf7ca5906/ChangeLog#L2865-L2866