### PR TITLE
Release astroid 3.1.0

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -191,6 +191,8 @@ Contributors
 - Alexander Scheel <alexander.m.scheel@gmail.com>
 - Alexander Presnyakov <flagist0@gmail.com>
 - Ahmed Azzaoui <ahmed.azzaoui@engie.com>
+- JulianJvn <128477611+JulianJvn@users.noreply.github.com>
+- Gwyn Ciesla <gwync@protonmail.com>
 
 Co-Author
 ---------

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,9 +3,21 @@ astroid's ChangeLog
 ===================
 
 
-What's New in astroid 3.1.0?
+What's New in astroid 3.2.0?
 ============================
 Release date: TBA
+
+
+
+What's New in astroid 3.1.1?
+============================
+Release date: TBA
+
+
+
+What's New in astroid 3.1.0?
+============================
+Release date: 2024-02-23
 
 * Include PEP 695 (Python 3.12) generic type syntax nodes in ``get_children()``,
   allowing checkers to visit them.

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.1.0-dev0"
+__version__ = "3.1.0"
 version = __version__

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.1.0"
+__version__ = "3.2.0-dev0"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.1.0"
+current = "3.2.0-dev0"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.1.0-dev0"
+current = "3.1.0"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
* Include PEP 695 (Python 3.12) generic type syntax nodes in ``get_children()``,
  allowing checkers to visit them.

  Refs pylint-dev/pylint#9193

* Add ``__main__`` as a possible inferred value for ``__name__`` to improve
  control flow inference around ``if __name__ == "__main__":`` guards.

  Closes #2071

* Following a deprecation period, the ``names`` arg to the ``Import`` constructor and
  the ``op`` arg to the ``BoolOp`` constructor are now required, and the ``doc`` args
  to the ``PartialFunction`` and ``Property`` constructors have been removed (call
  ``postinit(doc_node=...)`` instead.)

* Following a deprecation announced in astroid 1.5.0, the alias ``AstroidBuildingException`` is removed in favor of ``AstroidBuildingError``.

* Include modname in AST warnings. Useful for ``invalid escape sequence`` warnings
  with Python 3.12.

* ``RecursionError`` is now trapped and logged out as ``UserWarning`` during astroid node transformations with instructions about raising the system recursion limit.

  Closes pylint-dev/pylint#8842

* Suppress ``SyntaxWarning`` for invalid escape sequences on Python 3.12 when parsing modules.

  Closes pylint-dev/pylint#9322