### PR TITLE
Add .tox to Pylint ignore list

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -9,7 +9,7 @@
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS
+ignore=.tox,CVS
 
 # Add files or directories matching the regular expressions patterns to the
 # ignore-list. The regex matches against paths and can be in Posix or Windows


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This makes it easier to run `pylint --recursive=y .` locally without customizing the `--ignore` list.