### PR TITLE
Bump astroid to 3.2.3, update changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,14 +9,19 @@ Release date: TBA
 
 
 
-What's New in astroid 3.2.3?
+What's New in astroid 3.2.4?
 ============================
 Release date: TBA
+
+
+
+What's New in astroid 3.2.3?
+============================
+Release date: 2024-07-11
 
 * Fix ``AssertionError`` when inferring a property consisting of a partial function.
 
 Closes pylint-dev/pylint#9214
-
 
 
 What's New in astroid 3.2.2?

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.2.2"
+__version__ = "3.2.3"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.2.2"
+current = "3.2.3"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 3.2.3?
============================
Release date: 2024-07-11

* Fix ``AssertionError`` when inferring a property consisting of a partial function.

Closes pylint-dev/pylint#9214