### PR TITLE
Use extend-exclude instead of exclude in ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ ignore_missing_imports = true
 [tool.ruff]
 target-version = "py39"
 
-exclude = ["tests/testdata/"]
+extend-exclude = ["tests/testdata/"]
 
 # ruff is less lenient than pylint and does not make any exceptions
 # (for docstrings, strings and comments in particular).


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

The ruff docs recommend using extend-exclude for custom paths:

> Note that you'll typically want to use extend-exclude to modify the excluded paths.

-- https://docs.astral.sh/ruff/settings/#exclude