### PR TITLE
Fix useless-suppression Pylint warning

### DIFF
--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -244,8 +244,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
                 if isinstance(inferred, util.UninferableBase):
                     continue
                 try:
-                    # pylint: disable=unidiomatic-typecheck # We want a narrow check on the
-                    # parent type, not all of its subclasses
+                    # We want a narrow check on the parent type, not all of its subclasses
                     if type(inferred) in {bases.Instance, objects.ExceptionInstance}:
                         inferred = inferred._proxied
                         iattrs = inferred.instance_attrs

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,6 +3,6 @@
 # Tools used during development, prefer running these with pre-commit
 black
 pre-commit
-pylint>=3.2.0
+pylint>=3.2.7
 mypy
 ruff


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This PR fixes the following warning (Pylint 3.2.7):

```
astroid/builder.py:247:0: I0021: Useless suppression of 'unidiomatic-typecheck' (useless-suppression)
```