### PR TITLE
fix the documentation and the error message of modpath_from_file

### DIFF
--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -292,7 +292,9 @@ def modpath_from_file_with_callback(
             return modpath
 
     raise ImportError(
-        "Unable to find module for {} in {}".format(filename, ", \n".join(sys.path))
+        "Unable to find module for {} in {}".format(
+            filename, ", \n".join(paths_to_check)
+        )
     )
 
 
@@ -305,8 +307,8 @@ def modpath_from_file(filename: str, path: Sequence[str] | None = None) -> list[
     :param filename: file's path for which we want the module's name
 
     :type Optional[List[str]] path:
-      Optional list of path where the module or package should be
-      searched (use sys.path if nothing or None is given)
+      Optional list of paths where the module or package should be
+      searched, additionally to sys.path
 
     :raise ImportError:
       if the corresponding module's name has not been found


### PR DESCRIPTION
The doc should clarify that the search will always include sys.path.

The error message should reflect the actual paths used for checking.

<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

