### PR TITLE
Add deny list for modules to be skipped on AST generation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,12 @@ Release date: TBA
   Closes #1015
   Refs pylint-dev/pylint#4696
 
+* Adds ``module_denylist`` to ``AstroidManager`` for modules to be skipped during AST
+  generation. Modules in this list will cause an ``AstroidImportError`` to be raised
+  when an AST for them is requested.
+
+  Refs pylint-dev/pylint#9442
+
 
 What's New in astroid 3.1.1?
 ============================

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -203,7 +203,7 @@ class AstroidManager:
         # we want to fallback on the import system to make sure we get the correct
         # module.
         if modname in self.module_denylist:
-            raise AstroidImportError("Skipping ignored module")
+            raise AstroidImportError(f"Skipping ignored module {modname!r}")
         if modname in self.astroid_cache and use_cache:
             return self.astroid_cache[modname]
         if modname == "__main__":

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -59,6 +59,7 @@ class AstroidManager:
         "optimize_ast": False,
         "max_inferable_values": 100,
         "extension_package_whitelist": set(),
+        "module_denylist": set(),
         "_transform": TransformVisitor(),
     }
 
@@ -70,6 +71,7 @@ class AstroidManager:
         self.extension_package_whitelist = AstroidManager.brain[
             "extension_package_whitelist"
         ]
+        self.module_denylist = AstroidManager.brain["module_denylist"]
         self._transform = AstroidManager.brain["_transform"]
 
     @property
@@ -200,6 +202,8 @@ class AstroidManager:
         # importing a module with the same name as the file that is importing
         # we want to fallback on the import system to make sure we get the correct
         # module.
+        if modname in self.module_denylist:
+            raise AstroidImportError("Skipping ignored module")
         if modname in self.astroid_cache and use_cache:
             return self.astroid_cache[modname]
         if modname == "__main__":

--- a/astroid/test_utils.py
+++ b/astroid/test_utils.py
@@ -74,4 +74,5 @@ def brainless_manager():
     m._mod_file_cache = {}
     m._transform = transforms.TransformVisitor()
     m.extension_package_whitelist = set()
+    m.module_denylist = set()
     return m

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -385,7 +385,7 @@ class AstroidManagerTest(
 
     def test_denied_modules_raise(self) -> None:
         self.manager.module_denylist.add("random")
-        with pytest.raises(AstroidImportError):
+        with pytest.raises(AstroidImportError, match="random"):
             self.manager.ast_from_module_name("random")
         # and module not in the deny list shouldn't raise
         self.manager.ast_from_module_name("math")

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -383,6 +383,13 @@ class AstroidManagerTest(
         with pytest.raises(AstroidBuildingError):
             self.manager.ast_from_module_name(None)
 
+    def test_denied_modules_raise(self) -> None:
+        self.manager.module_denylist.add("random")
+        with pytest.raises(AstroidImportError):
+            self.manager.ast_from_module_name("random")
+        # and module not in the deny list shouldn't raise
+        self.manager.ast_from_module_name("math")
+
 
 class IsolatedAstroidManagerTest(resources.AstroidCacheSetupMixin, unittest.TestCase):
     def test_no_user_warning(self):


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Adds `module_denylist` to `AstroidManager` for modules to be skipped during AST generation.
Modules in this list will cause an ``AstroidImportError`` to be raised when an AST for them is requested.


<!-- If this PR references an issue without fixing it: -->

Refs pylint-dev/pylint#9442
Used by Pylint PR pylint-dev/pylint#9504

