### PR TITLE
add the parent node to "__main__"

### DIFF
--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -354,7 +354,9 @@ class Module(LocalsDictNodeNG):
         if name in self.special_attributes and not ignore_locals and not name_in_locals:
             result = [self.special_attributes.lookup(name)]
             if name == "__name__":
-                result.append(const_factory("__main__"))
+                main_const = const_factory("__main__")
+                main_const.parent = AstroidManager().builtins_module
+                result.append(main_const)
         elif not ignore_locals and name_in_locals:
             result = self.locals[name]
         elif self.package:


### PR DESCRIPTION
Not having a parent leads to weird situations, like `root()` returning
   the node itself, not a `Module`.

<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |



