### PR TITLE
use the ClassDef attribute inference process in Instances

### DIFF
--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -1295,7 +1295,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
             self.assertIsInstance(inferred[0], BoundMethod)
         inferred = list(Instance(cls).igetattr("m4"))
         self.assertEqual(len(inferred), 1)
-        self.assertIsInstance(inferred[0], nodes.FunctionDef)
+        self.assertIsInstance(inferred[0], BoundMethod)
 
     def test_getattr_from_grandpa(self) -> None:
         data = """


### PR DESCRIPTION
A part of getting rid of non-Module roots, see #2536


Instances often have «special_attributes». ClassDef does a lot of
   transformations of attibutes during inference, so let's reuse them
   in Instance.

We are fixing inference of the "special" attributes of
   Instances. Before these changes, the FunctionDef attributes
   wouldn't get wrapped into a BoundMethod. This was facilitated by
   extracting the logic of inferring attributes into
   'FunctionDef._infer_attrs' and reusing it in BaseInstance.

  This issue isn't visible right now, because the special attributes
   are simply not found due not being attached to the parent (the
   instance). Which in turn is caused by not providing the actual
   parent in the constructor. Since we are on a quest to always
  provide a parent, this change is necessary.

