### PR TITLE
Fix ruff deprecation warnings for top-level linter settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,11 +83,13 @@ ignore_missing_imports = true
 
 
 [tool.ruff]
+target-version = "py38"
 
 # ruff is less lenient than pylint and does not make any exceptions
 # (for docstrings, strings and comments in particular).
 line-length = 110
 
+[tool.ruff.lint]
 select = [
     "E",  # pycodestyle
     "F",  # pyflakes
@@ -112,8 +114,7 @@ fixable = [
     "RUF", # ruff
 ]
 unfixable = ["RUF001"]
-target-version = "py38"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # Ruff is autofixing a tests with a voluntarily sneaky unicode
 "tests/test_regrtest.py" = ["RUF001"]


### PR DESCRIPTION
## Description

Before this change:

```
$ ruff check . --exclude=tests/testdata
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'fixable' -> 'lint.fixable'
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'unfixable' -> 'lint.unfixable'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
All checks passed!
```

After this change:
```
$ ruff check . --exclude=tests/testdata
All checks passed!
```

Reference: https://docs.astral.sh/ruff/settings

<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |