### PR TITLE
Fix setuptools dependency to fix `test_identify_old_namespace_package_protocol` 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,7 +117,7 @@ jobs:
         run: |
           python -m venv venv
           . venv/bin/activate
-          python -m pip install -U pip setuptools wheel
+          python -m pip install -U pip wheel
           pip install -U -r requirements_full.txt
           pip install -e .
       - name: Run pytest

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -8,7 +8,7 @@ numpy>=1.17.0,<2; python_version<"3.12"
 python-dateutil
 PyQt6
 regex
-setuptools; python_version<"3.12"
+setuptools; python_version>="3.12"
 six
 urllib3>1,<2
 typing_extensions>=4.4.0


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Description

See the following failure when running tests in `python3.12`
```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    import warnings
    
    with warnings.catch_warnings():
        warnings.simplefilter("ignore", DeprecationWarning)
>       __import__("pkg_resources").declare_namespace(__name__)
E       ModuleNotFoundError: No module named 'pkg_resources'

testdata/python3/data/path_pkg_resources_1/package/__init__.py:5: ModuleNotFoundError

==================================== short test summary info =====================================
FAILED test_manager.py::AstroidManagerTest::test_identify_old_namespace_package_protocol - ModuleNotFoundError: No module named 'pkg_resources'
```
Looks the dependency was incorrectly changed in https://github.com/pylint-dev/astroid/commit/590498dba052b10b81eb8c63c93ee165da51c023. I also removed the implicit `setuptools` dependency as part of this. Not sure if `wheel` should also be moved to the requirements file. So I left it as is.

<!-- If this PR references an issue without fixing it: -->

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->
