### PR TITLE
Improve performance of _get_zipimporters

### DIFF
--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -341,7 +341,7 @@ def _is_setuptools_namespace(location: pathlib.Path) -> bool:
 
 def _get_zipimporters() -> Iterator[tuple[str, zipimport.zipimporter]]:
     for filepath, importer in sys.path_importer_cache.items():
-        if isinstance(importer, zipimport.zipimporter):
+        if importer is not None and isinstance(importer, zipimport.zipimporter):
             yield filepath, importer
 
 


### PR DESCRIPTION
### Description

`_get_zipimporters` can call `isinstance` millions of times when running pylint's `import-error` checker on a codebase like yt-dlp.

Checking for `None` first avoids the overhead of invoking `isinstance`.

Closes pylint-dev/pylint#9607.

### Performance

I ran pylint with just the `import-error` checker on the yt-dlp codebase.  With pylint 3.1.0 and astroid 3.1.0, linting takes ~38.2 seconds.  With the fix applied, linting takes ~36.3 seconds.

<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

### Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |