### PR TITLE
Bump astroid to 3.3.0, update changelog

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -206,3 +206,6 @@ under this name, or we did not manage to find their commits in the history.
 - Mark Gius
 - Jérome Perrin <perrinjerome@gmail.com>
 - Jamie Scott <jamie@jami.org.uk>
+- correctmost <134317971+correctmost@users.noreply.github.com>
+- Oleh Prypin <oleh@pryp.in>
+- Eric Vergnaud <eric.vergnaud@wanadoo.fr>

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,9 +3,21 @@ astroid's ChangeLog
 ===================
 
 
-What's New in astroid 3.3.0?
+What's New in astroid 3.4.0?
 ============================
 Release date: TBA
+
+
+
+What's New in astroid 3.3.1?
+============================
+Release date: TBA
+
+
+
+What's New in astroid 3.3.0?
+============================
+Release date: 2024-08-04
 
 * Add support for Python 3.13.
 
@@ -22,12 +34,6 @@ Release date: TBA
 * Add support for ``ssl.OP_LEGACY_SERVER_CONNECT`` (new in Python 3.12).
 
   Closes pylint-dev/pylint#9849
-
-
-What's New in astroid 3.2.5?
-============================
-Release date: TBA
-
 
 
 What's New in astroid 3.2.4?

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.3.0"
+__version__ = "3.4.0-dev0"
 version = __version__

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.3.0-dev0"
+__version__ = "3.3.0"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.3.0"
+current = "3.4.0-dev0"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.3.0-dev0"
+current = "3.3.0"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 3.3.0?
============================
Release date: 2024-08-04

* Add support for Python 3.13.

* Remove support for Python 3.8 (and constants `PY38`, `PY39_PLUS`, and `PYPY_7_3_11_PLUS`).

  Refs #2443

* Add the ``__annotations__`` attribute to the ``ClassDef`` object model.

  Closes pylint-dev/pylint#7126

* Implement inference for JoinedStr and FormattedValue

* Add support for ``ssl.OP_LEGACY_SERVER_CONNECT`` (new in Python 3.12).

  Closes pylint-dev/pylint#9849