### PR TITLE
Add ruff exclusions to pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,6 @@ repos:
     rev: "v0.6.3"
     hooks:
       - id: ruff
-        exclude: tests/testdata
         args: ["--fix"]
   - repo: https://github.com/Pierre-Sassoulas/copyright_notice_precommit
     rev: 0.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,8 @@ ignore_missing_imports = true
 [tool.ruff]
 target-version = "py39"
 
+exclude = ["tests/testdata/"]
+
 # ruff is less lenient than pylint and does not make any exceptions
 # (for docstrings, strings and comments in particular).
 line-length = 110


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This makes it easier to run `ruff check` outside of the pre-commit hook:

### Before
```
$ ruff check --output-format=concise
tests/testdata/python3/data/absimp/string.py:1:1: I001 [*] Import block is un-sorted or un-formatted
tests/testdata/python3/data/all.py:5:10: E701 Multiple statements on one line (colon)
tests/testdata/python3/data/appl/myConnection.py:1:1: I001 [*] Import block is un-sorted or un-formatted

[...snip...]
```

### After
```
$ ruff check --output-format=concise
All checks passed!
```