### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12"]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
@@ -138,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12"]
     steps:
       - name: Set temp directory
         run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
@@ -192,7 +192,7 @@ jobs:
       fail-fast: false
       matrix:
         # We only test on the lowest and highest supported PyPy versions
-        python-version: ["pypy3.8", "pypy3.10"]
+        python-version: ["pypy3.9", "pypy3.10"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4.1.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: pyupgrade
         exclude: tests/testdata
-        args: [--py38-plus]
+        args: [--py39-plus]
   - repo: https://github.com/Pierre-Sassoulas/black-disable-checker/
     rev: v1.1.3
     hooks:

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,20 +7,14 @@ What's New in astroid 3.3.0?
 ============================
 Release date: TBA
 
+* Remove support for Python 3.8.
+
+  Refs #2443
 
 
 What's New in astroid 3.2.2?
 ============================
 Release date: TBA
-
-* Fix ``RecursionError`` in ``infer_call_result()`` for certain ``__call__`` methods.
-
-  Closes pylint-dev/pylint#9139
-
-* Add ``AstroidManager.prefer_stubs`` attribute to control the astroid 3.2.0 feature that prefers stubs.
-
-  Refs pylint-dev/#9626
-  Refs pylint-dev/#9623
 
 
 What's New in astroid 3.2.1?

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,7 +7,7 @@ What's New in astroid 3.3.0?
 ============================
 Release date: TBA
 
-* Remove support for Python 3.8.
+* Remove support for Python 3.8 (and constants `PY38`, `PY39_PLUS`, and `PYPY_7_3_11_PLUS`).
 
   Refs #2443
 

--- a/astroid/_backport_stdlib_names.py
+++ b/astroid/_backport_stdlib_names.py
@@ -346,11 +346,7 @@ PY_3_9 = frozenset(
     }
 )
 
-if sys.version_info[:2] == (3, 7):
-    stdlib_module_names = PY_3_7
-elif sys.version_info[:2] == (3, 8):
-    stdlib_module_names = PY_3_8
-elif sys.version_info[:2] == (3, 9):
+if sys.version_info[:2] == (3, 9):
     stdlib_module_names = PY_3_9
 else:
     raise AssertionError("This module is only intended as a backport for Python <= 3.9")

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import itertools
 from collections.abc import Callable, Iterable
 from functools import partial
-from typing import TYPE_CHECKING, Any, Iterator, NoReturn, Type, Union, cast
+from typing import TYPE_CHECKING, Any, NoReturn, Type, Union, cast
+from collections.abc import Iterator
 
 from astroid import arguments, helpers, inference_tip, nodes, objects, util
 from astroid.builder import AstroidBuilder
@@ -40,10 +41,10 @@ ContainerObjects = Union[
 ]
 
 BuiltContainers = Union[
-    Type[tuple],
-    Type[list],
-    Type[set],
-    Type[frozenset],
+    type[tuple],
+    type[list],
+    type[set],
+    type[frozenset],
 ]
 
 CopyResult = Union[

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import itertools
 from collections.abc import Callable, Iterable, Iterator
 from functools import partial
-from typing import TYPE_CHECKING, Any, NoReturn, Type, Union, cast
+from typing import TYPE_CHECKING, Any, NoReturn, Union, cast
 
 from astroid import arguments, helpers, inference_tip, nodes, objects, util
 from astroid.builder import AstroidBuilder

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -7,10 +7,9 @@
 from __future__ import annotations
 
 import itertools
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from functools import partial
 from typing import TYPE_CHECKING, Any, NoReturn, Type, Union, cast
-from collections.abc import Iterator
 
 from astroid import arguments, helpers, inference_tip, nodes, objects, util
 from astroid.builder import AstroidBuilder

--- a/astroid/brain/brain_collections.py
+++ b/astroid/brain/brain_collections.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import extract_node, parse
-from astroid.const import PY39_PLUS
 from astroid.context import InferenceContext
 from astroid.exceptions import AttributeInferenceError
 from astroid.manager import AstroidManager
@@ -61,9 +60,7 @@ def _deque_mock():
         def __iadd__(self, other): pass
         def __mul__(self, other): pass
         def __imul__(self, other): pass
-        def __rmul__(self, other): pass"""
-    if PY39_PLUS:
-        base_deque_class += """
+        def __rmul__(self, other): pass
         @classmethod
         def __class_getitem__(self, item): return cls"""
     return base_deque_class
@@ -73,9 +70,7 @@ def _ordered_dict_mock():
     base_ordered_dict_class = """
     class OrderedDict(dict):
         def __reversed__(self): return self[::-1]
-        def move_to_end(self, key, last=False): pass"""
-    if PY39_PLUS:
-        base_ordered_dict_class += """
+        def move_to_end(self, key, last=False): pass
         @classmethod
         def __class_getitem__(cls, item): return cls"""
     return base_ordered_dict_class
@@ -116,11 +111,10 @@ def easy_class_getitem_inference(node, context: InferenceContext | None = None):
 def register(manager: AstroidManager) -> None:
     register_module_extender(manager, "collections", _collections_transform)
 
-    if PY39_PLUS:
-        # Starting with Python39 some objects of the collection module are subscriptable
-        # thanks to the __class_getitem__ method but the way it is implemented in
-        # _collection_abc makes it difficult to infer. (We would have to handle AssignName inference in the
-        # getitem method of the ClassDef class) Instead we put here a mock of the __class_getitem__ method
-        manager.register_transform(
-            ClassDef, easy_class_getitem_inference, _looks_like_subscriptable
-        )
+    # Starting with Python39 some objects of the collection module are subscriptable
+    # thanks to the __class_getitem__ method but the way it is implemented in
+    # _collection_abc makes it difficult to infer. (We would have to handle AssignName inference in the
+    # getitem method of the ClassDef class) Instead we put here a mock of the __class_getitem__ method
+    manager.register_transform(
+        ClassDef, easy_class_getitem_inference, _looks_like_subscriptable
+    )

--- a/astroid/brain/brain_hashlib.py
+++ b/astroid/brain/brain_hashlib.py
@@ -8,8 +8,7 @@ from astroid.manager import AstroidManager
 
 
 def _hashlib_transform():
-    maybe_usedforsecurity = ", usedforsecurity=True"
-    init_signature = f"value=''{maybe_usedforsecurity}"
+    init_signature = "value='', usedforsecurity=True"
     digest_signature = "self"
     shake_digest_signature = "self, length"
 
@@ -53,13 +52,13 @@ def _hashlib_transform():
     blake2b_signature = (
         "data=b'', *, digest_size=64, key=b'', salt=b'', "
         "person=b'', fanout=1, depth=1, leaf_size=0, node_offset=0, "
-        f"node_depth=0, inner_size=0, last_node=False{maybe_usedforsecurity}"
+        "node_depth=0, inner_size=0, last_node=False, usedforsecurity=True"
     )
 
     blake2s_signature = (
         "data=b'', *, digest_size=32, key=b'', salt=b'', "
         "person=b'', fanout=1, depth=1, leaf_size=0, node_offset=0, "
-        f"node_depth=0, inner_size=0, last_node=False{maybe_usedforsecurity}"
+        "node_depth=0, inner_size=0, last_node=False, usedforsecurity=True"
     )
 
     shake_algorithms = dict.fromkeys(

--- a/astroid/brain/brain_hashlib.py
+++ b/astroid/brain/brain_hashlib.py
@@ -4,12 +4,11 @@
 
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.const import PY39_PLUS
 from astroid.manager import AstroidManager
 
 
 def _hashlib_transform():
-    maybe_usedforsecurity = ", usedforsecurity=True" if PY39_PLUS else ""
+    maybe_usedforsecurity = ", usedforsecurity=True"
     init_signature = f"value=''{maybe_usedforsecurity}"
     digest_signature = "self"
     shake_digest_signature = "self, length"

--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from astroid import context, inference_tip, nodes
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import _extract_single_node, parse
-from astroid.const import PY39_PLUS, PY311_PLUS
+from astroid.const import PY311_PLUS
 from astroid.manager import AstroidManager
 
 
@@ -84,9 +84,8 @@ def infer_pattern_match(node: nodes.Call, ctx: context.InferenceContext | None =
         end_lineno=node.end_lineno,
         end_col_offset=node.end_col_offset,
     )
-    if PY39_PLUS:
-        func_to_add = _extract_single_node(CLASS_GETITEM_TEMPLATE)
-        class_def.locals["__class_getitem__"] = [func_to_add]
+    func_to_add = _extract_single_node(CLASS_GETITEM_TEMPLATE)
+    class_def.locals["__class_getitem__"] = [func_to_add]
     return iter([class_def])
 
 

--- a/astroid/brain/brain_regex.py
+++ b/astroid/brain/brain_regex.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from astroid import context, inference_tip, nodes
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import _extract_single_node, parse
-from astroid.const import PY39_PLUS
 from astroid.manager import AstroidManager
 
 
@@ -83,9 +82,8 @@ def infer_pattern_match(node: nodes.Call, ctx: context.InferenceContext | None =
         end_lineno=node.end_lineno,
         end_col_offset=node.end_col_offset,
     )
-    if PY39_PLUS:
-        func_to_add = _extract_single_node(CLASS_GETITEM_TEMPLATE)
-        class_def.locals["__class_getitem__"] = [func_to_add]
+    func_to_add = _extract_single_node(CLASS_GETITEM_TEMPLATE)
+    class_def.locals["__class_getitem__"] = [func_to_add]
     return iter([class_def])
 
 

--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -6,7 +6,7 @@ import textwrap
 
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.const import PY39_PLUS, PY310_PLUS, PY311_PLUS
+from astroid.const import PY310_PLUS, PY311_PLUS
 from astroid.manager import AstroidManager
 
 
@@ -17,10 +17,9 @@ def _subprocess_transform():
         self, args, bufsize=-1, executable=None, stdin=None, stdout=None, stderr=None,
         preexec_fn=None, close_fds=True, shell=False, cwd=None, env=None,
         universal_newlines=None, startupinfo=None, creationflags=0, restore_signals=True,
-        start_new_session=False, pass_fds=(), *, encoding=None, errors=None, text=None"""
+        start_new_session=False, pass_fds=(), *, encoding=None, errors=None, text=None,
+        user=None, group=None, extra_groups=None, umask=-1"""
 
-    if PY39_PLUS:
-        args += ", user=None, group=None, extra_groups=None, umask=-1"
     if PY310_PLUS:
         args += ", pipesize=-1"
     if PY311_PLUS:
@@ -89,8 +88,7 @@ def _subprocess_transform():
         {ctx_manager}
        """
     )
-    if PY39_PLUS:
-        code += """
+    code += """
     @classmethod
     def __class_getitem__(cls, item):
         pass

--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -86,13 +86,11 @@ def _subprocess_transform():
         def kill(self):
             pass
         {ctx_manager}
-       """
-    )
-    code += """
-    @classmethod
-    def __class_getitem__(cls, item):
-        pass
+        @classmethod
+        def __class_getitem__(cls, item):
+            pass
         """
+    )
 
     init_lines = textwrap.dedent(init).splitlines()
     indented_init = "\n".join(" " * 4 + line for line in init_lines)

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -23,7 +23,6 @@ Thanks to Lukasz Langa for fruitful discussion.
 from __future__ import annotations
 
 from astroid import extract_node, inference_tip, nodes
-from astroid.const import PY39_PLUS
 from astroid.context import InferenceContext
 from astroid.exceptions import UseInferenceDefault
 from astroid.manager import AstroidManager
@@ -64,7 +63,6 @@ def infer_type_sub(node, context: InferenceContext | None = None):
 
 
 def register(manager: AstroidManager) -> None:
-    if PY39_PLUS:
-        manager.register_transform(
-            nodes.Name, inference_tip(infer_type_sub), _looks_like_type_subscript
-        )
+    manager.register_transform(
+        nodes.Name, inference_tip(infer_type_sub), _looks_like_type_subscript
+    )

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -15,7 +15,7 @@ from typing import Final
 from astroid import context, extract_node, inference_tip
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder, _extract_single_node
-from astroid.const import PY39_PLUS, PY312_PLUS
+from astroid.const import PY312_PLUS
 from astroid.exceptions import (
     AstroidSyntaxError,
     AttributeInferenceError,
@@ -33,7 +33,6 @@ from astroid.nodes.node_classes import (
     Name,
     NodeNG,
     Subscript,
-    Tuple,
 )
 from astroid.nodes.scoped_nodes import ClassDef, FunctionDef
 
@@ -314,13 +313,7 @@ def infer_typing_alias(
         class_def.postinit(bases=[res], body=[], decorators=None)
 
     maybe_type_var = node.args[1]
-    if (
-        not PY39_PLUS
-        and not (isinstance(maybe_type_var, Tuple) and not maybe_type_var.elts)
-        or PY39_PLUS
-        and isinstance(maybe_type_var, Const)
-        and maybe_type_var.value > 0
-    ):
+    if isinstance(maybe_type_var, Const) and maybe_type_var.value > 0:
         # If typing alias is subscriptable, add `__class_getitem__` to ClassDef
         func_to_add = _extract_single_node(CLASS_GETITEM_TEMPLATE)
         class_def.locals["__class_getitem__"] = [func_to_add]
@@ -348,23 +341,12 @@ def _looks_like_special_alias(node: Call) -> bool:
     PY39: Callable = _CallableType(collections.abc.Callable, 2)
     """
     return isinstance(node.func, Name) and (
-        not PY39_PLUS
-        and node.func.name == "_VariadicGenericAlias"
-        and (
-            isinstance(node.args[0], Name)
-            and node.args[0].name == "tuple"
-            or isinstance(node.args[0], Attribute)
-            and node.args[0].as_string() == "collections.abc.Callable"
-        )
-        or PY39_PLUS
-        and (
-            node.func.name == "_TupleType"
-            and isinstance(node.args[0], Name)
-            and node.args[0].name == "tuple"
-            or node.func.name == "_CallableType"
-            and isinstance(node.args[0], Attribute)
-            and node.args[0].as_string() == "collections.abc.Callable"
-        )
+        node.func.name == "_TupleType"
+        and isinstance(node.args[0], Name)
+        and node.args[0].name == "tuple"
+        or node.func.name == "_CallableType"
+        and isinstance(node.args[0], Attribute)
+        and node.args[0].as_string() == "collections.abc.Callable"
     )
 
 
@@ -472,14 +454,9 @@ def register(manager: AstroidManager) -> None:
         Call, inference_tip(infer_typing_cast), _looks_like_typing_cast
     )
 
-    if PY39_PLUS:
-        manager.register_transform(
-            FunctionDef, inference_tip(infer_typedDict), _looks_like_typedDict
-        )
-    else:
-        manager.register_transform(
-            ClassDef, inference_tip(infer_old_typedDict), _looks_like_typedDict
-        )
+    manager.register_transform(
+        FunctionDef, inference_tip(infer_typedDict), _looks_like_typedDict
+    )
 
     manager.register_transform(
         Call, inference_tip(infer_typing_alias), _looks_like_typing_alias

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -202,14 +202,6 @@ def _looks_like_typedDict(  # pylint: disable=invalid-name
     return node.qname() in TYPING_TYPEDDICT_QUALIFIED
 
 
-def infer_old_typedDict(  # pylint: disable=invalid-name
-    node: ClassDef, ctx: context.InferenceContext | None = None
-) -> Iterator[ClassDef]:
-    func_to_add = _extract_single_node("dict")
-    node.locals["__call__"] = [func_to_add]
-    return iter([node])
-
-
 def infer_typedDict(  # pylint: disable=invalid-name
     node: FunctionDef, ctx: context.InferenceContext | None = None
 ) -> Iterator[ClassDef]:

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -5,8 +5,6 @@
 import enum
 import sys
 
-PY38 = sys.version_info[:2] == (3, 8)
-PY39_PLUS = sys.version_info >= (3, 9)
 PY310_PLUS = sys.version_info >= (3, 10)
 PY311_PLUS = sys.version_info >= (3, 11)
 PY312_PLUS = sys.version_info >= (3, 12)
@@ -16,9 +14,6 @@ WIN32 = sys.platform == "win32"
 
 IS_PYPY = sys.implementation.name == "pypy"
 IS_JYTHON = sys.implementation.name == "jython"
-
-# pylint: disable-next=no-member
-PYPY_7_3_11_PLUS = IS_PYPY and sys.pypy_version_info >= (7, 3, 11)  # type: ignore[attr-defined]
 
 
 class Context(enum.Enum):

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import contextlib
 import pprint
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Optional
 
 from astroid.typing import InferenceResult, SuccessfulInferenceResult
 

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 
 import contextlib
 import pprint
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Dict, Optional, Tuple
-from collections.abc import Sequence
 
 from astroid.typing import InferenceResult, SuccessfulInferenceResult
 

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import contextlib
 import pprint
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
+from collections.abc import Sequence
 
 from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
@@ -17,8 +18,8 @@ if TYPE_CHECKING:
     from astroid import constraint, nodes
     from astroid.nodes.node_classes import Keyword, NodeNG
 
-_InferenceCache = Dict[
-    Tuple["NodeNG", Optional[str], Optional[str], Optional[str]], Sequence["NodeNG"]
+_InferenceCache = dict[
+    tuple["NodeNG", Optional[str], Optional[str], Optional[str]], Sequence["NodeNG"]
 ]
 
 _INFERENCE_CACHE: _InferenceCache = {}

--- a/astroid/nodes/_base_nodes.py
+++ b/astroid/nodes/_base_nodes.py
@@ -10,9 +10,9 @@ Previously these were called Mixin nodes.
 from __future__ import annotations
 
 import itertools
-from collections.abc import Generator, Iterator
+from collections.abc import Callable, Generator, Iterator
 from functools import cached_property, lru_cache, partial
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union
 
 from astroid import bases, nodes, util
 from astroid.const import PY310_PLUS

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -13,12 +13,11 @@ import operator
 import sys
 import typing
 import warnings
-from collections.abc import Generator, Iterable, Iterator, Mapping
+from collections.abc import Callable, Generator, Iterable, Iterator, Mapping
 from functools import cached_property
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     ClassVar,
     Literal,
     Optional,
@@ -83,11 +82,11 @@ AssignedStmtsCall = Callable[
 ]
 InferBinaryOperation = Callable[
     [_NodesT, Optional[InferenceContext]],
-    typing.Generator[Union[InferenceResult, _BadOpMessageT], None, None],
+    Generator[Union[InferenceResult, _BadOpMessageT], None, None],
 ]
 InferLHS = Callable[
     [_NodesT, Optional[InferenceContext]],
-    typing.Generator[InferenceResult, None, Optional[InferenceErrorInfo]],
+    Generator[InferenceResult, None, Optional[InferenceErrorInfo]],
 ]
 InferUnaryOp = Callable[[_NodesT, str], ConstFactoryResult]
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -77,7 +77,7 @@ AssignedStmtsCall = Callable[
         _NodesT,
         AssignedStmtsPossibleNode,
         Optional[InferenceContext],
-        Optional[typing.List[int]],
+        Optional[list[int]],
     ],
     Any,
 ]

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 _NodesT = TypeVar("_NodesT", bound="NodeNG")
 _NodesT2 = TypeVar("_NodesT2", bound="NodeNG")
 _NodesT3 = TypeVar("_NodesT3", bound="NodeNG")
-SkipKlassT = Union[None, Type["NodeNG"], Tuple[Type["NodeNG"], ...]]
+SkipKlassT = Union[None, type["NodeNG"], tuple[type["NodeNG"], ...]]
 
 
 class NodeNG:

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -15,8 +15,6 @@ from typing import (
     Any,
     ClassVar,
     Literal,
-    Tuple,
-    Type,
     TypeVar,
     Union,
     cast,

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -19,7 +19,7 @@ from functools import cached_property, lru_cache
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, NoReturn, TypeVar
 
 from astroid import bases, protocols, util
-from astroid.const import IS_PYPY, PY38, PY39_PLUS, PYPY_7_3_11_PLUS
+from astroid.const import IS_PYPY
 from astroid.context import (
     CallContext,
     InferenceContext,
@@ -2007,7 +2007,7 @@ class ClassDef(  # pylint: disable=too-many-instance-attributes
 
         Can also return 0 if the line can not be determined.
         """
-        if IS_PYPY and PY38 and not PYPY_7_3_11_PLUS:
+        if IS_PYPY:
             # For Python < 3.8 the lineno is the line number of the first decorator.
             # We want the class statement lineno. Similar to 'FunctionDef.fromlineno'
             # PyPy (3.8): Fixed with version v7.3.11
@@ -2635,7 +2635,6 @@ class ClassDef(  # pylint: disable=too-many-instance-attributes
             if (
                 isinstance(method, node_classes.EmptyNode)
                 and self.pytype() == "builtins.type"
-                and PY39_PLUS
             ):
                 return self
             raise

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -19,7 +19,6 @@ from functools import cached_property, lru_cache
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, NoReturn, TypeVar
 
 from astroid import bases, protocols, util
-from astroid.const import IS_PYPY
 from astroid.context import (
     CallContext,
     InferenceContext,
@@ -2000,26 +1999,6 @@ class ClassDef(  # pylint: disable=too-many-instance-attributes
         _newstyle_impl,
         doc=("Whether this is a new style class or not\n\n" ":type: bool or None"),
     )
-
-    @cached_property
-    def fromlineno(self) -> int:
-        """The first line that this node appears on in the source code.
-
-        Can also return 0 if the line can not be determined.
-        """
-        if IS_PYPY:
-            # For Python < 3.8 the lineno is the line number of the first decorator.
-            # We want the class statement lineno. Similar to 'FunctionDef.fromlineno'
-            # PyPy (3.8): Fixed with version v7.3.11
-            lineno = self.lineno or 0
-            if self.decorators is not None:
-                lineno += sum(
-                    node.tolineno - (node.lineno or 0) + 1
-                    for node in self.decorators.nodes
-                )
-
-            return lineno or 0
-        return super().fromlineno
 
     @cached_property
     def blockstart_tolineno(self):

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -557,9 +557,10 @@ class InspectBuilder:
             # check if it sounds valid and then add an import node, else use a
             # dummy node
             try:
-                with redirect_stderr(io.StringIO()) as stderr, redirect_stdout(
-                    io.StringIO()
-                ) as stdout:
+                with (
+                    redirect_stderr(io.StringIO()) as stderr,
+                    redirect_stdout(io.StringIO()) as stdout,
+                ):
                     getattr(sys.modules[modname], name)
                     stderr_value = stderr.getvalue()
                     if stderr_value:

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1004,11 +1004,9 @@ class TreeRebuilder:
         self, cls: type[_ForT], node: ast.For | ast.AsyncFor, parent: NodeNG
     ) -> _ForT:
         """Visit a For node by returning a fresh instance of it."""
-        col_offset = node.col_offset
-
         newnode = cls(
             lineno=node.lineno,
-            col_offset=col_offset,
+            col_offset=node.col_offset,
             end_lineno=node.end_lineno,
             end_col_offset=node.end_col_offset,
             parent=parent,
@@ -1671,11 +1669,9 @@ class TreeRebuilder:
         node: ast.With | ast.AsyncWith,
         parent: NodeNG,
     ) -> _WithT:
-        col_offset = node.col_offset
-
         newnode = cls(
             lineno=node.lineno,
-            col_offset=col_offset,
+            col_offset=node.col_offset,
             end_lineno=node.end_lineno,
             end_col_offset=node.end_col_offset,
             parent=parent,

--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -21,12 +21,12 @@ if TYPE_CHECKING:
     _Predicate = Optional[Callable[[_SuccessfulInferenceResultT], bool]]
 
 _Vistables = Union[
-    "nodes.NodeNG", List["nodes.NodeNG"], Tuple["nodes.NodeNG", ...], str, None
+    "nodes.NodeNG", list["nodes.NodeNG"], tuple["nodes.NodeNG", ...], str, None
 ]
 _VisitReturns = Union[
     SuccessfulInferenceResult,
-    List[SuccessfulInferenceResult],
-    Tuple[SuccessfulInferenceResult, ...],
+    list[SuccessfulInferenceResult],
+    tuple[SuccessfulInferenceResult, ...],
     str,
     None,
 ]

--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import warnings
 from collections import defaultdict
 from collections.abc import Callable
-from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Optional, TypeVar, Union, cast, overload
 
 from astroid.context import _invalidate_cache
 from astroid.typing import SuccessfulInferenceResult, TransformFn

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -14,7 +15,6 @@ from typing import (
     TypeVar,
     Union,
 )
-from collections.abc import Generator
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -4,11 +4,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Generic,
     Protocol,
     TypedDict,

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -8,13 +8,13 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Generator,
     Generic,
     Protocol,
     TypedDict,
     TypeVar,
     Union,
 )
+from collections.abc import Generator
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/pylintrc
+++ b/pylintrc
@@ -39,7 +39,7 @@ unsafe-load-any-extension=no
 extension-pkg-whitelist=
 
 # Minimum supported python version
-py-version = 3.8.0
+py-version = 3.9.0
 
 
 [REPORTS]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -28,7 +27,7 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
     "Topic :: Software Development :: Testing",
 ]
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dependencies = [
     "typing-extensions>=4.0.0;python_version<'3.11'",
 ]
@@ -83,7 +82,7 @@ ignore_missing_imports = true
 
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 
 # ruff is less lenient than pylint and does not make any exceptions
 # (for docstrings, strings and comments in particular).

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -51,13 +51,6 @@ class CollectionsDequeTests(unittest.TestCase):
         self.assertIn("insert", inferred.locals)
         self.assertIn("index", inferred.locals)
 
-    @test_utils.require_version(maxver="3.8")
-    def test_deque_not_py39methods(self):
-        inferred = self._inferred_queue_instance()
-        with self.assertRaises(AttributeInferenceError):
-            inferred.getattr("__class_getitem__")
-
-    @test_utils.require_version(minver="3.9")
     def test_deque_py39methods(self):
         inferred = self._inferred_queue_instance()
         self.assertTrue(inferred.getattr("__class_getitem__"))
@@ -172,7 +165,6 @@ class TypeBrain(unittest.TestCase):
             # noinspection PyStatementEffect
             val_inf.getattr("__class_getitem__")[0]
 
-    @test_utils.require_version(minver="3.9")
     def test_builtin_subscriptable(self):
         """Starting with python3.9 builtin types such as list are subscriptable.
         Any builtin class such as "enumerate" or "staticmethod" also works."""
@@ -231,7 +223,6 @@ class CollectionsBrain(unittest.TestCase):
         with self.assertRaises(AttributeInferenceError):
             inferred.getattr("__class_getitem__")
 
-    @test_utils.require_version(minver="3.9")
     def test_collections_object_subscriptable(self):
         """Starting with python39 some object of collections module are subscriptable. Test one of them"""
         right_node = builder.extract_node(
@@ -295,7 +286,6 @@ class CollectionsBrain(unittest.TestCase):
         with self.assertRaises(AttributeInferenceError):
             inferred.getattr("__class_getitem__")
 
-    @test_utils.require_version(minver="3.9")
     def test_collections_object_subscriptable_2(self):
         """Starting with python39 Iterator in the collection.abc module is subscriptable"""
         node = builder.extract_node(
@@ -329,7 +319,6 @@ class CollectionsBrain(unittest.TestCase):
         with self.assertRaises(InferenceError):
             next(node.infer())
 
-    @test_utils.require_version(minver="3.9")
     def test_collections_object_subscriptable_3(self):
         """With Python 3.9 the ByteString class of the collections module is subscriptable
         (but not the same class from typing module)"""
@@ -345,7 +334,6 @@ class CollectionsBrain(unittest.TestCase):
             inferred.getattr("__class_getitem__")[0], nodes.FunctionDef
         )
 
-    @test_utils.require_version(minver="3.9")
     def test_collections_object_subscriptable_4(self):
         """Multiple inheritance with subscriptable collection class"""
         node = builder.extract_node(
@@ -627,7 +615,6 @@ class TypingBrain(unittest.TestCase):
         assert isinstance(inferred, nodes.ClassDef)
         assert isinstance(inferred.getattr("__class_getitem__")[0], nodes.FunctionDef)
 
-    @test_utils.require_version(minver="3.9")
     def test_typing_annotated_subscriptable(self):
         """Test typing.Annotated is subscriptable with __class_getitem__"""
         node = builder.extract_node(
@@ -658,7 +645,6 @@ class TypingBrain(unittest.TestCase):
         assert isinstance(slots[0], nodes.Const)
         assert slots[0].value == "value"
 
-    @test_utils.require_version(minver="3.9")
     def test_typing_no_duplicates(self):
         node = builder.extract_node(
             """
@@ -668,7 +654,6 @@ class TypingBrain(unittest.TestCase):
         )
         assert len(node.inferred()) == 1
 
-    @test_utils.require_version(minver="3.9")
     def test_typing_no_duplicates_2(self):
         node = builder.extract_node(
             """
@@ -735,7 +720,6 @@ class TypingBrain(unittest.TestCase):
         inferred = next(node.infer())
         self.assertIsInstance(inferred, astroid.Instance)
 
-    @test_utils.require_version("3.8")
     def test_typed_dict(self):
         code = builder.extract_node(
             """
@@ -911,7 +895,6 @@ class TypingBrain(unittest.TestCase):
                 inferred.getattr("__class_getitem__")[0], nodes.FunctionDef
             )
 
-    @test_utils.require_version(minver="3.9")
     def test_typing_object_builtin_subscriptable(self):
         """
         Test that builtins alias, such as typing.List, are subscriptable
@@ -927,7 +910,6 @@ class TypingBrain(unittest.TestCase):
             self.assertIsInstance(inferred.getattr("__iter__")[0], nodes.FunctionDef)
 
     @staticmethod
-    @test_utils.require_version(minver="3.9")
     def test_typing_type_subscriptable():
         node = builder.extract_node(
             """
@@ -1049,7 +1031,6 @@ class ReBrainTest(unittest.TestCase):
         with self.assertRaises(InferenceError):
             next(wrong_node2.infer())
 
-    @test_utils.require_version(minver="3.9")
     def test_re_pattern_subscriptable(self):
         """Test re.Pattern and re.Match are subscriptable in PY39+"""
         node1 = builder.extract_node(

--- a/tests/brain/test_hashlib.py
+++ b/tests/brain/test_hashlib.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import unittest
 
 from astroid import MANAGER
-from astroid.const import PY39_PLUS
 from astroid.nodes.scoped_nodes import ClassDef
 
 
@@ -19,10 +18,8 @@ class HashlibTest(unittest.TestCase):
         self.assertIn("block_size", class_obj)
         self.assertIn("digest_size", class_obj)
         # usedforsecurity was added in Python 3.9, see 8e7174a9
-        self.assertEqual(len(class_obj["__init__"].args.args), 3 if PY39_PLUS else 2)
-        self.assertEqual(
-            len(class_obj["__init__"].args.defaults), 2 if PY39_PLUS else 1
-        )
+        self.assertEqual(len(class_obj["__init__"].args.args), 3)
+        self.assertEqual(len(class_obj["__init__"].args.defaults), 2)
         self.assertEqual(len(class_obj["update"].args.args), 2)
 
     def test_hashlib(self) -> None:

--- a/tests/brain/test_regex.py
+++ b/tests/brain/test_regex.py
@@ -11,7 +11,7 @@ except ImportError:
 
 import pytest
 
-from astroid import MANAGER, builder, nodes, test_utils
+from astroid import MANAGER, builder, nodes
 
 
 @pytest.mark.skipif(not HAS_REGEX, reason="This test requires the regex library.")
@@ -27,7 +27,6 @@ class TestRegexBrain:
     @pytest.mark.xfail(
         reason="Started failing on main, but no one reproduced locally yet"
     )
-    @test_utils.require_version(minver="3.9")
     def test_regex_pattern_and_match_subscriptable(self):
         """Test regex.Pattern and regex.Match are subscriptable in PY39+."""
         node1 = builder.extract_node(

--- a/tests/brain/test_unittest.py
+++ b/tests/brain/test_unittest.py
@@ -5,13 +5,11 @@
 import unittest
 
 from astroid import builder
-from astroid.test_utils import require_version
 
 
 class UnittestTest(unittest.TestCase):
     """A class that tests the brain_unittest module."""
 
-    @require_version(minver="3.8.0")
     def test_isolatedasynciotestcase(self):
         """
         Tests that the IsolatedAsyncioTestCase class is statically imported

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -19,7 +19,7 @@ import unittest.mock
 import pytest
 
 from astroid import Instance, builder, nodes, test_utils, util
-from astroid.const import IS_PYPY, PY38, PY39_PLUS, PYPY_7_3_11_PLUS
+from astroid.const import IS_PYPY
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidSyntaxError,
@@ -57,10 +57,7 @@ class FromToLineNoTest(unittest.TestCase):
         self.assertIsInstance(strarg, nodes.Const)
         if IS_PYPY:
             self.assertEqual(strarg.fromlineno, 4)
-            if not PY39_PLUS:
-                self.assertEqual(strarg.tolineno, 4)
-            else:
-                self.assertEqual(strarg.tolineno, 5)
+            self.assertEqual(strarg.tolineno, 5)
         else:
             self.assertEqual(strarg.fromlineno, 4)
             self.assertEqual(strarg.tolineno, 5)
@@ -157,7 +154,7 @@ class FromToLineNoTest(unittest.TestCase):
 
         c = ast_module.body[2]
         assert isinstance(c, nodes.ClassDef)
-        if IS_PYPY and PY38 and not PYPY_7_3_11_PLUS:
+        if IS_PYPY:
             # Not perfect, but best we can do for PyPy 3.8 (< v7.3.11).
             # Can't detect closing bracket on new line.
             assert c.fromlineno == 12

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -154,12 +154,7 @@ class FromToLineNoTest(unittest.TestCase):
 
         c = ast_module.body[2]
         assert isinstance(c, nodes.ClassDef)
-        if IS_PYPY:
-            # Not perfect, but best we can do for PyPy 3.8 (< v7.3.11).
-            # Can't detect closing bracket on new line.
-            assert c.fromlineno == 12
-        else:
-            assert c.fromlineno == 13
+        assert c.fromlineno == 13
         assert c.tolineno == 14
 
     @staticmethod

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -6,7 +6,7 @@
 import functools
 import unittest
 
-from astroid import builder, nodes, test_utils
+from astroid import builder, nodes
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
@@ -789,7 +789,6 @@ class LookupControlFlowTest(unittest.TestCase):
         self.assertEqual(len(stmts2), 1)
         self.assertEqual(stmts2[0].lineno, 7)
 
-    @test_utils.require_version(minver="3.8")
     def test_assign_after_posonly_param(self):
         """When an assignment statement overwrites a function positional-only parameter,
         only the assignment is returned, even when the variable and assignment do

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -25,7 +25,6 @@ from astroid import (
     extract_node,
     nodes,
     parse,
-    test_utils,
     transforms,
     util,
 )
@@ -892,7 +891,6 @@ class ArgumentsNodeTC(unittest.TestCase):
         assert isinstance(args.kw_defaults[0], nodes.Const)
         assert args.kw_defaults[0].value == "default"
 
-    @test_utils.require_version(minver="3.8")
     def test_positional_only(self):
         ast = builder.parse(
             """
@@ -1630,7 +1628,6 @@ def test_get_doc() -> None:
     assert node.doc_node is None
 
 
-@test_utils.require_version(minver="3.8")
 def test_parse_fstring_debug_mode() -> None:
     node = astroid.extract_node('f"{3=}"')
     assert isinstance(node, nodes.JoinedStr)

--- a/tests/test_nodes_lineno.py
+++ b/tests/test_nodes_lineno.py
@@ -8,40 +8,9 @@ import pytest
 
 import astroid
 from astroid import builder, nodes
-from astroid.const import IS_PYPY, PY310_PLUS, PY312_PLUS
+from astroid.const import PY310_PLUS, PY312_PLUS
 
 
-@pytest.mark.skipif(
-    not IS_PYPY, reason="end_lineno and end_col_offset were added in PY38"
-)
-class TestEndLinenoNotSet:
-    """Test 'end_lineno' and 'end_col_offset' are initialized as 'None' for Python <
-    3.8.
-    """
-
-    @staticmethod
-    def test_end_lineno_not_set() -> None:
-        code = textwrap.dedent(
-            """
-        [1, 2, 3]  #@
-        var  #@
-        """
-        ).strip()
-        ast_nodes = builder.extract_node(code)
-        assert isinstance(ast_nodes, list) and len(ast_nodes) == 2
-
-        n1 = ast_nodes[0]
-        assert isinstance(n1, nodes.List)
-        assert (n1.lineno, n1.col_offset) == (1, 0)
-        assert (n1.end_lineno, n1.end_col_offset) == (None, None)
-
-        n2 = ast_nodes[1]
-        assert isinstance(n2, nodes.Name)
-        assert (n2.lineno, n2.col_offset) == (2, 0)
-        assert (n2.end_lineno, n2.end_col_offset) == (None, None)
-
-
-@pytest.mark.skipif(IS_PYPY, reason="end_lineno and end_col_offset were added in PY38")
 class TestLinenoColOffset:
     """Test 'lineno', 'col_offset', 'end_lineno', and 'end_col_offset' for all
     nodes.

--- a/tests/test_nodes_lineno.py
+++ b/tests/test_nodes_lineno.py
@@ -165,7 +165,6 @@ class TestLinenoColOffset:
         assert (c1.args[0].end_lineno, c1.args[0].end_col_offset) == (1, 9)
 
         # fmt: off
-        # 'lineno' and 'col_offset' information only added in Python 3.9
         assert (c1.keywords[0].lineno, c1.keywords[0].col_offset) == (1, 11)
         assert (c1.keywords[0].end_lineno, c1.keywords[0].end_col_offset) == (1, 21)
         assert (c1.keywords[0].value.lineno, c1.keywords[0].value.col_offset) == (1, 16)
@@ -803,7 +802,6 @@ class TestLinenoColOffset:
         assert isinstance(s3.slice, nodes.Tuple)
         assert (s3.lineno, s3.col_offset) == (3, 0)
         assert (s3.end_lineno, s3.end_col_offset) == (3, 11)
-        # 'lineno' and 'col_offset' information only added in Python 3.9
         assert (s3.slice.lineno, s3.slice.col_offset) == (3, 4)
         assert (s3.slice.end_lineno, s3.slice.end_col_offset) == (3, 10)
 
@@ -1191,7 +1189,6 @@ class TestLinenoColOffset:
         assert (c1.decorators.end_lineno, c1.decorators.end_col_offset) == (2, 11)
         assert (c1.bases[0].lineno, c1.bases[0].col_offset) == (3, 8)
         assert (c1.bases[0].end_lineno, c1.bases[0].end_col_offset) == (3, 14)
-        # 'lineno' and 'col_offset' information only added in Python 3.9
         assert (c1.keywords[0].lineno, c1.keywords[0].col_offset) == (3, 16)
         assert (c1.keywords[0].end_lineno, c1.keywords[0].end_col_offset) == (3, 22)
         assert (c1.body[0].lineno, c1.body[0].col_offset) == (4, 4)

--- a/tests/test_nodes_lineno.py
+++ b/tests/test_nodes_lineno.py
@@ -8,12 +8,11 @@ import pytest
 
 import astroid
 from astroid import builder, nodes
-from astroid.const import IS_PYPY, PY38, PY39_PLUS, PY310_PLUS, PY312_PLUS
+from astroid.const import IS_PYPY, PY310_PLUS, PY312_PLUS
 
 
 @pytest.mark.skipif(
-    not (PY38 and IS_PYPY),
-    reason="end_lineno and end_col_offset were added in PY38",
+    not IS_PYPY, reason="end_lineno and end_col_offset were added in PY38"
 )
 class TestEndLinenoNotSet:
     """Test 'end_lineno' and 'end_col_offset' are initialized as 'None' for Python <
@@ -42,10 +41,7 @@ class TestEndLinenoNotSet:
         assert (n2.end_lineno, n2.end_col_offset) == (None, None)
 
 
-@pytest.mark.skipif(
-    PY38 and IS_PYPY,
-    reason="end_lineno and end_col_offset were added in PY38",
-)
+@pytest.mark.skipif(IS_PYPY, reason="end_lineno and end_col_offset were added in PY38")
 class TestLinenoColOffset:
     """Test 'lineno', 'col_offset', 'end_lineno', and 'end_col_offset' for all
     nodes.
@@ -200,13 +196,9 @@ class TestLinenoColOffset:
         assert (c1.args[0].end_lineno, c1.args[0].end_col_offset) == (1, 9)
 
         # fmt: off
-        if PY39_PLUS:
-            # 'lineno' and 'col_offset' information only added in Python 3.9
-            assert (c1.keywords[0].lineno, c1.keywords[0].col_offset) == (1, 11)
-            assert (c1.keywords[0].end_lineno, c1.keywords[0].end_col_offset) == (1, 21)
-        else:
-            assert (c1.keywords[0].lineno, c1.keywords[0].col_offset) == (None, None)
-            assert (c1.keywords[0].end_lineno, c1.keywords[0].end_col_offset) == (None, None)
+        # 'lineno' and 'col_offset' information only added in Python 3.9
+        assert (c1.keywords[0].lineno, c1.keywords[0].col_offset) == (1, 11)
+        assert (c1.keywords[0].end_lineno, c1.keywords[0].end_col_offset) == (1, 21)
         assert (c1.keywords[0].value.lineno, c1.keywords[0].value.col_offset) == (1, 16)
         assert (c1.keywords[0].value.end_lineno, c1.keywords[0].value.end_col_offset) == (1, 21)
         # fmt: on
@@ -842,13 +834,9 @@ class TestLinenoColOffset:
         assert isinstance(s3.slice, nodes.Tuple)
         assert (s3.lineno, s3.col_offset) == (3, 0)
         assert (s3.end_lineno, s3.end_col_offset) == (3, 11)
-        if PY39_PLUS:
-            # 'lineno' and 'col_offset' information only added in Python 3.9
-            assert (s3.slice.lineno, s3.slice.col_offset) == (3, 4)
-            assert (s3.slice.end_lineno, s3.slice.end_col_offset) == (3, 10)
-        else:
-            assert (s3.slice.lineno, s3.slice.col_offset) == (None, None)
-            assert (s3.slice.end_lineno, s3.slice.end_col_offset) == (None, None)
+        # 'lineno' and 'col_offset' information only added in Python 3.9
+        assert (s3.slice.lineno, s3.slice.col_offset) == (3, 4)
+        assert (s3.slice.end_lineno, s3.slice.end_col_offset) == (3, 10)
 
     @staticmethod
     def test_end_lineno_import() -> None:
@@ -995,14 +983,8 @@ class TestLinenoColOffset:
             assert (s2.end_lineno, s2.end_col_offset) == (1, 29)
 
         assert isinstance(s2.value, nodes.Const)  # 42.1234
-        if PY39_PLUS:
-            assert (s2.value.lineno, s2.value.col_offset) == (1, 16)
-            assert (s2.value.end_lineno, s2.value.end_col_offset) == (1, 23)
-        else:
-            # Bug in Python 3.8
-            # https://bugs.python.org/issue44885
-            assert (s2.value.lineno, s2.value.col_offset) == (1, 1)
-            assert (s2.value.end_lineno, s2.value.end_col_offset) == (1, 8)
+        assert (s2.value.lineno, s2.value.col_offset) == (1, 16)
+        assert (s2.value.end_lineno, s2.value.end_col_offset) == (1, 23)
         assert isinstance(s2.format_spec, nodes.JoinedStr)  # ':02d'
         if PY312_PLUS:
             assert (s2.format_spec.lineno, s2.format_spec.col_offset) == (1, 23)
@@ -1033,14 +1015,8 @@ class TestLinenoColOffset:
             assert (s4.end_lineno, s4.end_col_offset) == (2, 17)
 
         assert isinstance(s4.value, nodes.Name)  # 'name'
-        if PY39_PLUS:
-            assert (s4.value.lineno, s4.value.col_offset) == (2, 10)
-            assert (s4.value.end_lineno, s4.value.end_col_offset) == (2, 14)
-        else:
-            # Bug in Python 3.8
-            # https://bugs.python.org/issue44885
-            assert (s4.value.lineno, s4.value.col_offset) == (2, 1)
-            assert (s4.value.end_lineno, s4.value.end_col_offset) == (2, 5)
+        assert (s4.value.lineno, s4.value.col_offset) == (2, 10)
+        assert (s4.value.end_lineno, s4.value.end_col_offset) == (2, 14)
 
     @staticmethod
     @pytest.mark.skipif(not PY310_PLUS, reason="pattern matching was added in PY310")
@@ -1246,13 +1222,9 @@ class TestLinenoColOffset:
         assert (c1.decorators.end_lineno, c1.decorators.end_col_offset) == (2, 11)
         assert (c1.bases[0].lineno, c1.bases[0].col_offset) == (3, 8)
         assert (c1.bases[0].end_lineno, c1.bases[0].end_col_offset) == (3, 14)
-        if PY39_PLUS:
-            # 'lineno' and 'col_offset' information only added in Python 3.9
-            assert (c1.keywords[0].lineno, c1.keywords[0].col_offset) == (3, 16)
-            assert (c1.keywords[0].end_lineno, c1.keywords[0].end_col_offset) == (3, 22)
-        else:
-            assert (c1.keywords[0].lineno, c1.keywords[0].col_offset) == (None, None)
-            assert (c1.keywords[0].end_lineno, c1.keywords[0].end_col_offset) == (None, None)
+        # 'lineno' and 'col_offset' information only added in Python 3.9
+        assert (c1.keywords[0].lineno, c1.keywords[0].col_offset) == (3, 16)
+        assert (c1.keywords[0].end_lineno, c1.keywords[0].end_col_offset) == (3, 22)
         assert (c1.body[0].lineno, c1.body[0].col_offset) == (4, 4)
         assert (c1.body[0].end_lineno, c1.body[0].end_col_offset) == (4, 8)
         # fmt: on

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -8,7 +8,7 @@ import xml
 import pytest
 
 import astroid
-from astroid import bases, builder, nodes, objects, test_utils, util
+from astroid import bases, builder, nodes, objects, util
 from astroid.const import PY311_PLUS
 from astroid.exceptions import InferenceError
 
@@ -362,7 +362,6 @@ class FunctionModelTest(unittest.TestCase):
         self.assertEqual(len(args), 2)
         self.assertEqual([arg.name for arg in args], ["self", "type"])
 
-    @test_utils.require_version(minver="3.8")
     def test__get__and_positional_only_args(self):
         node = builder.extract_node(
             """
@@ -573,7 +572,6 @@ class FunctionModelTest(unittest.TestCase):
         self.assertIsInstance(kwdefaults, astroid.Dict)
         # self.assertEqual(kwdefaults.getitem('f').value, 'lala')
 
-    @test_utils.require_version(minver="3.8")
     def test_annotation_positional_only(self):
         ast_node = builder.extract_node(
             """

--- a/tests/test_python3.py
+++ b/tests/test_python3.py
@@ -9,7 +9,6 @@ import pytest
 
 from astroid import exceptions, nodes
 from astroid.builder import AstroidBuilder, extract_node
-from astroid.test_utils import require_version
 
 
 class Python3TC(unittest.TestCase):
@@ -351,7 +350,6 @@ class Python3TC(unittest.TestCase):
         for comp in non_async_comprehensions:
             self.assertFalse(comp.generators[0].is_async)
 
-    @require_version("3.7")
     def test_async_comprehensions_outside_coroutine(self):
         # When async and await will become keywords, async comprehensions
         # will be allowed outside of coroutines body

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -29,7 +29,7 @@ from astroid import (
     util,
 )
 from astroid.bases import BoundMethod, Generator, Instance, UnboundMethod
-from astroid.const import IS_PYPY, WIN32
+from astroid.const import WIN32
 from astroid.exceptions import (
     AstroidBuildingError,
     AttributeInferenceError,
@@ -1348,10 +1348,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         astroid = builder.parse(data)
         self.assertEqual(astroid["g1"].fromlineno, 4)
         self.assertEqual(astroid["g1"].tolineno, 5)
-        if IS_PYPY:
-            self.assertEqual(astroid["g2"].fromlineno, 9)
-        else:
-            self.assertEqual(astroid["g2"].fromlineno, 10)
+        self.assertEqual(astroid["g2"].fromlineno, 10)
         self.assertEqual(astroid["g2"].tolineno, 11)
 
     def test_metaclass_error(self) -> None:

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -26,11 +26,10 @@ from astroid import (
     nodes,
     objects,
     parse,
-    test_utils,
     util,
 )
 from astroid.bases import BoundMethod, Generator, Instance, UnboundMethod
-from astroid.const import IS_PYPY, PY38, WIN32
+from astroid.const import IS_PYPY, WIN32
 from astroid.exceptions import (
     AstroidBuildingError,
     AttributeInferenceError,
@@ -1349,7 +1348,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         astroid = builder.parse(data)
         self.assertEqual(astroid["g1"].fromlineno, 4)
         self.assertEqual(astroid["g1"].tolineno, 5)
-        if PY38 and IS_PYPY:
+        if IS_PYPY:
             self.assertEqual(astroid["g2"].fromlineno, 9)
         else:
             self.assertEqual(astroid["g2"].fromlineno, 10)
@@ -2750,13 +2749,11 @@ def test_metaclass_cannot_infer_call_yields_an_instance() -> None:
         ),
     ],
 )
-@test_utils.require_version("3.8")
 def test_posonlyargs_python_38(func):
     ast_node = builder.extract_node(func)
     assert ast_node.as_string().strip() == func.strip()
 
 
-@test_utils.require_version("3.8")
 def test_posonlyargs_default_value() -> None:
     ast_node = builder.extract_node(
         """


### PR DESCRIPTION
3.8 is EOL in late October 2024, and 3.13 final is scheduled for early October 2024. Aiming for new minor releases of astroid and pylint by then to drop support for 3.8 and add support for 3.13.