### PR TITLE
Release astroid 3.2.0

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -204,3 +204,5 @@ under this name, or we did not manage to find their commits in the history.
 - carl
 - alain lefroy
 - Mark Gius
+- Jérome Perrin <perrinjerome@gmail.com>
+- Jamie Scott <jamie@jami.org.uk>

--- a/ChangeLog
+++ b/ChangeLog
@@ -31,12 +31,6 @@ Release date: TBA
   Closes #1107
 
 
-What's New in astroid 3.1.1?
-============================
-Release date: TBA
-
-
-
 What's New in astroid 3.1.0?
 ============================
 Release date: 2024-02-23

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,9 +3,21 @@ astroid's ChangeLog
 ===================
 
 
-What's New in astroid 3.2.0?
+What's New in astroid 3.3.0?
 ============================
 Release date: TBA
+
+
+
+What's New in astroid 3.2.1?
+============================
+Release date: TBA
+
+
+
+What's New in astroid 3.2.0?
+============================
+Release date: 2024-05-07
 
 * ``.pyi`` stub files are now preferred over ``.py`` files when resolving imports, (except for numpy).
 

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.2.0"
+__version__ = "3.3.0-dev0"
 version = __version__

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.2.0-dev0"
+__version__ = "3.2.0"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.2.0-dev0"
+current = "3.2.0"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.2.0"
+current = "3.3.0-dev0"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 3.2.0?
============================
Release date: TBA

* ``.pyi`` stub files are now preferred over ``.py`` files when resolving imports, (except for numpy).

  Closes pylint-dev/#9185

* ``igetattr()`` returns the last same-named function in a class (instead of
  the first). This avoids false positives in pylint with ``@overload``.

  Closes #1015
  Refs pylint-dev/pylint#4696

* Adds ``module_denylist`` to ``AstroidManager`` for modules to be skipped during AST
  generation. Modules in this list will cause an ``AstroidImportError`` to be raised
  when an AST for them is requested.

  Refs pylint-dev/pylint#9442

* Make ``astroid.interpreter._import.util.is_namespace`` only consider modules
  using a loader set to ``NamespaceLoader`` or ``None`` as namespaces.
  This fixes a problem that ``six.moves`` brain was not effective if ``six.moves``
  was already imported.

  Closes #1107