### PR TITLE
Add python 3.13 to the continuous integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13-dev"]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
@@ -138,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13-dev"]
     steps:
       - name: Set temp directory
         run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ What's New in astroid 3.3.0?
 ============================
 Release date: TBA
 
+* Add support for Python 3.13.
+
 * Remove support for Python 3.8 (and constants `PY38`, `PY39_PLUS`, and `PYPY_7_3_11_PLUS`).
 
   Refs #2443

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -508,6 +508,8 @@ def _looks_like_dataclasses(node: nodes.Module) -> bool:
 
 
 def _resolve_private_replace_to_public(node: nodes.Module) -> None:
+    """In python/cpython@6f3c138, a _replace() method was extracted from
+    replace(), and this indirection made replace() uninferable."""
     if "_replace" in node.locals:
         node.locals["replace"] = node.locals["_replace"]
 

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -19,7 +19,7 @@ from typing import Literal, Union
 
 from astroid import bases, context, nodes
 from astroid.builder import parse
-from astroid.const import PY310_PLUS
+from astroid.const import PY310_PLUS, PY313_PLUS
 from astroid.exceptions import AstroidSyntaxError, InferenceError, UseInferenceDefault
 from astroid.inference_tip import inference_tip
 from astroid.manager import AstroidManager
@@ -503,6 +503,15 @@ def _looks_like_dataclass_field_call(
     return inferred.name == FIELD_NAME and inferred.root().name in DATACLASS_MODULES
 
 
+def _looks_like_dataclasses(node: nodes.Module) -> bool:
+    return node.qname() == "dataclasses"
+
+
+def _resolve_private_replace_to_public(node: nodes.Module) -> None:
+    if "_replace" in node.locals:
+        node.locals["replace"] = node.locals["_replace"]
+
+
 def _get_field_default(field_call: nodes.Call) -> _FieldDefaultReturn:
     """Return a the default value of a field call, and the corresponding keyword
     argument name.
@@ -608,6 +617,13 @@ def _infer_instance_from_annotation(
 
 
 def register(manager: AstroidManager) -> None:
+    if PY313_PLUS:
+        manager.register_transform(
+            nodes.Module,
+            _resolve_private_replace_to_public,
+            _looks_like_dataclasses,
+        )
+
     manager.register_transform(
         nodes.ClassDef, dataclass_transform, is_decorated_with_dataclass
     )

--- a/astroid/brain/brain_pathlib.py
+++ b/astroid/brain/brain_pathlib.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 
 from astroid import bases, context, inference_tip, nodes
 from astroid.builder import _extract_single_node
+from astroid.const import PY313_PLUS
 from astroid.exceptions import InferenceError, UseInferenceDefault
 from astroid.manager import AstroidManager
 
@@ -27,10 +28,11 @@ def _looks_like_parents_subscript(node: nodes.Subscript) -> bool:
         value = next(node.value.infer())
     except (InferenceError, StopIteration):
         return False
+    parents = "pathlib._abc._PathParents" if PY313_PLUS else "pathlib._PathParents"
     return (
         isinstance(value, bases.Instance)
         and isinstance(value._proxied, nodes.ClassDef)
-        and value.qname() == "pathlib._PathParents"
+        and value.qname() == parents
     )
 
 

--- a/astroid/brain/brain_pathlib.py
+++ b/astroid/brain/brain_pathlib.py
@@ -28,7 +28,7 @@ def _looks_like_parents_subscript(node: nodes.Subscript) -> bool:
         value = next(node.value.infer())
     except (InferenceError, StopIteration):
         return False
-    parents = "pathlib._abc._PathParents" if PY313_PLUS else "pathlib._PathParents"
+    parents = "builtins.tuple" if PY313_PLUS else "pathlib._PathParents"
     return (
         isinstance(value, bases.Instance)
         and isinstance(value._proxied, nodes.ClassDef)

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -15,7 +15,7 @@ from typing import Final
 from astroid import context, extract_node, inference_tip
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder, _extract_single_node
-from astroid.const import PY312_PLUS
+from astroid.const import PY312_PLUS, PY313_PLUS
 from astroid.exceptions import (
     AstroidSyntaxError,
     AttributeInferenceError,
@@ -166,6 +166,15 @@ def infer_typing_attr(
     if not value.qname().startswith("typing.") or value.qname() in TYPING_ALIAS:
         # If typing subscript belongs to an alias handle it separately.
         raise UseInferenceDefault
+
+    if (
+        PY313_PLUS
+        and isinstance(value, FunctionDef)
+        and value.qname() == "typing.Annotated"
+    ):
+        # typing.Annotated is a FunctionDef on 3.13+
+        node._explicit_inference = lambda node, context: iter([value])
+        return iter([value])
 
     if isinstance(value, ClassDef) and value.qname() in {
         "typing.Generic",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -8,6 +8,7 @@ numpy>=1.17.0,<2; python_version<"3.12"
 python-dateutil
 PyQt6
 regex
+setuptools
 six
 urllib3>1,<2
 typing_extensions>=4.4.0

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -634,7 +634,7 @@ class TypingBrain(unittest.TestCase):
         assert ancestors[1].name == "object"
 
     def test_typing_annotated_subscriptable(self):
-        """Test typing.Annotated is subscriptable with __class_getitem__"""
+        """typing.Annotated is subscriptable with __class_getitem__ below 3.13."""
         node = builder.extract_node(
             """
         import typing
@@ -642,8 +642,13 @@ class TypingBrain(unittest.TestCase):
         """
         )
         inferred = next(node.infer())
-        assert isinstance(inferred, nodes.ClassDef)
-        assert isinstance(inferred.getattr("__class_getitem__")[0], nodes.FunctionDef)
+        if PY313_PLUS:
+            assert isinstance(inferred, nodes.FunctionDef)
+        else:
+            assert isinstance(inferred, nodes.ClassDef)
+            assert isinstance(
+                inferred.getattr("__class_getitem__")[0], nodes.FunctionDef
+            )
 
     def test_typing_generic_slots(self):
         """Test slots for Generic subclass."""

--- a/tests/brain/test_pathlib.py
+++ b/tests/brain/test_pathlib.py
@@ -24,7 +24,7 @@ def test_inference_parents() -> None:
     assert len(inferred) == 1
     assert isinstance(inferred[0], bases.Instance)
     if PY313_PLUS:
-        assert inferred[0].qname() == "pathlib._abc._PathParents"
+        assert inferred[0].qname() == "builtins.tuple"
     else:
         assert inferred[0].qname() == "pathlib._PathParents"
 
@@ -43,7 +43,10 @@ def test_inference_parents_subscript_index() -> None:
     inferred = path.inferred()
     assert len(inferred) == 1
     assert isinstance(inferred[0], bases.Instance)
-    assert inferred[0].qname() == "pathlib.Path"
+    if PY313_PLUS:
+        assert inferred[0].qname() == "pathlib._local.Path"
+    else:
+        assert inferred[0].qname() == "pathlib.Path"
 
 
 def test_inference_parents_subscript_slice() -> None:

--- a/tests/brain/test_pathlib.py
+++ b/tests/brain/test_pathlib.py
@@ -5,7 +5,7 @@
 
 import astroid
 from astroid import bases
-from astroid.const import PY310_PLUS
+from astroid.const import PY310_PLUS, PY313_PLUS
 from astroid.util import Uninferable
 
 
@@ -23,7 +23,10 @@ def test_inference_parents() -> None:
     inferred = name_node.inferred()
     assert len(inferred) == 1
     assert isinstance(inferred[0], bases.Instance)
-    assert inferred[0].qname() == "pathlib._PathParents"
+    if PY313_PLUS:
+        assert inferred[0].qname() == "pathlib._abc._PathParents"
+    else:
+        assert inferred[0].qname() == "pathlib._PathParents"
 
 
 def test_inference_parents_subscript_index() -> None:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -4453,8 +4453,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         # and reraise it as a TypeError in Class.getitem
         node = extract_node(
             """
-        def test():
-            yield
+        def test(): ...
         test()
         """
         )


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description
Add compatibility with Python 3.13.