### PR TITLE
Add the ``__annotations__`` attribute to the ``ClassDef`` object model.

### DIFF
--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -493,7 +493,7 @@ class ClassModel(ObjectModel):
         super().__init__()
 
     @property
-    def attr___annotations__(self) -> Unkown:
+    def attr___annotations__(self) -> node_classes.Unkown:
         return node_classes.Unknown()
 
     @property

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -493,6 +493,10 @@ class ClassModel(ObjectModel):
         super().__init__()
 
     @property
+    def attr___annotations__(self):
+        return node_classes.Unknown()
+
+    @property
     def attr___module__(self):
         return node_classes.Const(self._instance.root().qname())
 

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -493,7 +493,7 @@ class ClassModel(ObjectModel):
         super().__init__()
 
     @property
-    def attr___annotations__(self):
+    def attr___annotations__(self) -> Unkown:
         return node_classes.Unknown()
 
     @property

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1949,7 +1949,10 @@ class ClassDef(  # pylint: disable=too-many-instance-attributes
         """
         locals_ = (("__module__", self.special_attributes.attr___module__),)
         # __qualname__ is defined in PEP3155
-        locals_ += (("__qualname__", self.special_attributes.attr___qualname__),)
+        locals_ += (
+            ("__qualname__", self.special_attributes.attr___qualname__),
+            ("__annotations__", self.special_attributes.attr___annotations__),
+        )
         return locals_
 
     # pylint: disable=redefined-outer-name

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -849,12 +849,13 @@ class FileBuildTest(unittest.TestCase):
         klass1 = module["YO"]
         locals1 = klass1.locals
         keys = sorted(locals1.keys())
-        assert_keys = ["__init__", "__module__", "__qualname__", "a"]
+        assert_keys = ["__annotations__", "__init__", "__module__", "__qualname__", "a"]
         self.assertEqual(keys, assert_keys)
         klass2 = module["YOUPI"]
         locals2 = klass2.locals
         keys = locals2.keys()
         assert_keys = [
+            "__annotations__",
             "__init__",
             "__module__",
             "__qualname__",

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -857,3 +857,47 @@ def test_lru_cache(parentheses) -> None:
     assert wrapped.name == "foo"
     cache_info = next(ast_nodes[2].infer())
     assert isinstance(cache_info, astroid.Instance)
+
+
+def test_class_annotations() -> None:
+    """Test that the `__annotations__` attribute is avaiable in the class scope"""
+    annotations, klass_attribute = builder.extract_node(
+        """
+        class Test:
+            __annotations__  #@
+        Test.__annotations__  #@
+        """
+    )
+    # Test that `__annotations__` attribute is available in the class scope:
+    assert isinstance(annotations, nodes.Name)
+    # The `__annotations__` attribute is `Uninferable`:
+    assert next(annotations.infer()) is astroid.Uninferable
+
+    # Test that we can access the class annotations:
+    assert isinstance(klass_attribute, nodes.Attribute)
+
+
+def test_class_annotations_typed_dict() -> None:
+    """Test that we can access class annotations on various TypedDicts"""
+    apple, pear = builder.extract_node(
+        """
+        from typing import TypedDict
+
+
+        class Apple(TypedDict):
+            a: int
+            b: str
+
+
+        Pear = TypedDict('OtherTypedDict', {'a': int, 'b': str})
+
+
+        Apple.__annotations__  #@
+        Pear.__annotations__  #@
+        """
+    )
+
+    assert isinstance(apple, nodes.Attribute)
+    assert next(apple.infer()) is astroid.Uninferable
+    assert isinstance(pear, nodes.Attribute)
+    assert next(pear.infer()) is astroid.Uninferable

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -1210,6 +1210,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         astroid = builder.parse(data, __name__)
         cls = astroid["WebAppObject"]
         assert_keys = [
+            "__annotations__",
             "__module__",
             "__qualname__",
             "appli",


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
Add the ``__annotations__`` attribute to the ``ClassDef`` object model.
Pylint now does not emit a ``no-member`` error when accessing ``__annotations__`` in the following cases:

**case 1.**
```python
class Test:
    print(__annotations__)
```

**case 2.**
```python
from typing import TypedDict

OtherTypedDict = TypedDict('OtherTypedDict', {'a': int, 'b': str})
print(OtherTypedDict.__annotations__)
```

**case 1** is similar to the behaviour of some of the other special attributes:
```python
class Test:
    print(__module__)
    print(__qualname__)
    print(__annotations__)
```
It turns out that this fix also fixed **case 2**.
However, it's still unclear why case 2 was only a false positive for Python 3.9 and older 😬 

<!-- If this PR references an issue without fixing it: -->

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes pylint-dev/pylint#7126
