### PR TITLE
Fix pylint regression with invalid format strings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,9 @@ What's New in astroid 3.3.1?
 ============================
 Release date: TBA
 
+* Fix a crash introduced in 3.3.0 involving invalid format strings.
+
+  Closes #2492
 
 
 What's New in astroid 3.3.0?

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4698,7 +4698,7 @@ class FormattedValue(NodeNG):
                             end_col_offset=self.end_col_offset,
                         )
                         continue
-                    except ValueError:  # happens when format_spec.value is invalid
+                    except (ValueError, TypeError):  # happens when format_spec.value is invalid
                         pass  # fall through
                 if not uninferable_already_generated:
                     yield util.Uninferable

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4698,10 +4698,8 @@ class FormattedValue(NodeNG):
                             end_col_offset=self.end_col_offset,
                         )
                         continue
-                    except (
-                        ValueError,
-                        TypeError,
-                    ):  # happens when format_spec.value is invalid
+                    except (ValueError, TypeError):
+                        # happens when format_spec.value is invalid
                         pass  # fall through
                 if not uninferable_already_generated:
                     yield util.Uninferable

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4687,19 +4687,23 @@ class FormattedValue(NodeNG):
                     uninferable_already_generated = True
                 continue
             for value in self.value.infer(context, **kwargs):
-                if not isinstance(value, Const):
-                    if not uninferable_already_generated:
-                        yield util.Uninferable
-                        uninferable_already_generated = True
-                    continue
-                formatted = format(value.value, format_spec.value)
-                yield Const(
-                    formatted,
-                    lineno=self.lineno,
-                    col_offset=self.col_offset,
-                    end_lineno=self.end_lineno,
-                    end_col_offset=self.end_col_offset,
-                )
+                if isinstance(value, Const):
+                    try:
+                        formatted = format(value.value, format_spec.value)
+                        yield Const(
+                            formatted,
+                            lineno=self.lineno,
+                            col_offset=self.col_offset,
+                            end_lineno=self.end_lineno,
+                            end_col_offset=self.end_col_offset,
+                        )
+                        continue
+                    except ValueError:  # happens when format_spec.value is invalid
+                        pass  # fall through
+                if not uninferable_already_generated:
+                    yield util.Uninferable
+                    uninferable_already_generated = True
+                continue
 
 
 MISSING_VALUE = "{MISSING_VALUE}"

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4698,7 +4698,10 @@ class FormattedValue(NodeNG):
                             end_col_offset=self.end_col_offset,
                         )
                         continue
-                    except (ValueError, TypeError):  # happens when format_spec.value is invalid
+                    except (
+                        ValueError,
+                        TypeError,
+                    ):  # happens when format_spec.value is invalid
                         pass  # fall through
                 if not uninferable_already_generated:
                     yield util.Uninferable

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -6528,16 +6528,16 @@ def test_infer_assign_attr() -> None:
         ),
         (
             """
-        class A:
-            def __enter__(self):
-                return A()
-            def __exit__(self, err_type, err, traceback):
-                return
-        class B(A):
-                pass
-        with B() as b:
-            b #@
-        """,
+    class A:
+        def __enter__(self):
+            return A()
+        def __exit__(self, err_type, err, traceback):
+            return
+    class B(A):
+            pass
+    with B() as b:
+        b #@
+    """,
             "A",
         ),
         (
@@ -6750,7 +6750,7 @@ def test_infer_dict_passes_context() -> None:
                 def inner(cls):
                     return method(cls)
                 return inner
-    
+
             class X(object):
                 @klassmethod1
                 def x(cls):

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -6514,16 +6514,16 @@ def test_infer_assign_attr() -> None:
     [
         (
             """
-            class A:
-                def __enter__(self):
-                    return self
-                def __exit__(self, err_type, err, traceback):
-                    return
-            class B(A):
-                pass
-            with B() as b:
-                b #@
-            """,
+        class A:
+            def __enter__(self):
+                return self
+            def __exit__(self, err_type, err, traceback):
+                return
+        class B(A):
+            pass
+        with B() as b:
+            b #@
+        """,
             "B",
         ),
         (
@@ -6542,14 +6542,14 @@ def test_infer_assign_attr() -> None:
         ),
         (
             """
-            class A:
-                def test(self):
-                    return A()
-            class B(A):
-                def test(self):
-                    return A.test(self)
-            B().test()
-            """,
+        class A:
+            def test(self):
+                return A()
+        class B(A):
+            def test(self):
+                return A.test(self)
+        B().test()
+        """,
             "A",
         ),
     ],
@@ -6745,67 +6745,67 @@ def test_infer_dict_passes_context() -> None:
     [
         (
             """
-                def klassmethod1(method):
-                    @classmethod
-                    def inner(cls):
-                        return method(cls)
-                    return inner
-
-                class X(object):
-                    @klassmethod1
-                    def x(cls):
-                        return 'X'
-                X.x
-                """,
+            def klassmethod1(method):
+                @classmethod
+                def inner(cls):
+                    return method(cls)
+                return inner
+    
+            class X(object):
+                @klassmethod1
+                def x(cls):
+                    return 'X'
+            X.x
+            """,
             BoundMethod,
             "classmethod",
         ),
         (
             """
-                def staticmethod1(method):
-                    @staticmethod
-                    def inner(cls):
-                        return method(cls)
-                    return inner
+            def staticmethod1(method):
+                @staticmethod
+                def inner(cls):
+                    return method(cls)
+                return inner
 
-                class X(object):
-                    @staticmethod1
-                    def x(cls):
-                        return 'X'
-                X.x
-                """,
+            class X(object):
+                @staticmethod1
+                def x(cls):
+                    return 'X'
+            X.x
+            """,
             nodes.FunctionDef,
             "staticmethod",
         ),
         (
             """
-                def klassmethod1(method):
-                    def inner(cls):
-                        return method(cls)
-                    return classmethod(inner)
+            def klassmethod1(method):
+                def inner(cls):
+                    return method(cls)
+                return classmethod(inner)
 
-                class X(object):
-                    @klassmethod1
-                    def x(cls):
-                        return 'X'
-                X.x
-                """,
+            class X(object):
+                @klassmethod1
+                def x(cls):
+                    return 'X'
+            X.x
+            """,
             BoundMethod,
             "classmethod",
         ),
         (
             """
-                def staticmethod1(method):
-                    def inner(cls):
-                        return method(cls)
-                    return staticmethod(inner)
+            def staticmethod1(method):
+                def inner(cls):
+                    return method(cls)
+                return staticmethod(inner)
 
-                class X(object):
-                    @staticmethod1
-                    def x(cls):
-                        return 'X'
-                X.x
-                """,
+            class X(object):
+                @staticmethod1
+                def x(cls):
+                    return 'X'
+            X.x
+            """,
             nodes.FunctionDef,
             "staticmethod",
         ),

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -5510,6 +5510,11 @@ precision = 4
 value = 12.34567
 result = f"result: {value:{width}.{precision}}!"
 """, "result:      12.35!"),
+("""width = 10
+precision = 4
+value = None
+result = f"result: {value:{width}.{precision}}!"
+""", None),
     ("""width = None
 precision = 4
 value = 12.34567

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -666,20 +666,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(value_node, Const)
         self.assertEqual(value_node.value, "Hello John!")
 
-    def test_formatted_fstring_inference(self) -> None:
-        code = """
-            width = 10
-            precision = 4
-            value = 12.34567
-            result = f"result: {value:{width}.{precision}}!"
-            """
-        ast = parse(code, __name__)
-        node = ast["result"]
-        inferred = node.inferred()
-        self.assertEqual(len(inferred), 1)
-        value_node = inferred[0]
-        self.assertIsInstance(value_node, Const)
-        self.assertEqual(value_node.value, "result:      12.35!")
+
 
     def test_float_complex_ambiguity(self) -> None:
         code = '''
@@ -5515,6 +5502,31 @@ class ObjectDunderNewTest(unittest.TestCase):
         )
         inferred = next(node.infer())
         self.assertIsInstance(inferred, Instance)
+
+
+@pytest.mark.parametrize("code, result", [
+    ("""width = 10
+precision = 4
+value = 12.34567
+result = f"result: {value:{width}.{precision}}!"
+""", "result:      12.35!"),
+    ("""width = None
+precision = 4
+value = 12.34567
+result = f"result: {value:{width}.{precision}}!"
+""", None)
+])
+def test_formatted_fstring_inference(code, result) -> None:
+    ast = parse(code, __name__)
+    node = ast["result"]
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    value_node = inferred[0]
+    if result is None:
+        assert value_node is util.Uninferable
+    else:
+        assert isinstance(value_node, Const)
+        assert value_node.value == result
 
 
 def test_augassign_recursion() -> None:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -76,10 +76,10 @@ class InferenceUtilsTest(unittest.TestCase):
 
 
 def _assertInferElts(
-        node_type: ABCMeta,
-        self: InferenceTest,
-        node: Any,
-        elts: list[int] | list[str],
+    node_type: ABCMeta,
+    self: InferenceTest,
+    node: Any,
+    elts: list[int] | list[str],
 ) -> None:
     inferred = next(node.infer())
     self.assertIsInstance(inferred, node_type)
@@ -102,7 +102,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual(inferred.value, expected)
 
     def assertInferDict(
-            self, node: nodes.Call | nodes.Dict | nodes.NodeNG, expected: Any
+        self, node: nodes.Call | nodes.Dict | nodes.NodeNG, expected: Any
     ) -> None:
         inferred = next(node.infer())
         self.assertIsInstance(inferred, nodes.Dict)
@@ -1030,7 +1030,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         import_node.do_import_module()
         # calling file_from_module_name() indicates we didn't hit the cache
         with unittest.mock.patch.object(
-                manager.AstroidManager, "file_from_module_name", side_effect=AssertionError
+            manager.AstroidManager, "file_from_module_name", side_effect=AssertionError
         ):
             import_node.do_import_module()
 
@@ -1042,13 +1042,13 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
 
     def test_unary_not(self) -> None:
         for code in (
-                "a = not (1,); b = not ()",
-                "a = not {1:2}; b = not {}",
-                "a = not [1, 2]; b = not []",
-                "a = not {1, 2}; b = not set()",
-                "a = not 1; b = not 0",
-                'a = not "a"; b = not ""',
-                'a = not b"a"; b = not b""',
+            "a = not (1,); b = not ()",
+            "a = not {1:2}; b = not {}",
+            "a = not [1, 2]; b = not []",
+            "a = not {1, 2}; b = not set()",
+            "a = not 1; b = not 0",
+            'a = not "a"; b = not ""',
+            'a = not b"a"; b = not b""',
         ):
             ast = builder.string_build(code, __name__, __file__)
             self._test_const_inferred(ast["a"], False)
@@ -3689,21 +3689,21 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual(inferred.value, 42)
 
     def _slicing_test_helper(
-            self,
-            pairs: tuple[
-                tuple[str, list[int] | str],
-                tuple[str, list[int] | str],
-                tuple[str, list[int] | str],
-                tuple[str, list[int] | str],
-                tuple[str, list[int] | str],
-                tuple[str, list[int] | str],
-                tuple[str, list[int] | str],
-                tuple[str, list[int] | str],
-                tuple[str, list[int] | str],
-                tuple[str, list[int] | str],
-            ],
-            cls: ABCMeta | type,
-            get_elts: Callable,
+        self,
+        pairs: tuple[
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+        ],
+        cls: ABCMeta | type,
+        get_elts: Callable,
     ) -> None:
         for code, expected in pairs:
             ast_node = extract_node(code)
@@ -5064,7 +5064,7 @@ class TestType(unittest.TestCase):
 class ArgumentsTest(unittest.TestCase):
     @staticmethod
     def _get_dict_value(
-            inferred: dict,
+        inferred: dict,
     ) -> list[tuple[str, int]] | list[tuple[str, str]]:
         items = inferred.items
         return sorted((key.value, value.value) for key, value in items)
@@ -5392,7 +5392,7 @@ class CallSiteTest(unittest.TestCase):
         return arguments.CallSite.from_call(call)
 
     def _test_call_site_pair(
-            self, code: str, expected_args: list[int], expected_keywords: dict[str, int]
+        self, code: str, expected_args: list[int], expected_keywords: dict[str, int]
     ) -> None:
         ast_node = extract_node(code)
         call_site = self._call_site_from_call(ast_node)
@@ -5406,7 +5406,7 @@ class CallSiteTest(unittest.TestCase):
             self.assertEqual(call_site.keyword_arguments[keyword].value, value)
 
     def _test_call_site(
-            self, pairs: list[tuple[str, list[int], dict[str, int]]]
+        self, pairs: list[tuple[str, list[int], dict[str, int]]]
     ) -> None:
         for pair in pairs:
             self._test_call_site_pair(*pair)
@@ -5507,30 +5507,30 @@ class ObjectDunderNewTest(unittest.TestCase):
     [
         # regular f-string
         (
-                """width = 10
+            """width = 10
 precision = 4
 value = 12.34567
 result = f"result: {value:{width}.{precision}}!"
 """,
-                "result:      12.35!",
+            "result:      12.35!",
         ),
         # unsupported format
         (
-                """width = None
+            """width = None
 precision = 4
 value = 12.34567
 result = f"result: {value:{width}.{precision}}!"
 """,
-                None
+            None,
         ),
         # unsupported value
         (
-                """width = 10
+            """width = 10
 precision = 4
 value = None
 result = f"result: {value:{width}.{precision}}!"
 """,
-                None
+            None,
         ),
     ],
 )
@@ -6513,7 +6513,7 @@ def test_infer_assign_attr() -> None:
     "code,instance_name",
     [
         (
-                """
+            """
             class A:
                 def __enter__(self):
                     return self
@@ -6524,10 +6524,10 @@ def test_infer_assign_attr() -> None:
             with B() as b:
                 b #@
             """,
-                "B",
+            "B",
         ),
         (
-                """
+            """
         class A:
             def __enter__(self):
                 return A()
@@ -6538,10 +6538,10 @@ def test_infer_assign_attr() -> None:
         with B() as b:
             b #@
         """,
-                "A",
+            "A",
         ),
         (
-                """
+            """
             class A:
                 def test(self):
                     return A()
@@ -6550,7 +6550,7 @@ def test_infer_assign_attr() -> None:
                     return A.test(self)
             B().test()
             """,
-                "A",
+            "A",
         ),
     ],
 )
@@ -6744,70 +6744,70 @@ def test_infer_dict_passes_context() -> None:
     "code,obj,obj_type",
     [
         (
-                """
+            """
                 def klassmethod1(method):
                     @classmethod
                     def inner(cls):
                         return method(cls)
                     return inner
-    
+
                 class X(object):
                     @klassmethod1
                     def x(cls):
                         return 'X'
                 X.x
                 """,
-                BoundMethod,
-                "classmethod",
+            BoundMethod,
+            "classmethod",
         ),
         (
-                """
+            """
                 def staticmethod1(method):
                     @staticmethod
                     def inner(cls):
                         return method(cls)
                     return inner
-    
+
                 class X(object):
                     @staticmethod1
                     def x(cls):
                         return 'X'
                 X.x
                 """,
-                nodes.FunctionDef,
-                "staticmethod",
+            nodes.FunctionDef,
+            "staticmethod",
         ),
         (
-                """
+            """
                 def klassmethod1(method):
                     def inner(cls):
                         return method(cls)
                     return classmethod(inner)
-    
+
                 class X(object):
                     @klassmethod1
                     def x(cls):
                         return 'X'
                 X.x
                 """,
-                BoundMethod,
-                "classmethod",
+            BoundMethod,
+            "classmethod",
         ),
         (
-                """
+            """
                 def staticmethod1(method):
                     def inner(cls):
                         return method(cls)
                     return staticmethod(inner)
-    
+
                 class X(object):
                     @staticmethod1
                     def x(cls):
                         return 'X'
                 X.x
                 """,
-                nodes.FunctionDef,
-                "staticmethod",
+            nodes.FunctionDef,
+            "staticmethod",
         ),
     ],
 )


### PR DESCRIPTION
|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Catches errors when attempting to format fstrings with invalid format strings, and yields Uninferable

Closes #2492
