### PR TITLE
Bump astroid to 3.3.3, update changelog

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -209,3 +209,4 @@ under this name, or we did not manage to find their commits in the history.
 - correctmost <134317971+correctmost@users.noreply.github.com>
 - Oleh Prypin <oleh@pryp.in>
 - Eric Vergnaud <eric.vergnaud@wanadoo.fr>
+- Hashem Nasarat <Hnasar@users.noreply.github.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,9 +9,15 @@ Release date: TBA
 
 
 
-What's New in astroid 3.3.3?
+What's New in astroid 3.3.4?
 ============================
 Release date: TBA
+
+
+
+What's New in astroid 3.3.3?
+============================
+Release date: 2024-09-20
 
 * Fix inference regression with property setters.
 

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.3.2"
+__version__ = "3.3.3"
 version = __version__

--- a/script/.contributors_aliases.json
+++ b/script/.contributors_aliases.json
@@ -22,6 +22,10 @@
     "mails": ["55152140+jayaddison@users.noreply.github.com", "jay@jp-hosting.net"],
     "name": "James Addison"
   },
+  "Hnasar@users.noreply.github.com": {
+    "mails": ["Hnasar@users.noreply.github.com", "hashem@hudson-trading.com"],
+    "name": "Hashem Nasarat"
+  },
   "adam.grant.hendry@gmail.com": {
     "mails": ["adam.grant.hendry@gmail.com"],
     "name": "Adam Hendry"
@@ -84,10 +88,6 @@
     "mails": ["guillaume.peillex@gmail.com"],
     "name": "Hippo91",
     "team": "Maintainers"
-  },
-  "Hnasar@users.noreply.github.com": {
-    "mails": ["Hnasar@users.noreply.github.com", "hashem@hudson-trading.com"],
-    "name": "Hashem Nasarat"
   },
   "hugovk@users.noreply.github.com": {
     "mails": ["hugovk@users.noreply.github.com"],

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.3.2"
+current = "3.3.3"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 3.3.3?
============================
Release date: 2024-09-20

* Fix inference regression with property setters.

  Closes pylint-dev/pylint#9811

* Add annotation-only instance attributes to attrs classes to fix `no-member` false positives.

  Closes #2514