### PR TITLE
Remove unused _path member from Finder

### DIFF
--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -83,8 +83,8 @@ class ModuleSpec(NamedTuple):
 class Finder:
     """A finder is a class which knows how to find a particular module."""
 
-    def __init__(self, path: Sequence[str] | None = None) -> None:
-        self._path = path or sys.path
+    def __init__(self, path: Sequence[str]) -> None:
+        pass
 
     @staticmethod
     @abc.abstractmethod


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

`_path` appears to be unused in Pylint and astroid.
