### PR TITLE
Avoid extra isinstance calls in _builtin_filter_predicate

### DIFF
--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -189,8 +189,8 @@ def _builtin_filter_predicate(node, builtin_name) -> bool:
         # Match = type(...)
         # ```
         return False
-    if isinstance(node.func, nodes.Name) and node.func.name == builtin_name:
-        return True
+    if isinstance(node.func, nodes.Name):
+        return node.func.name == builtin_name
     if isinstance(node.func, nodes.Attribute):
         return (
             node.func.attrname == "fromkeys"


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

When linting yt-dlp, `_builtin_filter_predicate` calls `isinstance` 3.23 million times. ~594,000 of these calls can be avoided with an earlier return.

## Stats

### Before
```
# Total isinstance calls

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
 13060759    2.083    0.000    2.096    0.000 {built-in method builtins.isinstance}
```

```
# _builtin_filter_predicate -> isinstance calls

astroid/brain/brain_builtin_inference.py:174(_builtin_filter_predicate)  ->
   ncalls  tottime  cumtime
  3237287    0.505    0.505  {built-in method builtins.isinstance}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pylint --recursive=y .` | 33.868 ± 0.264 | 33.425 | 34.245 | 1.00 |


### After
```
# Total isinstance calls

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
 12466757    2.141    0.000    2.155    0.000 {built-in method builtins.isinstance}
```

```
# _builtin_filter_predicate -> isinstance calls

astroid/brain/brain_builtin_inference.py:174(_builtin_filter_predicate)  ->
   ncalls  tottime  cumtime
  2643280    0.447    0.447  {built-in method builtins.isinstance}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pylint --recursive=y .` | 33.421 ± 0.184 | 33.165 | 33.733 | 1.00 |
