### PR TITLE
enforce a non-None parent in build_function

### DIFF
--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -136,6 +136,7 @@ def build_class(
 
 def build_function(
     name: str,
+    parent: nodes.NodeNG,
     args: list[str] | None = None,
     posonlyargs: list[str] | None = None,
     defaults: list[Any] | None = None,
@@ -149,7 +150,7 @@ def build_function(
         name,
         lineno=0,
         col_offset=0,
-        parent=node_classes.Unknown(),
+        parent=parent,
         end_col_offset=0,
         end_lineno=0,
     )
@@ -321,6 +322,7 @@ def object_build_function(
 
     return build_function(
         getattr(member, "__name__", "<no-name>"),
+        node,
         args,
         posonlyargs,
         defaults,
@@ -344,7 +346,7 @@ def object_build_methoddescriptor(
     """create astroid for a living method descriptor object"""
     # FIXME get arguments ?
     name = getattr(member, "__name__", "<no-name>")
-    func = build_function(name, doc=member.__doc__)
+    func = build_function(name, node, doc=member.__doc__)
     _add_dunder_class(func, node, member)
     return func
 

--- a/tests/test_raw_building.py
+++ b/tests/test_raw_building.py
@@ -55,28 +55,28 @@ class RawBuildingTC(unittest.TestCase):
         self.assertEqual(node.doc_node, None)
 
     def test_build_function(self) -> None:
-        node = build_function("MyFunction")
+        node = build_function("MyFunction", DUMMY_MOD)
         self.assertEqual(node.name, "MyFunction")
         self.assertEqual(node.doc_node, None)
 
     def test_build_function_args(self) -> None:
         args = ["myArgs1", "myArgs2"]
-        node = build_function("MyFunction", args)
+        node = build_function("MyFunction", DUMMY_MOD, args)
         self.assertEqual("myArgs1", node.args.args[0].name)
         self.assertEqual("myArgs2", node.args.args[1].name)
         self.assertEqual(2, len(node.args.args))
 
     def test_build_function_defaults(self) -> None:
         defaults = ["defaults1", "defaults2"]
-        node = build_function(name="MyFunction", args=None, defaults=defaults)
+        node = build_function("MyFunction", DUMMY_MOD, args=None, defaults=defaults)
         self.assertEqual(2, len(node.args.defaults))
 
     def test_build_function_posonlyargs(self) -> None:
-        node = build_function(name="MyFunction", posonlyargs=["a", "b"])
+        node = build_function("MyFunction", DUMMY_MOD, posonlyargs=["a", "b"])
         self.assertEqual(2, len(node.args.posonlyargs))
 
     def test_build_function_kwonlyargs(self) -> None:
-        node = build_function(name="MyFunction", kwonlyargs=["a", "b"])
+        node = build_function("MyFunction", DUMMY_MOD, kwonlyargs=["a", "b"])
         assert len(node.args.kwonlyargs) == 2
         assert node.args.kwonlyargs[0].name == "a"
         assert node.args.kwonlyargs[1].name == "b"


### PR DESCRIPTION
A part of getting rid of non-Module roots, see #2536

We also remove `add_local_node` to avoid redundancy. Instead we do the
   attachment to the parent scope in the constructor of `FunctionDef`.

We append a node to the body of the frame when it is also the
   parent. If it's not a parent, then the node should belong to the
   "body" of the parent if it existed. An example is a definition
   within an "if", where the parent is the If node, but the frame is
   the whole module.

it's a part of the campaign to get rid of non-module roots



<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

Refs #XXXX

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #XXXX
