### PR TITLE
Remove Python 3.8 from tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,312}
+envlist = py{39,310,311,312}
 skip_missing_interpreters = true
 isolated_build = true
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Python 3.8 is no longer supported by astroid.