### PR TITLE
Bump astroid to 3.2.1, update changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,9 +9,15 @@ Release date: TBA
 
 
 
-What's New in astroid 3.2.1?
+What's New in astroid 3.2.2?
 ============================
 Release date: TBA
+
+
+
+What's New in astroid 3.2.1?
+============================
+Release date: 2024-05-16
 
 * Fix ``RecursionError`` in ``infer_call_result()`` for certain ``__call__`` methods.
 
@@ -19,8 +25,8 @@ Release date: TBA
 
 * Add ``AstroidManager.prefer_stubs`` attribute to control the astroid 3.2.0 feature that prefers stubs.
 
-  Refs pylint-dev/#9626
-  Refs pylint-dev/#9623
+  Refs pylint-dev/pylint#9626
+  Refs pylint-dev/pylint#9623
 
 
 What's New in astroid 3.2.0?

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.2.0"
+__version__ = "3.2.1"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.2.0"
+current = "3.2.1"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 3.2.1?
============================
Release date: 2024-05-16

* Fix ``RecursionError`` in ``infer_call_result()`` for certain ``__call__`` methods.

  Closes pylint-dev/pylint#9139

* Add ``AstroidManager.prefer_stubs`` attribute to control the astroid 3.2.0 feature that prefers stubs.

  Refs pylint-dev/pylint#9626
  Refs pylint-dev/pylint#9623