### PR TITLE
Bump astroid to 3.3.1, update changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,9 +9,15 @@ Release date: TBA
 
 
 
-What's New in astroid 3.3.1?
+What's New in astroid 3.3.2?
 ============================
 Release date: TBA
+
+
+
+What's New in astroid 3.3.1?
+============================
+Release date: 2024-08-06
 
 * Fix a crash introduced in 3.3.0 involving invalid format strings.
 

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.3.0"
+current = "3.3.1"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 3.3.1?
============================
Release date: 2024-08-06

* Fix a crash introduced in 3.3.0 involving invalid format strings.

  Closes #2492