### PR TITLE
Cache _has_init calls to avoid repeated stats

### DIFF
--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -23,6 +23,7 @@ from astroid.interpreter._import import spec, util
 from astroid.modutils import (
     NoSourceFile,
     _cache_normalize_path_,
+    _has_init,
     file_info_from_modpath,
     get_source_file,
     is_module_name_part_of_extension_package_whitelist,
@@ -457,6 +458,7 @@ class AstroidManager:
         for lru_cache in (
             LookupMixIn.lookup,
             _cache_normalize_path_,
+            _has_init,
             util.is_namespace,
             ObjectModel.attributes,
             ClassDef._metaclass_lookup_attribute,

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -666,6 +666,7 @@ def _is_python_file(filename: str) -> bool:
     return filename.endswith((".py", ".pyi", ".so", ".pyd", ".pyw"))
 
 
+@lru_cache(maxsize=1024)
 def _has_init(directory: str) -> str | None:
     """If the given directory has a valid __init__ file, return its path,
     else return None.


### PR DESCRIPTION
### Description
`_has_init` can end up checking for the presence of the same files over and over.

For example, when running pylint's import-error checks on a codebase like yt-dlp, ~43,000 redundant stats were performed prior to caching.

Closes pylint-dev/pylint#9613.

### Performance

I ran pylint with just the `import-error` checks on the yt-dlp codebase.  With pylint-dev/astroid@2c38c0275b790265ab450b79e8dc602e651ca9d3 and
pylint-dev/pylint@7521eb1dc6ac89fcf1763bee879d1207a87ddefa, linting takes ~34.1 seconds.  With the fix applied, linting takes ~33.8 seconds.

<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |