### PR TITLE
drop test units which requires python 2.x

### DIFF
--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -47,6 +47,7 @@ from astroid.nodes.scoped_nodes.scoped_nodes import _is_metaclass
 
 from . import resources
 
+
 def _test_dict_interface(
     self: Any,
     node: nodes.ClassDef | nodes.FunctionDef | nodes.Module,


### PR DESCRIPTION
Already it is not possible to build this module with python 2.x (`requires-python = ">=3.8.0"` from pyproject.toml) so keeping those units in the code does not make to much sense.

<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

Refs #XXXX

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #XXXX
