### PR TITLE
Make the "test_helpers.py" test file runnable by itself

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,6 +8,7 @@ import unittest
 import pytest
 
 from astroid import builder, helpers, manager, nodes, raw_building, util
+from astroid.builder import AstroidBuilder
 from astroid.const import IS_PYPY
 from astroid.exceptions import _NonDeducibleTypeHierarchy
 from astroid.nodes.scoped_nodes import ClassDef
@@ -17,6 +18,7 @@ class TestHelpers(unittest.TestCase):
     def setUp(self) -> None:
         builtins_name = builtins.__name__
         astroid_manager = manager.AstroidManager()
+        AstroidBuilder(astroid_manager)  # Only to ensure boostrap
         self.builtins = astroid_manager.astroid_cache[builtins_name]
         self.manager = manager.AstroidManager()
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Write a good description on what the PR does.
- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Currently, although running `pytest` passes, **running `pytest tests/test_helpers.py`** does not, it **gives the following error**:

    ...
      File "/tmp/astroid/tests/test_helpers.py", line 20, in setUp
        self.builtins = astroid_manager.astroid_cache[builtins_name]
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
    KeyError: 'builtins'

This started being the case since commit 33d0e8445f5d17aeae94d65918436ddb8affcc72, previously the file was runnable by itself.

This is a test-only fix, changelog non-applicable.