### PR TITLE
Avoid extra isinstance calls in _visit_generic

### DIFF
--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -104,11 +104,13 @@ class TransformVisitor:
     def _visit_generic(self, node: nodes.NodeNG) -> SuccessfulInferenceResult: ...
 
     def _visit_generic(self, node: _Vistables) -> _VisitReturns:
+        if not node:
+            return node
         if isinstance(node, list):
             return [self._visit_generic(child) for child in node]
         if isinstance(node, tuple):
             return tuple(self._visit_generic(child) for child in node)
-        if not node or isinstance(node, str):
+        if isinstance(node, str):
             return node
 
         try:


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
When linting yt-dlp, `_visit_generic` calls `isinstance` 4.266 million times.  ~615,000 of these calls can be avoided by checking for falsy values first.

## Stats

### Before

```
# Total isinstance calls

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
 14065668    2.160    0.000    2.172    0.000 {built-in method builtins.isinstance}
```

```
# _visit_generic -> isinstance calls

astroid/astroid/transforms.py:106(_visit_generic)  ->   4266200    0.643    0.643  {built-in method builtins.isinstance}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pylint --recursive=y .` | 36.214 ± 0.381 | 35.590 | 36.608 | 1.00 |


### After

```
# Total isinstance calls

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
 13449748    2.058    0.000    2.070    0.000 {built-in method builtins.isinstance}
```

```
# _visit_generic -> isinstance calls

astroid/astroid/transforms.py:106(_visit_generic)  ->   3650282    0.549    0.549  {built-in method builtins.isinstance}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pylint --recursive=y .` | 35.564 ± 0.330 | 35.051 | 35.901 | 1.00 |


### Reproduction notes
- The tables were generated by hyperfine
  - `hyperfine --ignore-failure --warmup 2 --runs 5 --export-markdown=baseline.md 'pylint --recursive=y .'`