### PR TITLE
Suppress SyntaxWarnings when parsing modules

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -27,6 +27,10 @@ Release date: TBA
 * Include modname in AST warnings. Useful for ``invalid escape sequence`` warnings
   with Python 3.12.
 
+* Suppress ``SyntaxWarnings`` when parsing modules.
+
+  Closes pylint-dev/pylint#9322
+
 
 
 What's New in astroid 3.0.3?

--- a/ChangeLog
+++ b/ChangeLog
@@ -27,7 +27,7 @@ Release date: TBA
 * Include modname in AST warnings. Useful for ``invalid escape sequence`` warnings
   with Python 3.12.
 
-* Suppress ``SyntaxWarnings`` when parsing modules.
+* Suppress ``SyntaxWarning`` for invalid escape sequences on Python 3.12 when parsing modules.
 
   Closes pylint-dev/pylint#9322
 

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -21,6 +21,7 @@ from tokenize import detect_encoding
 
 from astroid import bases, modutils, nodes, raw_building, rebuilder, util
 from astroid._ast import ParserModule, get_parser_module
+from astroid.const import PY312_PLUS
 from astroid.exceptions import AstroidBuildingError, AstroidSyntaxError, InferenceError
 from astroid.manager import AstroidManager
 
@@ -33,6 +34,9 @@ _TRANSIENT_FUNCTION = "__"
 # when calling extract_node.
 _STATEMENT_SELECTOR = "#@"
 MISPLACED_TYPE_ANNOTATION_ERROR = "misplaced type annotation"
+
+if PY312_PLUS:
+    warnings.filterwarnings("ignore", "invalid escape sequence", SyntaxWarning)
 
 
 def open_source_file(filename: str) -> tuple[TextIOWrapper, str, str]:
@@ -174,11 +178,9 @@ class AstroidBuilder(raw_building.InspectBuilder):
     ) -> tuple[nodes.Module, rebuilder.TreeRebuilder]:
         """Build tree node from data and add some informations."""
         try:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", SyntaxWarning)
-                node, parser_module = _parse_string(
-                    data, type_comments=True, modname=modname
-                )
+            node, parser_module = _parse_string(
+                data, type_comments=True, modname=modname
+            )
         except (TypeError, ValueError, SyntaxError) as exc:
             raise AstroidSyntaxError(
                 "Parsing Python code failed:\n{error}",

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -14,6 +14,7 @@ import ast
 import os
 import textwrap
 import types
+import warnings
 from collections.abc import Iterator, Sequence
 from io import TextIOWrapper
 from tokenize import detect_encoding
@@ -173,9 +174,11 @@ class AstroidBuilder(raw_building.InspectBuilder):
     ) -> tuple[nodes.Module, rebuilder.TreeRebuilder]:
         """Build tree node from data and add some informations."""
         try:
-            node, parser_module = _parse_string(
-                data, type_comments=True, modname=modname
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", SyntaxWarning)
+                node, parser_module = _parse_string(
+                    data, type_comments=True, modname=modname
+                )
         except (TypeError, ValueError, SyntaxError) as exc:
             raise AstroidSyntaxError(
                 "Parsing Python code failed:\n{error}",

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -19,7 +19,7 @@ import unittest.mock
 import pytest
 
 from astroid import Instance, builder, nodes, test_utils, util
-from astroid.const import IS_PYPY, PY38, PY39_PLUS, PYPY_7_3_11_PLUS
+from astroid.const import IS_PYPY, PY38, PY39_PLUS, PY312_PLUS, PYPY_7_3_11_PLUS
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidSyntaxError,
@@ -416,6 +416,7 @@ class BuilderTest(unittest.TestCase):
         with self.assertRaises(AstroidSyntaxError):
             self.builder.string_build('"\\x1"')
 
+    @pytest.mark.skipif(PY312_PLUS, reason="Ignoring SyntaxWarnings triggered by 3.12+")
     def test_data_build_error_filename(self) -> None:
         """Check that error filename is set to modname if given."""
         with pytest.raises(AstroidSyntaxError, match="invalid escape sequence") as ctx:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -19,7 +19,7 @@ import unittest.mock
 import pytest
 
 from astroid import Instance, builder, nodes, test_utils, util
-from astroid.const import IS_PYPY, PY38, PY39_PLUS, PY312_PLUS, PYPY_7_3_11_PLUS
+from astroid.const import IS_PYPY, PY38, PY39_PLUS, PYPY_7_3_11_PLUS
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidSyntaxError,
@@ -416,7 +416,6 @@ class BuilderTest(unittest.TestCase):
         with self.assertRaises(AstroidSyntaxError):
             self.builder.string_build('"\\x1"')
 
-    @pytest.mark.skipif(PY312_PLUS, reason="Ignoring SyntaxWarnings triggered by 3.12+")
     def test_data_build_error_filename(self) -> None:
         """Check that error filename is set to modname if given."""
         with pytest.raises(AstroidSyntaxError, match="invalid escape sequence") as ctx:


### PR DESCRIPTION
## Description
Following the conclusion in https://github.com/pylint-dev/pylint/issues/9322, ignore `SyntaxWarnings` when parsing modules with `ast.parse`.