### PR TITLE
Fix AssertionError when inferring a property consisting of a partial function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,10 @@ What's New in astroid 3.2.3?
 ============================
 Release date: TBA
 
+* Fix ``AssertionError`` when inferring a property consisting of a partial function.
+
+Closes pylint-dev/pylint#9214
+
 
 What's New in astroid 3.2.2?
 ============================

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2518,6 +2518,10 @@ class ClassDef(  # pylint: disable=too-many-instance-attributes
                 elif isinstance(inferred, objects.Property):
                     function = inferred.function
                     if not class_context:
+                        if not context.callcontext:
+                            context.callcontext = CallContext(
+                                args=function.args.arguments, callee=function
+                            )
                         # Through an instance so we can solve the property
                         yield from function.infer_call_result(
                             caller=self, context=context

--- a/tests/test_regrtest.py
+++ b/tests/test_regrtest.py
@@ -477,3 +477,22 @@ def test_recursion_during_inference(mocked) -> None:
     with pytest.raises(InferenceError) as error:
         next(node.infer())
     assert error.value.message.startswith("RecursionError raised")
+
+
+def test_regression_missing_callcontext() -> None:
+    node: nodes.Attribute = _extract_single_node(
+        textwrap.dedent(
+            """
+        import functools
+
+        class MockClass:
+            def _get_option(self, option):
+                return "mystr"
+
+            enabled = property(functools.partial(_get_option, option='myopt'))
+
+        MockClass().enabled
+        """
+        )
+    )
+    assert node.inferred()[0].value == "mystr"


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Closes pylint-dev/pylint#9214

Thanks Martin Belanger for the report and Bryce Guinta for the test case.

@brycepg would you like to review?