### PR TITLE
Check for empty format specs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,9 @@ What's New in astroid 3.4.0?
 ============================
 Release date: TBA
 
+* Fix a crash from inferring empty format specs
+
+  Closes pylint-dev/pylint#9945
 
 
 What's New in astroid 3.3.4?

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,18 +7,19 @@ What's New in astroid 3.4.0?
 ============================
 Release date: TBA
 
-* Fix a crash from inferring empty format specs
-
-  Closes pylint-dev/pylint#9945
 
 
 What's New in astroid 3.3.4?
 ============================
 Release date: TBA
 
-* Fix inference regression with property setters
+* Fix bug with ``manager.clear_cache()`` not fully clearing cache
 
-  Closes pylint-dev/pylint#9811
+  Refs https://github.com/pylint-dev/pylint/pull/9932#issuecomment-2364985551
+
+* Fix a crash from inferring empty format specs.
+
+  Closes pylint-dev/pylint#9945
 
 
 What's New in astroid 3.3.3?

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4788,6 +4788,9 @@ class JoinedStr(NodeNG):
     def _infer_from_values(
         cls, nodes: list[NodeNG], context: InferenceContext | None = None, **kwargs: Any
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
+        if not nodes:
+            yield
+            return
         if len(nodes) == 1:
             yield from nodes[0]._infer(context, **kwargs)
             return

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7380,3 +7380,12 @@ def test_sys_argv_uninferable() -> None:
     sys_argv_value = list(a._infer())
     assert len(sys_argv_value) == 1
     assert sys_argv_value[0] is Uninferable
+
+
+def test_empty_format_spec() -> None:
+    """Regression test for https://github.com/pylint-dev/pylint/issues/9945."""
+    node = extract_node('f"{x:}"')
+    assert isinstance(node, nodes.JoinedStr)
+
+    with pytest.raises(IndexError):
+        assert len(list(node.infer())) == 0

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7387,5 +7387,4 @@ def test_empty_format_spec() -> None:
     node = extract_node('f"{x:}"')
     assert isinstance(node, nodes.JoinedStr)
 
-    with pytest.raises(IndexError):
-        assert len(list(node.infer())) == 0
+    assert list(node.infer()) == [util.Uninferable]


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Format specifications were assumed to be nonempty. But empty format strings are possible, and an empty one would trigger a crash.

https://docs.python.org/3/library/string.html#format-specification-mini-language

> A general convention is that an empty format specification produces the same result as if you had called str() on the value. A non-empty format specification typically modifies the result.

Closes https://github.com/pylint-dev/pylint/issues/9945