### PR TITLE
Bump astroid to 3.3.4, update changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,9 +9,15 @@ Release date: TBA
 
 
 
-What's New in astroid 3.3.4?
+What's New in astroid 3.3.5?
 ============================
 Release date: TBA
+
+
+
+What's New in astroid 3.3.4?
+============================
+Release date: 2024-09-23
 
 * Fix regression with f-string inference.
 

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.3.3"
+__version__ = "3.3.4"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.3.3"
+current = "3.3.4"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 3.3.4?
============================
Release date: 2024-09-23

* Fix regression with f-string inference.

  Closes pylint-dev/pylint#9947

* Fix bug with ``manager.clear_cache()`` not fully clearing cache

  Refs https://github.com/pylint-dev/pylint/pull/9932#issuecomment-2364985551

* Fix a crash from inferring empty format specs.

  Closes pylint-dev/pylint#9945