### PR TITLE
Avoid overhead of cast() calls when not type checking

### DIFF
--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -78,7 +78,9 @@ class TransformVisitor:
     def _visit(self, node: nodes.NodeNG) -> SuccessfulInferenceResult:
         for name in node._astroid_fields:
             value = getattr(node, name)
-            value = cast(_Vistables, value)
+            if TYPE_CHECKING:
+                value = cast(_Vistables, value)
+
             visited = self._visit_generic(value)
             if visited != value:
                 setattr(node, name, visited)


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
While profiling Pylint with the yt-dlp codebase, I noticed that `cast` was called 1.277 million times:

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  1277992    0.130    0.000    0.130    0.000 /usr/lib/python3.12/typing.py:2173(cast)
```

This PR avoids 1.1 million of these calls.

## Background
https://github.com/python/cpython/pull/116290#issuecomment-1977567392 has this to say about `cast`:

> My own vision for call inlining is that it's mostly going to make "trivial" functions disappear -- a good example would be typing.cast(), which returns its second argument unchanged. I currently sometimes hesitate about putting that in because of the perceived overhead of even the most trivial function call [...]

## Stats

### Before

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  1277992    0.130    0.000    0.130    0.000 /usr/lib/python3.12/typing.py:2173(cast)
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pylint --recursive=y .` | 36.214 ± 0.381 | 35.590 | 36.608 | 1.00 |


### After

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   176834    0.022    0.000    0.022    0.000 /usr/lib/python3.12/typing.py:2173(cast)
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pylint --recursive=y .` | 35.195 ± 0.165 | 34.974 | 35.326 | 1.00 |


### Reproduction notes
- The tables were generated by hyperfine
  - `hyperfine --ignore-failure --warmup 2 --runs 5 --export-markdown=baseline.md 'pylint --recursive=y .'`