### PR TITLE
Correct pre-commit's pylint warnings

### DIFF
--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -309,7 +309,6 @@ class AstroidManager:
                     modname.split("."), context_file=contextfile
                 )
             except ImportError as e:
-                # pylint: disable-next=redefined-variable-type
                 value = AstroidImportError(
                     "Failed to import module {modname} with error:\n{error}.",
                     modname=modname,
@@ -406,8 +405,7 @@ class AstroidManager:
         # take care, on living object __module__ is regularly wrong :(
         modastroid = self.ast_from_module_name(modname)
         if klass is obj:
-            for inferred in modastroid.igetattr(name, context):
-                yield inferred
+            yield from modastroid.igetattr(name, context)
         else:
             for inferred in modastroid.igetattr(name, context):
                 yield inferred.instantiate_class()

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1557,8 +1557,6 @@ class FunctionDef(
         :returns: What the function yields
         :rtype: iterable(NodeNG or Uninferable) or None
         """
-        # pylint: disable=not-an-iterable
-        # https://github.com/pylint-dev/astroid/issues/1015
         for yield_ in self.nodes_of_class(node_classes.Yield):
             if yield_.value is None:
                 const = node_classes.Const(None)

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1557,6 +1557,8 @@ class FunctionDef(
         :returns: What the function yields
         :rtype: iterable(NodeNG or Uninferable) or None
         """
+        # pylint: disable=not-an-iterable
+        # https://github.com/pylint-dev/astroid/issues/1015
         for yield_ in self.nodes_of_class(node_classes.Yield):
             if yield_.value is None:
                 const = node_classes.Const(None)


### PR DESCRIPTION
The introduction of use-yield-from generated a new warning on the source code. Some messages no longer needed to be disabled as well. These warnings have been corrected to prevent pre-commit from failing.

<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
