### PR TITLE
Require build class parent

### DIFF
--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -37,8 +37,7 @@ def safe_infer(
 
 
 def _build_proxy_class(cls_name: str, builtins: nodes.Module) -> nodes.ClassDef:
-    proxy = raw_building.build_class(cls_name)
-    proxy.parent = builtins
+    proxy = raw_building.build_class(cls_name, builtins)
     return proxy
 
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -178,6 +178,13 @@ def function_to_method(n, klass):
     return n
 
 
+def _attach_to_parent(node: NodeNG, name: str, parent: NodeNG):
+    frame = parent.frame()
+    frame.set_local(name, node)
+    if frame is parent:
+        frame._append_node(node)
+
+
 class Module(LocalsDictNodeNG):
     """Class representing an :class:`ast.Module` node.
 
@@ -1935,7 +1942,7 @@ class ClassDef(  # pylint: disable=too-many-instance-attributes
             parent=parent,
         )
         if parent and not isinstance(parent, Unknown):
-            parent.frame().set_local(name, self)
+            _attach_to_parent(self, name, parent)
 
         for local_name, node in self.implicit_locals():
             self.add_local_node(node, local_name)

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1704,8 +1704,7 @@ def test_infer_dict_from_keys() -> None:
     """
     )
     for node in bad_nodes:
-        with pytest.raises(InferenceError):
-            next(node.infer())
+        assert isinstance(next(node.infer()), util.UninferableBase)
 
     # Test uninferable values
     good_nodes = astroid.extract_node(

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1704,7 +1704,9 @@ def test_infer_dict_from_keys() -> None:
     """
     )
     for node in bad_nodes:
-        assert isinstance(next(node.infer()), util.UninferableBase)
+        with pytest.raises(InferenceError):
+            if isinstance(next(node.infer()), util.UninferableBase):
+                raise InferenceError
 
     # Test uninferable values
     good_nodes = astroid.extract_node(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -26,8 +26,7 @@ class TestHelpers(unittest.TestCase):
         return self.builtins.getattr(obj_name)[0]
 
     def _build_custom_builtin(self, obj_name: str) -> ClassDef:
-        proxy = raw_building.build_class(obj_name)
-        proxy.parent = self.builtins
+        proxy = raw_building.build_class(obj_name, self.builtins)
         return proxy
 
     def assert_classes_equal(self, cls: ClassDef, other: ClassDef) -> None:

--- a/tests/test_raw_building.py
+++ b/tests/test_raw_building.py
@@ -33,6 +33,8 @@ from astroid.raw_building import (
     build_module,
 )
 
+DUMMY_MOD = build_module("DUMMY")
+
 
 class RawBuildingTC(unittest.TestCase):
     def test_attach_dummy_node(self) -> None:
@@ -48,7 +50,7 @@ class RawBuildingTC(unittest.TestCase):
         self.assertEqual(node.parent, None)
 
     def test_build_class(self) -> None:
-        node = build_class("MyClass")
+        node = build_class("MyClass", DUMMY_MOD)
         self.assertEqual(node.name, "MyClass")
         self.assertEqual(node.doc_node, None)
 


### PR DESCRIPTION

A part of getting rid of non-Module roots, see #2536
