### PR TITLE
Remove unnecessary isinstance calls from transform predicates

### DIFF
--- a/astroid/brain/brain_numpy_ndarray.py
+++ b/astroid/brain/brain_numpy_ndarray.py
@@ -151,8 +151,8 @@ def infer_numpy_ndarray(node, context: InferenceContext | None = None):
     return node.infer(context=context)
 
 
-def _looks_like_numpy_ndarray(node) -> bool:
-    return isinstance(node, Attribute) and node.attrname == "ndarray"
+def _looks_like_numpy_ndarray(node: Attribute) -> bool:
+    return node.attrname == "ndarray"
 
 
 def register(manager: AstroidManager) -> None:

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -28,7 +28,7 @@ from astroid.exceptions import UseInferenceDefault
 from astroid.manager import AstroidManager
 
 
-def _looks_like_type_subscript(node) -> bool:
+def _looks_like_type_subscript(node: nodes.Name) -> bool:
     """
     Try to figure out if a Name node is used inside a type related subscript.
 
@@ -36,7 +36,7 @@ def _looks_like_type_subscript(node) -> bool:
     :type node: astroid.nodes.node_classes.NodeNG
     :return: whether the node is a Name node inside a type related subscript
     """
-    if isinstance(node, nodes.Name) and isinstance(node.parent, nodes.Subscript):
+    if isinstance(node.parent, nodes.Subscript):
         return node.name == "type"
     return False
 

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -398,7 +398,7 @@ def infer_special_alias(
 
 
 def _looks_like_typing_cast(node: Call) -> bool:
-    return isinstance(node, Call) and (
+    return (
         isinstance(node.func, Name)
         and node.func.name == "cast"
         or isinstance(node.func, Attribute)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
This PR reduces the number of isinstance calls when linting yt-dlp by ~390k.

## Stats

### Before

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
 13449993    2.005    0.000    2.015    0.000 {built-in method builtins.isinstance}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pylint --recursive=y .` | 32.888 ± 0.092 | 32.777 | 32.968 | 1.00 |


### After

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
 13058540    1.977    0.000    1.989    0.000 {built-in method builtins.isinstance}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pylint --recursive=y .` | 32.867 ± 0.154 | 32.667 | 33.020 | 1.00 |
