### PR TITLE
[Backport maintenance/3.3.x] Fix `manager.clear_cache()` not fully clearing the module cache (#2572)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,7 +13,9 @@ What's New in astroid 3.3.4?
 ============================
 Release date: TBA
 
+* Fix bug with ``manager.clear_cache()`` not fully clearing cache
 
+  Refs https://github.com/pylint-dev/pylint/pull/9932#issuecomment-2364985551
 
 What's New in astroid 3.3.3?
 ============================

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -464,6 +464,8 @@ class AstroidManager:
         _invalidate_cache()  # inference context cache
 
         self.astroid_cache.clear()
+        self._mod_file_cache.clear()
+
         # NB: not a new TransformVisitor()
         AstroidManager.brain["_transform"].transforms = collections.defaultdict(list)
 

--- a/tests/testdata/python3/data/cache/a.py
+++ b/tests/testdata/python3/data/cache/a.py
@@ -1,0 +1,1 @@
+""" Test for clear cache. Doesn't need anything here"""


### PR DESCRIPTION
(cherry picked from commit 58286a1bbe55f41dc2eca0ae61755d030654f093)
