### PR TITLE
Move Pylint exclusions to pylintrc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,6 @@ repos:
             "--output-format=github",
             # "--load-plugins=pylint.extensions.docparams", We're not ready for that
           ]
-        exclude: tests/testdata|conf.py
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.11.2
     hooks:

--- a/pylintrc
+++ b/pylintrc
@@ -11,6 +11,12 @@
 # paths.
 ignore=CVS
 
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=doc/conf.py,tests/testdata/
+
 # Pickle collected data for later comparisons.
 persistent=yes
 


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This makes it easier to run Pylint outside of the pre-commit hooks.