### PR TITLE
Improve inference for generic classes (PEP 695)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,7 +22,7 @@ Release date: TBA
   Refs pylint-dev/#9626
   Refs pylint-dev/#9623
 
-* Fix ``unsubscriptable-object`` error for generic classes using the PEP 695 syntax (Python 3.12).
+* Improve inference for generic classes using the PEP 695 syntax (Python 3.12).
 
   Closes pylint-dev/#9406
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,10 @@ Release date: TBA
   Refs pylint-dev/#9626
   Refs pylint-dev/#9623
 
+* Fix ``unsubscriptable-object`` error for generic classes using the PEP 695 syntax (Python 3.12).
+
+  Closes pylint-dev/#9406
+
 
 What's New in astroid 3.2.1?
 ============================

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -205,17 +205,9 @@ def infer_typing_generic_class_pep695(
     node: ClassDef, ctx: context.InferenceContext | None = None
 ) -> Iterator[ClassDef]:
     """Add __class_getitem__ for generic classes. Python 3.12+."""
-    try:
-        value = next(node.infer())
-    except (InferenceError, StopIteration) as exc:
-        raise UseInferenceDefault from exc
-
-    if not (isinstance(value, ClassDef) and value.type_params):
-        raise UseInferenceDefault
-
     func_to_add = _extract_single_node(CLASS_GETITEM_TEMPLATE)
-    value.locals["__class_getitem__"] = [func_to_add]
-    return iter([value])
+    node.locals["__class_getitem__"] = [func_to_add]
+    return iter([node])
 
 
 def _looks_like_typedDict(  # pylint: disable=invalid-name

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -196,6 +196,28 @@ def infer_typing_attr(
     return node.infer(context=ctx)
 
 
+def _looks_like_generic_class_pep695(node: ClassDef) -> bool:
+    """Check if class is uses type parameter. Python 3.12+."""
+    return len(node.type_params) > 0
+
+
+def infer_typing_generic_class_pep695(
+    node: ClassDef, ctx: context.InferenceContext | None = None
+) -> Iterator[ClassDef]:
+    """Add __class_getitem__ for generic classes. Python 3.12+."""
+    try:
+        value = next(node.infer())
+    except (InferenceError, StopIteration) as exc:
+        raise UseInferenceDefault from exc
+
+    if not (isinstance(value, ClassDef) and value.type_params):
+        raise UseInferenceDefault
+
+    func_to_add = _extract_single_node(CLASS_GETITEM_TEMPLATE)
+    value.locals["__class_getitem__"] = [func_to_add]
+    return iter([value])
+
+
 def _looks_like_typedDict(  # pylint: disable=invalid-name
     node: FunctionDef | ClassDef,
 ) -> bool:
@@ -490,3 +512,8 @@ def register(manager: AstroidManager) -> None:
 
     if PY312_PLUS:
         register_module_extender(manager, "typing", _typing_transform)
+        manager.register_transform(
+            ClassDef,
+            inference_tip(infer_typing_generic_class_pep695),
+            _looks_like_generic_class_pep695,
+        )

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -197,7 +197,7 @@ def infer_typing_attr(
 
 
 def _looks_like_generic_class_pep695(node: ClassDef) -> bool:
-    """Check if class is uses type parameter. Python 3.12+."""
+    """Check if class is using type parameter. Python 3.12+."""
     return len(node.type_params) > 0
 
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2192,7 +2192,10 @@ class ClassDef(  # pylint: disable=too-many-instance-attributes
             and name in AstroidManager().builtins_module
         )
         if (
-            any(node == base or base.parent_of(node) for base in self.bases)
+            any(
+                node == base or base.parent_of(node) and not self.type_params
+                for base in self.bases
+            )
             or lookup_upper_frame
         ):
             # Handle the case where we have either a name

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -924,8 +924,7 @@ def generic_type_assigned_stmts(
     context: InferenceContext | None = None,
     assign_path: None = None,
 ) -> Generator[nodes.NodeNG, None, None]:
-    """Return empty generator (return -> raises StopIteration) so inferred value
-    is Uninferable.
+    """Hack. Return any Node so inference doesn't fail
+    when evaluating __class_getitem__. Replace with 'return' if it causes issues.
     """
-    return
-    yield
+    yield nodes.Const(None)

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -925,6 +925,6 @@ def generic_type_assigned_stmts(
     assign_path: None = None,
 ) -> Generator[nodes.NodeNG, None, None]:
     """Hack. Return any Node so inference doesn't fail
-    when evaluating __class_getitem__. Replace with 'return' if it causes issues.
+    when evaluating __class_getitem__. Revert if it's causing issues.
     """
     yield nodes.Const(None)

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -633,11 +633,17 @@ class TypingBrain(unittest.TestCase):
         node = builder.extract_node(
             """
         class Foo[T]: ...
+        class Bar[T](Foo[T]): ...
         """
         )
         inferred = next(node.infer())
         assert isinstance(inferred, nodes.ClassDef)
+        assert inferred.name == "Bar"
         assert isinstance(inferred.getattr("__class_getitem__")[0], nodes.FunctionDef)
+        ancestors = list(inferred.ancestors())
+        assert len(ancestors) == 2
+        assert ancestors[0].name == "Foo"
+        assert ancestors[1].name == "object"
 
     @test_utils.require_version(minver="3.9")
     def test_typing_annotated_subscriptable(self):

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -627,6 +627,18 @@ class TypingBrain(unittest.TestCase):
         assert isinstance(inferred, nodes.ClassDef)
         assert isinstance(inferred.getattr("__class_getitem__")[0], nodes.FunctionDef)
 
+    @test_utils.require_version(minver="3.12")
+    def test_typing_generic_subscriptable_pep695(self):
+        """Test class using type parameters is subscriptable with __class_getitem__ (added in PY312)"""
+        node = builder.extract_node(
+            """
+        class Foo[T]: ...
+        """
+        )
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.ClassDef)
+        assert isinstance(inferred.getattr("__class_getitem__")[0], nodes.FunctionDef)
+
     @test_utils.require_version(minver="3.9")
     def test_typing_annotated_subscriptable(self):
         """Test typing.Annotated is subscriptable with __class_getitem__"""

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -425,7 +425,10 @@ class TestGenericTypeSyntax:
         assign_stmts = extract_node("type Point[T] = tuple[float, float]")
         type_var: nodes.TypeVar = assign_stmts.type_params[0]
         assigned = next(type_var.name.assigned_stmts())
-        assert assigned is Uninferable
+        # Hack so inference doesn't fail when evaluating __class_getitem__
+        # Revert if it's causing issues.
+        assert isinstance(assigned, nodes.Const)
+        assert assigned.value is None
 
     @staticmethod
     def test_assigned_stmts_type_var_tuple():
@@ -433,7 +436,10 @@ class TestGenericTypeSyntax:
         assign_stmts = extract_node("type Alias[*Ts] = tuple[*Ts]")
         type_var_tuple: nodes.TypeVarTuple = assign_stmts.type_params[0]
         assigned = next(type_var_tuple.name.assigned_stmts())
-        assert assigned is Uninferable
+        # Hack so inference doesn't fail when evaluating __class_getitem__
+        # Revert if it's causing issues.
+        assert isinstance(assigned, nodes.Const)
+        assert assigned.value is None
 
     @staticmethod
     def test_assigned_stmts_param_spec():
@@ -441,4 +447,7 @@ class TestGenericTypeSyntax:
         assign_stmts = extract_node("type Alias[**P] = Callable[P, int]")
         param_spec: nodes.ParamSpec = assign_stmts.type_params[0]
         assigned = next(param_spec.name.assigned_stmts())
-        assert assigned is Uninferable
+        # Hack so inference doesn't fail when evaluating __class_getitem__
+        # Revert if it's causing issues.
+        assert isinstance(assigned, nodes.Const)
+        assert assigned.value is None


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Generic classes with PEP 695 should be considered subscriptable, i.e. have a `__class_getitem__` method.
```py
class Foo[T]: ...
```

Refs https://github.com/pylint-dev/pylint/issues/9406
_Will close the issue after adding some more tests in pylint._