### PR TITLE
brain_attrs: Support annotation-only members

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,10 @@ What's New in astroid 3.3.3?
 ============================
 Release date: TBA
 
+* Add annotation-only instance attributes to attrs classes to fix `no-member` false positives.
+
+  Closes #2514
+
 
 
 What's New in astroid 3.3.2?

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -24,6 +24,13 @@ ATTRIB_NAMES = frozenset(
         "field",
     )
 )
+NEW_ATTRS_NAMES = frozenset(
+    (
+        "attrs.define",
+        "attrs.mutable",
+        "attrs.frozen",
+    )
+)
 ATTRS_NAMES = frozenset(
     (
         "attr.s",
@@ -33,9 +40,7 @@ ATTRS_NAMES = frozenset(
         "attr.define",
         "attr.mutable",
         "attr.frozen",
-        "attrs.define",
-        "attrs.mutable",
-        "attrs.frozen",
+        *NEW_ATTRS_NAMES,
     )
 )
 
@@ -64,13 +69,14 @@ def attr_attributes_transform(node: ClassDef) -> None:
     # Prevents https://github.com/pylint-dev/pylint/issues/1884
     node.locals["__attrs_attrs__"] = [Unknown(parent=node)]
 
+    use_bare_annotations = is_decorated_with_attrs(node, NEW_ATTRS_NAMES)
     for cdef_body_node in node.body:
         if not isinstance(cdef_body_node, (Assign, AnnAssign)):
             continue
         if isinstance(cdef_body_node.value, Call):
             if cdef_body_node.value.func.as_string() not in ATTRIB_NAMES:
                 continue
-        else:
+        elif not use_bare_annotations:
             continue
         targets = (
             cdef_body_node.targets

--- a/script/.contributors_aliases.json
+++ b/script/.contributors_aliases.json
@@ -85,6 +85,10 @@
     "name": "Hippo91",
     "team": "Maintainers"
   },
+  "Hnasar@users.noreply.github.com": {
+    "mails": ["Hnasar@users.noreply.github.com", "hashem@hudson-trading.com"],
+    "name": "Hashem Nasarat"
+  },
   "hugovk@users.noreply.github.com": {
     "mails": ["hugovk@users.noreply.github.com"],
     "name": "Hugo van Kemenade"


### PR DESCRIPTION
Similar to dataclasses, the following class which uses instance variable annotations is valid:

```py
@attrs.define
class AttrsCls:
    x: int
AttrsCls(1).x
```

However, before this commit astroid failed to transform the class attribute into an instance attribute and this led to `no-member` errors in pylint.

Only the new `attrs` API supports this form out-of-the-box, so just address the common case.


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

Closes #2514