### PR TITLE
wrap GeneratorModel methods into BoundMethod; remove redundant test

### DIFF
--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -718,6 +718,10 @@ class Generator(BaseInstance):
 class AsyncGenerator(Generator):
     """Special node representing an async generator."""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        AsyncGenerator.special_attributes = objectmodel.AsyncGeneratorModel()
+
     def pytype(self) -> Literal["builtins.async_generator"]:
         return "builtins.async_generator"
 

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -695,19 +695,19 @@ class BoundMethodModel(FunctionModel):
 
 
 class GeneratorModel(FunctionModel, ContextManagerModel):
-    def __new__(cls, *args, **kwargs):
+    def __init__(self):
         # Append the values from the GeneratorType unto this object.
-        ret = super().__new__(cls, *args, **kwargs)
+        super().__init__()
         generator = AstroidManager().builtins_module["generator"]
         for name, values in generator.locals.items():
             method = values[0]
+            if isinstance(method, nodes.FunctionDef):
+                method = bases.BoundMethod(method, _get_bound_node(self))
 
             def patched(cls, meth=method):
                 return meth
 
-            setattr(type(ret), IMPL_PREFIX + name, property(patched))
-
-        return ret
+            setattr(type(self), IMPL_PREFIX + name, property(patched))
 
     @property
     def attr___name__(self):
@@ -724,9 +724,9 @@ class GeneratorModel(FunctionModel, ContextManagerModel):
 
 
 class AsyncGeneratorModel(GeneratorModel):
-    def __new__(cls, *args, **kwargs):
+    def __init__(self):
         # Append the values from the AGeneratorType unto this object.
-        ret = super().__new__(cls, *args, **kwargs)
+        super().__init__()
         astroid_builtins = AstroidManager().builtins_module
         generator = astroid_builtins.get("async_generator")
         if generator is None:
@@ -735,13 +735,13 @@ class AsyncGeneratorModel(GeneratorModel):
 
         for name, values in generator.locals.items():
             method = values[0]
+            if isinstance(method, nodes.FunctionDef):
+                method = bases.BoundMethod(method, _get_bound_node(self))
 
             def patched(cls, meth=method):
                 return meth
 
-            setattr(type(ret), IMPL_PREFIX + name, property(patched))
-
-        return ret
+            setattr(type(self), IMPL_PREFIX + name, property(patched))
 
 
 class InstanceModel(ObjectModel):

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -728,11 +728,7 @@ class AsyncGeneratorModel(GeneratorModel):
         # Append the values from the AGeneratorType unto this object.
         super().__init__()
         astroid_builtins = AstroidManager().builtins_module
-        generator = astroid_builtins.get("async_generator")
-        if generator is None:
-            # Make it backward compatible.
-            generator = astroid_builtins.get("generator")
-
+        generator = astroid_builtins["async_generator"]
         for name, values in generator.locals.items():
             method = values[0]
             if isinstance(method, nodes.FunctionDef):

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -627,9 +627,8 @@ def _astroid_bootstrapping() -> None:
         col_offset=0,
         end_lineno=0,
         end_col_offset=0,
-        parent=nodes.Unknown(),
+        parent=astroid_builtin,
     )
-    _GeneratorType.parent = astroid_builtin
     generator_doc_node = (
         nodes.Const(value=types.GeneratorType.__doc__)
         if types.GeneratorType.__doc__
@@ -651,9 +650,8 @@ def _astroid_bootstrapping() -> None:
             col_offset=0,
             end_lineno=0,
             end_col_offset=0,
-            parent=nodes.Unknown(),
+            parent=astroid_builtin,
         )
-        _AsyncGeneratorType.parent = astroid_builtin
         async_generator_doc_node = (
             nodes.Const(value=types.AsyncGeneratorType.__doc__)
             if types.AsyncGeneratorType.__doc__

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -322,24 +322,6 @@ class LookupTest(resources.SysPathSetup, unittest.TestCase):
             self.assertEqual(len(name.lookup("x")[1]), 1, repr(name))
             self.assertEqual(name.lookup("x")[1][0].lineno, 3, repr(name))
 
-    def test_generator_attributes(self) -> None:
-        tree = builder.parse(
-            """
-            def count():
-                "test"
-                yield 0
-
-            iterer = count()
-            num = iterer.next()
-        """
-        )
-        next_node = tree.body[2].value.func
-        gener = next_node.expr.inferred()[0]
-        self.assertIsInstance(gener.getattr("__next__")[0], nodes.FunctionDef)
-        self.assertIsInstance(gener.getattr("send")[0], nodes.FunctionDef)
-        self.assertIsInstance(gener.getattr("throw")[0], nodes.FunctionDef)
-        self.assertIsInstance(gener.getattr("close")[0], nodes.FunctionDef)
-
     def test_explicit___name__(self) -> None:
         code = """
             class Pouet:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1454,7 +1454,7 @@ def test_is_generator_for_yield_assignments() -> None:
     assert bool(inferred.is_generator())
 
 
-class AsyncGeneratorTest:
+class AsyncGeneratorTest(unittest.TestCase):
     def test_async_generator(self):
         node = astroid.extract_node(
             """
@@ -1471,23 +1471,6 @@ class AsyncGeneratorTest:
         assert inferred.getattr("__anext__")
         assert inferred.pytype() == "builtins.async_generator"
         assert inferred.display_type() == "AsyncGenerator"
-
-    def test_async_generator_is_generator_on_older_python(self):
-        node = astroid.extract_node(
-            """
-        async def a_iter(n):
-            for i in range(1, n + 1):
-                yield i
-                await asyncio.sleep(1)
-        a_iter(2) #@
-        """
-        )
-        inferred = next(node.infer())
-        assert isinstance(inferred, bases.Generator)
-        assert inferred.getattr("__iter__")
-        assert inferred.getattr("__next__")
-        assert inferred.pytype() == "builtins.generator"
-        assert inferred.display_type() == "Generator"
 
 
 def test_f_string_correct_line_numbering() -> None:


### PR DESCRIPTION
The LookupTest.test_generator_attributes contains outdated Python 2
   code (doesn't run on Python 3). The test is superceded by
   GeneratorModelTest.test_model.

A part of getting rid of non-Module roots, see https://github.com/pylint-dev/astroid/pull/2536

Supersedes #2563.