### PR TITLE
Bump astroid to 3.2.2, update changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,7 +21,7 @@ Release date: 2024-05-20
 
 * Improve inference for generic classes using the PEP 695 syntax (Python 3.12).
 
-  Closes pylint-dev/#9406
+  Closes pylint-dev/pylint#9406
 
 
 What's New in astroid 3.2.1?

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,10 +9,15 @@ Release date: TBA
 
 
 
-What's New in astroid 3.2.2?
+What's New in astroid 3.2.3?
 ============================
 Release date: TBA
 
+
+
+What's New in astroid 3.2.2?
+============================
+Release date: 2024-05-20
 
 * Improve inference for generic classes using the PEP 695 syntax (Python 3.12).
 

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.2.1"
+__version__ = "3.2.2"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.2.1"
+current = "3.2.2"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 3.2.2?
============================
Release date: 2024-05-20

* Improve inference for generic classes using the PEP 695 syntax (Python 3.12).

  Refs pylint-dev/pylint#9406