### PR TITLE
[PY313] Add stubs for soft-deprecated typing members

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,9 @@ What's New in astroid 3.3.2?
 ============================
 Release date: TBA
 
+* Restore support for soft-deprecated members of the ``typing`` module with python 3.13.
+
+  Refs pylint-dev/pylint#9852
 
 
 What's New in astroid 3.3.1?

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -451,6 +451,18 @@ def _typing_transform():
         @classmethod
         def __class_getitem__(cls, item):  return cls
     class TypeVarTuple: ...
+    class ContextManager:
+        @classmethod
+        def __class_getitem__(cls, item):  return cls
+    class AsyncContextManager:
+        @classmethod
+        def __class_getitem__(cls, item):  return cls
+    class Pattern:
+        @classmethod
+        def __class_getitem__(cls, item):  return cls
+    class Match:
+        @classmethod
+        def __class_getitem__(cls, item):  return cls
     """
         )
     )


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Needed for pylint 3.13 support. These members became more dynamic in 3.13, see https://github.com/python/cpython/pull/109651.