### PR TITLE
Move typing imports and some definitions behind guard

### DIFF
--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -4,12 +4,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from astroid import nodes
 from astroid.bases import Instance
 from astroid.context import CallContext, InferenceContext
 from astroid.exceptions import InferenceError, NoDefault
-from astroid.typing import InferenceResult
 from astroid.util import Uninferable, UninferableBase, safe_infer
+
+if TYPE_CHECKING:
+    from astroid.typing import InferenceResult
 
 
 class CallSite:

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -29,8 +29,8 @@ from astroid.interpreter import objectmodel
 from astroid.util import Uninferable, UninferableBase, safe_infer
 
 if TYPE_CHECKING:
-    from typing import Any, Literal
     from collections.abc import Iterable, Iterator
+    from typing import Any, Literal
 
     from astroid.constraint import Constraint
     from astroid.typing import (

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 
 import collections
 import collections.abc
-from collections.abc import Iterable, Iterator
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING
 
 from astroid import decorators, nodes
 from astroid.const import PY310_PLUS
@@ -27,15 +26,18 @@ from astroid.exceptions import (
     NameInferenceError,
 )
 from astroid.interpreter import objectmodel
-from astroid.typing import (
-    InferenceErrorInfo,
-    InferenceResult,
-    SuccessfulInferenceResult,
-)
 from astroid.util import Uninferable, UninferableBase, safe_infer
 
 if TYPE_CHECKING:
+    from typing import Any, Literal
+    from collections.abc import Iterable, Iterator
+
     from astroid.constraint import Constraint
+    from astroid.typing import (
+        InferenceErrorInfo,
+        InferenceResult,
+        SuccessfulInferenceResult,
+    )
 
 
 PROPERTIES = {"builtins.property", "abc.abstractproperty"}

--- a/astroid/brain/brain_argparse.py
+++ b/astroid/brain/brain_argparse.py
@@ -4,11 +4,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from astroid import arguments, nodes
-from astroid.context import InferenceContext
 from astroid.exceptions import UseInferenceDefault
 from astroid.inference_tip import inference_tip
 from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid.context import InferenceContext
 
 
 def infer_namespace(node, context: InferenceContext | None = None):

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -8,10 +8,17 @@ Astroid hook for the attrs library
 Without this hook pylint reports unsupported-assignment-operation
 for attrs classes
 """
-from astroid.manager import AstroidManager
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.nodes.node_classes import AnnAssign, Assign, AssignName, Call, Unknown
 from astroid.nodes.scoped_nodes import ClassDef
 from astroid.util import safe_infer
+
+if TYPE_CHECKING:
+    from astroid.manager import AstroidManager
 
 ATTRIB_NAMES = frozenset(
     (

--- a/astroid/brain/brain_boto3.py
+++ b/astroid/brain/brain_boto3.py
@@ -4,9 +4,16 @@
 
 """Astroid hooks for understanding ``boto3.ServiceRequest()``."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.builder import extract_node
-from astroid.manager import AstroidManager
 from astroid.nodes.scoped_nodes import ClassDef
+
+if TYPE_CHECKING:
+    from astroid.manager import AstroidManager
+
 
 BOTO_SERVICE_FACTORY_QUALIFIED_NAME = "boto3.resources.base.ServiceResource"
 
@@ -28,5 +35,7 @@ def _looks_like_boto3_service_request(node: ClassDef) -> bool:
 
 def register(manager: AstroidManager) -> None:
     manager.register_transform(
-        ClassDef, service_request_transform, _looks_like_boto3_service_request
+        ClassDef,
+        service_request_transform,
+        _looks_like_boto3_service_request,
     )

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -26,8 +26,8 @@ from astroid.nodes import scoped_nodes
 from astroid.raw_building import build_module
 
 if TYPE_CHECKING:
-    from typing import Any, NoReturn
     from collections.abc import Callable, Iterable
+    from typing import Any, NoReturn
 
     from astroid.bases import Instance
     from astroid.context import InferenceContext

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -7,13 +7,12 @@
 from __future__ import annotations
 
 import itertools
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Iterator
 from functools import partial
-from typing import TYPE_CHECKING, Any, NoReturn, Union, cast
+from typing import TYPE_CHECKING, Union, cast
 
 from astroid import arguments, helpers, nodes, objects, util
 from astroid.builder import AstroidBuilder
-from astroid.context import InferenceContext
 from astroid.exceptions import (
     AstroidTypeError,
     AttributeInferenceError,
@@ -25,14 +24,18 @@ from astroid.inference_tip import inference_tip
 from astroid.manager import AstroidManager
 from astroid.nodes import scoped_nodes
 from astroid.raw_building import build_module
-from astroid.typing import (
-    ConstFactoryResult,
-    InferenceResult,
-    SuccessfulInferenceResult,
-)
 
 if TYPE_CHECKING:
+    from typing import Any, NoReturn
+    from collections.abc import Callable, Iterable
+
     from astroid.bases import Instance
+    from astroid.context import InferenceContext
+    from astroid.typing import (
+        ConstFactoryResult,
+        InferenceResult,
+        SuccessfulInferenceResult,
+    )
 
 ContainerObjects = Union[
     objects.FrozenSet,

--- a/astroid/brain/brain_collections.py
+++ b/astroid/brain/brain_collections.py
@@ -12,8 +12,8 @@ from astroid.exceptions import AttributeInferenceError
 from astroid.nodes.scoped_nodes import ClassDef
 
 if TYPE_CHECKING:
-    from astroid.manager import AstroidManager
     from astroid.context import InferenceContext
+    from astroid.manager import AstroidManager
 
 
 def _collections_transform():

--- a/astroid/brain/brain_collections.py
+++ b/astroid/brain/brain_collections.py
@@ -4,12 +4,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import extract_node, parse
-from astroid.context import InferenceContext
 from astroid.exceptions import AttributeInferenceError
-from astroid.manager import AstroidManager
 from astroid.nodes.scoped_nodes import ClassDef
+
+if TYPE_CHECKING:
+    from astroid.manager import AstroidManager
+    from astroid.context import InferenceContext
 
 
 def _collections_transform():

--- a/astroid/brain/brain_crypt.py
+++ b/astroid/brain/brain_crypt.py
@@ -2,10 +2,16 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def _re_transform() -> nodes.Module:

--- a/astroid/brain/brain_ctypes.py
+++ b/astroid/brain/brain_ctypes.py
@@ -10,12 +10,17 @@ the C coded module _ctypes.
 Thus astroid doesn't know that the value member is a builtin type
 among float, int, bytes or str.
 """
-import sys
+from __future__ import annotations
 
-from astroid import nodes
+import sys
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def enrich_ctypes_redefined_types() -> nodes.Module:

--- a/astroid/brain/brain_curses.py
+++ b/astroid/brain/brain_curses.py
@@ -2,10 +2,16 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def _curses_transform() -> nodes.Module:

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -25,8 +25,8 @@ from astroid.manager import AstroidManager
 from astroid.util import Uninferable, UninferableBase, safe_infer
 
 if TYPE_CHECKING:
-    from typing import Literal, Union
     from collections.abc import Iterator
+    from typing import Literal, Union
 
     from astroid import context
     from astroid.typing import InferenceResult

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -14,23 +14,29 @@ dataclasses. References:
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from typing import Literal, Union
+from typing import TYPE_CHECKING
 
-from astroid import bases, context, nodes
+from astroid import bases, nodes
 from astroid.builder import parse
 from astroid.const import PY310_PLUS, PY313_PLUS
 from astroid.exceptions import AstroidSyntaxError, InferenceError, UseInferenceDefault
 from astroid.inference_tip import inference_tip
 from astroid.manager import AstroidManager
-from astroid.typing import InferenceResult
 from astroid.util import Uninferable, UninferableBase, safe_infer
 
-_FieldDefaultReturn = Union[
-    None,
-    tuple[Literal["default"], nodes.NodeNG],
-    tuple[Literal["default_factory"], nodes.Call],
-]
+if TYPE_CHECKING:
+    from typing import Literal, Union
+    from collections.abc import Iterator
+
+    from astroid import context
+    from astroid.typing import InferenceResult
+
+    _FieldDefaultReturn = Union[
+        None,
+        tuple[Literal["default"], nodes.NodeNG],
+        tuple[Literal["default_factory"], nodes.Call],
+    ]
+
 
 DATACLASSES_DECORATORS = frozenset(("dataclass",))
 FIELD_NAME = "field"

--- a/astroid/brain/brain_datetime.py
+++ b/astroid/brain/brain_datetime.py
@@ -2,11 +2,17 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
 from astroid.const import PY312_PLUS
 from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
 
 
 def datetime_transform() -> nodes.Module:

--- a/astroid/brain/brain_dateutil.py
+++ b/astroid/brain/brain_dateutil.py
@@ -4,12 +4,17 @@
 
 """Astroid hooks for dateutil."""
 
-import textwrap
+from __future__ import annotations
 
-from astroid import nodes
+import textwrap
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
 from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
 
 
 def dateutil_transform() -> nodes.Module:

--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from astroid import nodes
-    from astroid.manager import AstroidManager
     from astroid.context import InferenceContext
+    from astroid.manager import AstroidManager
     from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
 

--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -6,21 +6,27 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from functools import partial
 from itertools import chain
+from typing import TYPE_CHECKING
 
-from astroid import BoundMethod, arguments, nodes, objects
+from astroid import BoundMethod, arguments, objects
 from astroid.builder import extract_node
-from astroid.context import InferenceContext
 from astroid.exceptions import InferenceError, UseInferenceDefault
 from astroid.inference_tip import inference_tip
 from astroid.interpreter import objectmodel
-from astroid.manager import AstroidManager
 from astroid.nodes.node_classes import AssignName, Attribute, Call, Name
 from astroid.nodes.scoped_nodes import FunctionDef
-from astroid.typing import InferenceResult, SuccessfulInferenceResult
 from astroid.util import UninferableBase, safe_infer
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from astroid import nodes
+    from astroid.manager import AstroidManager
+    from astroid.context import InferenceContext
+    from astroid.typing import InferenceResult, SuccessfulInferenceResult
+
 
 LRU_CACHE = "functools.lru_cache"
 

--- a/astroid/brain/brain_hashlib.py
+++ b/astroid/brain/brain_hashlib.py
@@ -2,10 +2,16 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def _hashlib_transform() -> nodes.Module:

--- a/astroid/brain/brain_http.py
+++ b/astroid/brain/brain_http.py
@@ -3,12 +3,17 @@
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
 """Astroid brain hints for some of the `http` module."""
-import textwrap
+from __future__ import annotations
 
-from astroid import nodes
+import textwrap
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
 from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
 
 
 def _http_transform() -> nodes.Module:

--- a/astroid/brain/brain_hypothesis.py
+++ b/astroid/brain/brain_hypothesis.py
@@ -16,8 +16,15 @@ defined using the `@hypothesis.strategies.composite` decorator.  For example:
 
     a_strategy()
 """
-from astroid.manager import AstroidManager
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.nodes.scoped_nodes import FunctionDef
+
+if TYPE_CHECKING:
+    from astroid.manager import AstroidManager
+
 
 COMPOSITE_NAMES = (
     "composite",

--- a/astroid/brain/brain_multiprocessing.py
+++ b/astroid/brain/brain_multiprocessing.py
@@ -2,12 +2,18 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.bases import BoundMethod
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.exceptions import InferenceError
-from astroid.manager import AstroidManager
 from astroid.nodes.scoped_nodes import FunctionDef
+
+if TYPE_CHECKING:
+    from astroid.manager import AstroidManager
 
 
 def _multiprocessing_transform():

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -24,8 +24,8 @@ from astroid.inference_tip import inference_tip
 from astroid.manager import AstroidManager
 
 if TYPE_CHECKING:
-    from typing import Final
     from collections.abc import Iterator
+    from typing import Final
 
     import astroid
     from astroid import bases

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -8,12 +8,10 @@ from __future__ import annotations
 
 import functools
 import keyword
-from collections.abc import Iterator
 from textwrap import dedent
-from typing import Final
+from typing import TYPE_CHECKING
 
-import astroid
-from astroid import arguments, bases, nodes, util
+from astroid import arguments, nodes, util
 from astroid.builder import AstroidBuilder, _extract_single_node, extract_node
 from astroid.context import InferenceContext
 from astroid.exceptions import (
@@ -24,6 +22,14 @@ from astroid.exceptions import (
 )
 from astroid.inference_tip import inference_tip
 from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from typing import Final
+    from collections.abc import Iterator
+
+    import astroid
+    from astroid import bases
+
 
 ENUM_QNAME: Final[str] = "enum.Enum"
 TYPING_NAMEDTUPLE_QUALIFIED: Final = {

--- a/astroid/brain/brain_nose.py
+++ b/astroid/brain/brain_nose.py
@@ -4,15 +4,21 @@
 
 """Hooks for nose library."""
 
+from __future__ import annotations
+
 import re
 import textwrap
+from typing import TYPE_CHECKING
 
 from astroid.bases import BoundMethod
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
 from astroid.exceptions import InferenceError
-from astroid.manager import AstroidManager
 from astroid.nodes import List, Module
+
+if TYPE_CHECKING:
+    from astroid.manager import AstroidManager
+
 
 CAPITALS = re.compile("([A-Z])")
 

--- a/astroid/brain/brain_numpy_core_einsumfunc.py
+++ b/astroid/brain/brain_numpy_core_einsumfunc.py
@@ -7,10 +7,16 @@ Astroid hooks for numpy.core.einsumfunc module:
 https://github.com/numpy/numpy/blob/main/numpy/core/einsumfunc.py.
 """
 
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def numpy_core_einsumfunc_transform() -> nodes.Module:

--- a/astroid/brain/brain_numpy_core_fromnumeric.py
+++ b/astroid/brain/brain_numpy_core_fromnumeric.py
@@ -3,10 +3,16 @@
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
 """Astroid hooks for numpy.core.fromnumeric module."""
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def numpy_core_fromnumeric_transform() -> nodes.Module:

--- a/astroid/brain/brain_numpy_core_function_base.py
+++ b/astroid/brain/brain_numpy_core_function_base.py
@@ -4,15 +4,21 @@
 
 """Astroid hooks for numpy.core.function_base module."""
 
+from __future__ import annotations
+
 import functools
+from typing import TYPE_CHECKING
 
 from astroid.brain.brain_numpy_utils import (
     attribute_looks_like_numpy_member,
     infer_numpy_member,
 )
 from astroid.inference_tip import inference_tip
-from astroid.manager import AstroidManager
 from astroid.nodes.node_classes import Attribute
+
+if TYPE_CHECKING:
+    from astroid.manager import AstroidManager
+
 
 METHODS_TO_BE_INFERRED = {
     "linspace": """def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis=0):

--- a/astroid/brain/brain_numpy_core_multiarray.py
+++ b/astroid/brain/brain_numpy_core_multiarray.py
@@ -4,9 +4,11 @@
 
 """Astroid hooks for numpy.core.multiarray module."""
 
-import functools
+from __future__ import annotations
 
-from astroid import nodes
+import functools
+from typing import TYPE_CHECKING
+
 from astroid.brain.brain_numpy_utils import (
     attribute_looks_like_numpy_member,
     infer_numpy_member,
@@ -15,8 +17,11 @@ from astroid.brain.brain_numpy_utils import (
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.inference_tip import inference_tip
-from astroid.manager import AstroidManager
 from astroid.nodes.node_classes import Attribute, Name
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def numpy_core_multiarray_transform() -> nodes.Module:

--- a/astroid/brain/brain_numpy_core_numeric.py
+++ b/astroid/brain/brain_numpy_core_numeric.py
@@ -4,9 +4,11 @@
 
 """Astroid hooks for numpy.core.numeric module."""
 
-import functools
+from __future__ import annotations
 
-from astroid import nodes
+import functools
+from typing import TYPE_CHECKING
+
 from astroid.brain.brain_numpy_utils import (
     attribute_looks_like_numpy_member,
     infer_numpy_member,
@@ -14,8 +16,11 @@ from astroid.brain.brain_numpy_utils import (
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.inference_tip import inference_tip
-from astroid.manager import AstroidManager
 from astroid.nodes.node_classes import Attribute
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def numpy_core_numeric_transform() -> nodes.Module:

--- a/astroid/brain/brain_numpy_core_numerictypes.py
+++ b/astroid/brain/brain_numpy_core_numerictypes.py
@@ -5,11 +5,17 @@
 # TODO(hippo91) : correct the methods signature.
 
 """Astroid hooks for numpy.core.numerictypes module."""
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.brain_numpy_utils import numpy_supports_type_hints
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def numpy_core_numerictypes_transform() -> nodes.Module:

--- a/astroid/brain/brain_numpy_core_umath.py
+++ b/astroid/brain/brain_numpy_core_umath.py
@@ -7,10 +7,16 @@
 # typecheck in `_emit_no_member` function)
 
 """Astroid hooks for numpy.core.umath module."""
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def numpy_core_umath_transform() -> nodes.Module:

--- a/astroid/brain/brain_numpy_ma.py
+++ b/astroid/brain/brain_numpy_ma.py
@@ -4,10 +4,16 @@
 
 """Astroid hooks for numpy ma module."""
 
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def numpy_ma_transform() -> nodes.Module:

--- a/astroid/brain/brain_numpy_ndarray.py
+++ b/astroid/brain/brain_numpy_ndarray.py
@@ -5,12 +5,16 @@
 """Astroid hooks for numpy ndarray class."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from astroid.brain.brain_numpy_utils import numpy_supports_type_hints
 from astroid.builder import extract_node
-from astroid.context import InferenceContext
 from astroid.inference_tip import inference_tip
-from astroid.manager import AstroidManager
 from astroid.nodes.node_classes import Attribute
+
+if TYPE_CHECKING:
+    from astroid.context import InferenceContext
+    from astroid.manager import AstroidManager
 
 
 def infer_numpy_ndarray(node, context: InferenceContext | None = None):

--- a/astroid/brain/brain_numpy_random_mtrand.py
+++ b/astroid/brain/brain_numpy_random_mtrand.py
@@ -4,10 +4,16 @@
 
 # TODO(hippo91) : correct the functions return types
 """Astroid hooks for numpy.random.mtrand module."""
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def numpy_random_mtrand_transform() -> nodes.Module:

--- a/astroid/brain/brain_numpy_utils.py
+++ b/astroid/brain/brain_numpy_utils.py
@@ -6,9 +6,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from astroid.builder import extract_node
-from astroid.context import InferenceContext
-from astroid.nodes.node_classes import Attribute, Import, Name
+from astroid.nodes.node_classes import Import, Name
+
+if TYPE_CHECKING:
+    from astroid.context import InferenceContext
+    from astroid.nodes.node_classes import Attribute
+
 
 # Class subscript is available in numpy starting with version 1.20.0
 NUMPY_VERSION_TYPE_HINTS_SUPPORT = ("1", "20", "0")

--- a/astroid/brain/brain_pathlib.py
+++ b/astroid/brain/brain_pathlib.py
@@ -4,14 +4,20 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
-from astroid import bases, context, nodes
+from astroid import bases, nodes
 from astroid.builder import _extract_single_node
 from astroid.const import PY313_PLUS
 from astroid.exceptions import InferenceError, UseInferenceDefault
 from astroid.inference_tip import inference_tip
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from astroid import context
+    from astroid.manager import AstroidManager
+
 
 PATH_TEMPLATE = """
 from pathlib import Path

--- a/astroid/brain/brain_pkg_resources.py
+++ b/astroid/brain/brain_pkg_resources.py
@@ -2,10 +2,16 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def pkg_resources_transform() -> nodes.Module:

--- a/astroid/brain/brain_pytest.py
+++ b/astroid/brain/brain_pytest.py
@@ -3,10 +3,16 @@
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
 """Astroid hooks for pytest."""
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
 from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
 
 
 def pytest_transform() -> nodes.Module:

--- a/astroid/brain/brain_random.py
+++ b/astroid/brain/brain_random.py
@@ -5,11 +5,10 @@
 from __future__ import annotations
 
 import random
+from typing import TYPE_CHECKING
 
-from astroid.context import InferenceContext
 from astroid.exceptions import UseInferenceDefault
 from astroid.inference_tip import inference_tip
-from astroid.manager import AstroidManager
 from astroid.nodes.node_classes import (
     Attribute,
     Call,
@@ -21,6 +20,11 @@ from astroid.nodes.node_classes import (
     Tuple,
 )
 from astroid.util import safe_infer
+
+if TYPE_CHECKING:
+    from astroid.context import InferenceContext
+    from astroid.manager import AstroidManager
+
 
 ACCEPTED_ITERABLES_FOR_SAMPLE = (List, Set, Tuple)
 

--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -4,12 +4,17 @@
 
 from __future__ import annotations
 
-from astroid import context, nodes
+from typing import TYPE_CHECKING
+
+from astroid import nodes
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import _extract_single_node, parse
 from astroid.const import PY311_PLUS
 from astroid.inference_tip import inference_tip
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import context
+    from astroid.manager import AstroidManager
 
 
 def _re_transform() -> nodes.Module:

--- a/astroid/brain/brain_regex.py
+++ b/astroid/brain/brain_regex.py
@@ -4,11 +4,16 @@
 
 from __future__ import annotations
 
-from astroid import context, nodes
+from typing import TYPE_CHECKING
+
+from astroid import nodes
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import _extract_single_node, parse
 from astroid.inference_tip import inference_tip
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import context
+    from astroid.manager import AstroidManager
 
 
 def _regex_transform() -> nodes.Module:

--- a/astroid/brain/brain_responses.py
+++ b/astroid/brain/brain_responses.py
@@ -10,10 +10,16 @@ It might need to be manually updated from the public methods of
 
 See: https://github.com/getsentry/responses/blob/master/responses.py
 """
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def responses_funcs() -> nodes.Module:

--- a/astroid/brain/brain_scipy_signal.py
+++ b/astroid/brain/brain_scipy_signal.py
@@ -3,10 +3,16 @@
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
 """Astroid hooks for scipy.signal module."""
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def scipy_signal() -> nodes.Module:

--- a/astroid/brain/brain_signal.py
+++ b/astroid/brain/brain_signal.py
@@ -25,11 +25,16 @@ actual standard signal numbers - which may vary depending on the system.
 """
 
 
+from __future__ import annotations
+
 import sys
+from typing import TYPE_CHECKING
 
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid.manager import AstroidManager
 
 
 def _signals_enums_transform():

--- a/astroid/brain/brain_sqlalchemy.py
+++ b/astroid/brain/brain_sqlalchemy.py
@@ -2,10 +2,16 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def _session_transform() -> nodes.Module:

--- a/astroid/brain/brain_ssl.py
+++ b/astroid/brain/brain_ssl.py
@@ -4,11 +4,17 @@
 
 """Astroid hooks for the ssl library."""
 
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.const import PY310_PLUS, PY312_PLUS
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def _verifyflags_enum() -> str:

--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import textwrap
 from typing import TYPE_CHECKING
 
-
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.const import PY310_PLUS, PY311_PLUS

--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -2,13 +2,19 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-import textwrap
+from __future__ import annotations
 
-from astroid import nodes
+import textwrap
+from typing import TYPE_CHECKING
+
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.const import PY310_PLUS, PY311_PLUS
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def _subprocess_transform() -> nodes.Module:

--- a/astroid/brain/brain_threading.py
+++ b/astroid/brain/brain_threading.py
@@ -2,10 +2,16 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def _thread_transform() -> nodes.Module:

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -30,8 +30,8 @@ from astroid.exceptions import UseInferenceDefault
 from astroid.inference_tip import inference_tip
 
 if TYPE_CHECKING:
-    from astroid.manager import AstroidManager
     from astroid.context import InferenceContext
+    from astroid.manager import AstroidManager
 
 
 def _looks_like_type_subscript(node: nodes.Name) -> bool:

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -22,12 +22,16 @@ Thanks to Lukasz Langa for fruitful discussion.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from astroid import nodes
 from astroid.builder import extract_node
-from astroid.context import InferenceContext
 from astroid.exceptions import UseInferenceDefault
 from astroid.inference_tip import inference_tip
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid.manager import AstroidManager
+    from astroid.context import InferenceContext
 
 
 def _looks_like_type_subscript(node: nodes.Name) -> bool:

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -35,8 +35,8 @@ from astroid.nodes.node_classes import (
 from astroid.nodes.scoped_nodes import ClassDef, FunctionDef
 
 if TYPE_CHECKING:
-    from typing import Final
     from collections.abc import Iterator
+    from typing import Final
 
     from astroid import context
     from astroid.nodes.node_classes import NodeNG

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -8,11 +8,9 @@ from __future__ import annotations
 
 import textwrap
 import typing
-from collections.abc import Iterator
 from functools import partial
-from typing import Final
+from typing import TYPE_CHECKING
 
-from astroid import context
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder, _extract_single_node, extract_node
 from astroid.const import PY312_PLUS, PY313_PLUS
@@ -32,10 +30,16 @@ from astroid.nodes.node_classes import (
     Const,
     JoinedStr,
     Name,
-    NodeNG,
     Subscript,
 )
 from astroid.nodes.scoped_nodes import ClassDef, FunctionDef
+
+if TYPE_CHECKING:
+    from typing import Final
+    from collections.abc import Iterator
+
+    from astroid import context
+    from astroid.nodes.node_classes import NodeNG
 
 TYPING_TYPEVARS = {"TypeVar", "NewType"}
 TYPING_TYPEVARS_QUALIFIED: Final = {

--- a/astroid/brain/brain_unittest.py
+++ b/astroid/brain/brain_unittest.py
@@ -3,10 +3,16 @@
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
 """Astroid hooks for unittest module."""
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+    from astroid.manager import AstroidManager
 
 
 def IsolatedAsyncioTestCaseImport() -> nodes.Module:

--- a/astroid/brain/brain_uuid.py
+++ b/astroid/brain/brain_uuid.py
@@ -3,9 +3,16 @@
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
 """Astroid hooks for the UUID module."""
-from astroid.manager import AstroidManager
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from astroid.nodes.node_classes import Const
 from astroid.nodes.scoped_nodes import ClassDef
+
+if TYPE_CHECKING:
+    from astroid.manager import AstroidManager
 
 
 def _patch_uuid_class(node: ClassDef) -> None:

--- a/astroid/brain/helpers.py
+++ b/astroid/brain/helpers.py
@@ -4,10 +4,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
-from astroid.manager import AstroidManager
 from astroid.nodes.scoped_nodes import Module
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from astroid.manager import AstroidManager
 
 
 def register_module_extender(

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -10,20 +10,26 @@ at the same time.
 
 from __future__ import annotations
 
-import ast
 import os
 import textwrap
-import types
 import warnings
-from collections.abc import Iterator, Sequence
-from io import TextIOWrapper
 from tokenize import detect_encoding
+from typing import TYPE_CHECKING
 
 from astroid import bases, modutils, nodes, raw_building, rebuilder, util
-from astroid._ast import ParserModule, get_parser_module
+from astroid._ast import get_parser_module
 from astroid.const import PY312_PLUS
 from astroid.exceptions import AstroidBuildingError, AstroidSyntaxError, InferenceError
 from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    import ast
+    import types
+    from io import TextIOWrapper
+    from collections.abc import Iterator, Sequence
+
+    from astroid._ast import ParserModule
+
 
 # The name of the transient function that is used to
 # wrap expressions to be extracted when calling

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -25,8 +25,8 @@ from astroid.manager import AstroidManager
 if TYPE_CHECKING:
     import ast
     import types
-    from io import TextIOWrapper
     from collections.abc import Iterator, Sequence
+    from io import TextIOWrapper
 
     from astroid._ast import ParserModule
 

--- a/astroid/constraint.py
+++ b/astroid/constraint.py
@@ -5,23 +5,25 @@
 """Classes representing different types of constraints on inference values."""
 from __future__ import annotations
 
-import sys
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from astroid import nodes, util
-from astroid.typing import InferenceResult
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
 
 if TYPE_CHECKING:
-    from astroid import bases
+    import sys
+    from typing import Union
+    from collections.abc import Iterator
 
-_NameNodes = Union[nodes.AssignAttr, nodes.Attribute, nodes.AssignName, nodes.Name]
+    from astroid import bases
+    from astroid.typing import InferenceResult
+
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
+
+    _NameNodes = Union[nodes.AssignAttr, nodes.Attribute, nodes.AssignName, nodes.Name]
 
 
 class Constraint(ABC):

--- a/astroid/constraint.py
+++ b/astroid/constraint.py
@@ -12,8 +12,8 @@ from astroid import nodes, util
 
 if TYPE_CHECKING:
     import sys
-    from typing import Union
     from collections.abc import Iterator
+    from typing import Union
 
     from astroid import bases
     from astroid.typing import InferenceResult

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -8,18 +8,21 @@ from __future__ import annotations
 
 import contextlib
 import pprint
-from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, Optional
-
-from astroid.typing import InferenceResult, SuccessfulInferenceResult
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Optional
+    from collections.abc import Iterator, Sequence
+
     from astroid import constraint, nodes
     from astroid.nodes.node_classes import Keyword, NodeNG
+    from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
-_InferenceCache = dict[
-    tuple["NodeNG", Optional[str], Optional[str], Optional[str]], Sequence["NodeNG"]
-]
+    _InferenceCache = dict[
+        tuple["NodeNG", Optional[str], Optional[str], Optional[str]],
+        Sequence["NodeNG"],
+    ]
+
 
 _INFERENCE_CACHE: _InferenceCache = {}
 

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -11,8 +11,8 @@ import pprint
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Optional
     from collections.abc import Iterator, Sequence
+    from typing import Optional
 
     from astroid import constraint, nodes
     from astroid.nodes.node_classes import Keyword, NodeNG

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -10,13 +10,16 @@ import functools
 import inspect
 import sys
 import warnings
-from collections.abc import Callable, Generator
-from typing import TypeVar
+from typing import TypeVar, TYPE_CHECKING
 
 from astroid import util
 from astroid.context import InferenceContext
 from astroid.exceptions import InferenceError
-from astroid.typing import InferenceResult
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+
+    from astroid.typing import InferenceResult
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -10,7 +10,7 @@ import functools
 import inspect
 import sys
 import warnings
-from typing import TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from astroid import util
 from astroid.context import InferenceContext

--- a/astroid/exceptions.py
+++ b/astroid/exceptions.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
     from collections.abc import Iterable, Iterator
+    from typing import Any
 
     from astroid import arguments, bases, nodes, objects
     from astroid.context import InferenceContext

--- a/astroid/exceptions.py
+++ b/astroid/exceptions.py
@@ -6,14 +6,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator
-from typing import TYPE_CHECKING, Any
-
-from astroid.typing import InferenceResult, SuccessfulInferenceResult
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Any
+    from collections.abc import Iterable, Iterator
+
     from astroid import arguments, bases, nodes, objects
     from astroid.context import InferenceContext
+    from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
 __all__ = (
     "AstroidBuildingError",

--- a/astroid/filter_statements.py
+++ b/astroid/filter_statements.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from astroid import nodes
-from astroid.typing import SuccessfulInferenceResult
 
 if TYPE_CHECKING:
     from astroid.nodes import _base_nodes
+    from astroid.typing import SuccessfulInferenceResult
 
 
 def _get_filtered_node_statements(

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 from astroid import bases, manager, nodes, objects, raw_building, util
 from astroid.context import CallContext, InferenceContext
@@ -19,8 +19,12 @@ from astroid.exceptions import (
     _NonDeducibleTypeHierarchy,
 )
 from astroid.nodes import scoped_nodes
-from astroid.typing import InferenceResult
 from astroid.util import safe_infer as real_safe_infer
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from astroid.typing import InferenceResult
 
 
 def safe_infer(

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -13,8 +13,8 @@ from astroid.exceptions import InferenceOverwriteError, UseInferenceDefault
 from astroid.nodes import NodeNG
 
 if TYPE_CHECKING:
-    from typing import Any, TypeVar
     from collections.abc import Generator
+    from typing import Any, TypeVar
 
     from astroid.context import InferenceContext
     from astroid.typing import (

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -7,25 +7,30 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from collections.abc import Generator
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING
 
-from astroid.context import InferenceContext
 from astroid.exceptions import InferenceOverwriteError, UseInferenceDefault
 from astroid.nodes import NodeNG
-from astroid.typing import (
-    InferenceResult,
-    InferFn,
-    TransformFn,
-)
+
+if TYPE_CHECKING:
+    from typing import Any, TypeVar
+    from collections.abc import Generator
+
+    from astroid.context import InferenceContext
+    from astroid.typing import (
+        InferenceResult,
+        InferFn,
+        TransformFn,
+    )
+
+    _NodesT = TypeVar("_NodesT", bound=NodeNG)
+
 
 _cache: OrderedDict[
     tuple[InferFn[Any], NodeNG, InferenceContext | None], list[InferenceResult]
 ] = OrderedDict()
 
 _CURRENTLY_INFERRING: set[tuple[InferFn[Any], NodeNG]] = set()
-
-_NodesT = TypeVar("_NodesT", bound=NodeNG)
 
 
 def clear_inference_tip_cache() -> None:

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -10,20 +10,22 @@ import importlib
 import importlib.machinery
 import importlib.util
 import os
-import pathlib
 import sys
-import types
 import warnings
 import zipimport
-from collections.abc import Iterable, Iterator, Sequence
 from functools import lru_cache
 from pathlib import Path
-from typing import Literal, NamedTuple, Protocol
+from typing import TYPE_CHECKING, NamedTuple, Protocol
 
 from astroid.const import PY310_PLUS
 from astroid.modutils import EXT_LIB_DIRS, cached_os_path_isfile
 
 from . import util
+
+if TYPE_CHECKING:
+    import types
+    from typing import Literal
+    from collections.abc import Iterable, Iterator, Sequence
 
 
 # The MetaPathFinder protocol comes from typeshed, which says:
@@ -321,7 +323,7 @@ _SPEC_FINDERS = (
 )
 
 
-def _is_setuptools_namespace(location: pathlib.Path) -> bool:
+def _is_setuptools_namespace(location: Path) -> bool:
     try:
         with open(location / "__init__.py", "rb") as stream:
             data = stream.read(4096)

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -24,8 +24,8 @@ from . import util
 
 if TYPE_CHECKING:
     import types
-    from typing import Literal
     from collections.abc import Iterable, Iterator, Sequence
+    from typing import Literal
 
 
 # The MetaPathFinder protocol comes from typeshed, which says:

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -7,10 +7,13 @@ from __future__ import annotations
 import pathlib
 import sys
 from functools import lru_cache
-from importlib._bootstrap_external import _NamespacePath
+from typing import TYPE_CHECKING
 from importlib.util import _find_spec_from_path  # type: ignore[attr-defined]
 
 from astroid.const import IS_PYPY
+
+if TYPE_CHECKING:
+    from importlib._bootstrap_external import _NamespacePath
 
 if sys.version_info >= (3, 11):
     from importlib.machinery import NamespaceLoader

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 import pathlib
 import sys
 from functools import lru_cache
-from typing import TYPE_CHECKING
 from importlib.util import _find_spec_from_path  # type: ignore[attr-defined]
+from typing import TYPE_CHECKING
 
 from astroid.const import IS_PYPY
 

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -27,9 +27,8 @@ import itertools
 import os
 import pprint
 import types
-from collections.abc import Iterator
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING
 
 import astroid
 from astroid import bases, nodes, util
@@ -37,10 +36,13 @@ from astroid.context import InferenceContext, copy_context
 from astroid.exceptions import AttributeInferenceError, InferenceError, NoDefault
 from astroid.manager import AstroidManager
 from astroid.nodes import node_classes
-from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
 if TYPE_CHECKING:
+    from typing import Any, Literal
+    from collections.abc import Iterator
+
     from astroid.objects import Property
+    from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
 IMPL_PREFIX = "attr_"
 LEN_OF_IMPL_PREFIX = len(IMPL_PREFIX)

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -38,8 +38,8 @@ from astroid.manager import AstroidManager
 from astroid.nodes import node_classes
 
 if TYPE_CHECKING:
-    from typing import Any, Literal
     from collections.abc import Iterator
+    from typing import Any, Literal
 
     from astroid.objects import Property
     from astroid.typing import InferenceResult, SuccessfulInferenceResult

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -11,13 +11,11 @@ from __future__ import annotations
 
 import collections
 import os
-import types
 import zipimport
-from collections.abc import Callable, Iterator, Sequence
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING
 
 from astroid import nodes
-from astroid.context import InferenceContext, _invalidate_cache
+from astroid.context import _invalidate_cache
 from astroid.exceptions import AstroidBuildingError, AstroidImportError
 from astroid.interpreter._import import spec, util
 from astroid.modutils import (
@@ -34,7 +32,15 @@ from astroid.modutils import (
     modpath_from_file,
 )
 from astroid.transforms import TransformVisitor
-from astroid.typing import AstroidManagerBrain, InferenceResult
+
+if TYPE_CHECKING:
+    import types
+    from typing import Any, ClassVar
+    from collections.abc import Callable, Iterator, Sequence
+
+    from astroid.context import InferenceContext
+    from astroid.typing import AstroidManagerBrain, InferenceResult
+
 
 ZIP_IMPORT_EXTS = (".zip", ".egg", ".whl", ".pyz", ".pyzw")
 

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -35,8 +35,8 @@ from astroid.transforms import TransformVisitor
 
 if TYPE_CHECKING:
     import types
-    from typing import Any, ClassVar
     from collections.abc import Callable, Iterator, Sequence
+    from typing import Any, ClassVar
 
     from astroid.context import InferenceContext
     from astroid.typing import AstroidManagerBrain, InferenceResult

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -25,14 +25,18 @@ import logging
 import os
 import sys
 import sysconfig
-import types
 import warnings
-from collections.abc import Callable, Iterable, Sequence
 from contextlib import redirect_stderr, redirect_stdout
 from functools import lru_cache
+from typing import TYPE_CHECKING
 
 from astroid.const import IS_JYTHON, PY310_PLUS
 from astroid.interpreter._import import spec, util
+
+if TYPE_CHECKING:
+    import types
+    from collections.abc import Callable, Iterable, Sequence
+
 
 if PY310_PLUS:
     from sys import stdlib_module_names

--- a/astroid/nodes/_base_nodes.py
+++ b/astroid/nodes/_base_nodes.py
@@ -29,8 +29,8 @@ from astroid.nodes.node_ng import NodeNG
 from astroid.typing import InferenceResult
 
 if TYPE_CHECKING:
-    from typing import Any, ClassVar, Optional, Union
     from collections.abc import Callable, Generator, Iterator
+    from typing import Any, ClassVar, Optional, Union
 
     from astroid.nodes.node_classes import LocalsDictNodeNG
 

--- a/astroid/nodes/_base_nodes.py
+++ b/astroid/nodes/_base_nodes.py
@@ -10,9 +10,8 @@ Previously these were called Mixin nodes.
 from __future__ import annotations
 
 import itertools
-from collections.abc import Callable, Generator, Iterator
 from functools import cached_property, lru_cache, partial
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union
+from typing import TYPE_CHECKING
 
 from astroid import bases, nodes, util
 from astroid.const import PY310_PLUS
@@ -30,6 +29,9 @@ from astroid.nodes.node_ng import NodeNG
 from astroid.typing import InferenceResult
 
 if TYPE_CHECKING:
+    from typing import Any, ClassVar, Optional, Union
+    from collections.abc import Callable, Generator, Iterator
+
     from astroid.nodes.node_classes import LocalsDictNodeNG
 
     GetFlowFactory = Callable[

--- a/astroid/nodes/as_string.py
+++ b/astroid/nodes/as_string.py
@@ -7,12 +7,13 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 from astroid import nodes
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from astroid import objects
     from astroid.nodes import Const
     from astroid.nodes.node_classes import (

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING
 from astroid import decorators, protocols, util
 from astroid.bases import Instance, _infer_stmts
 from astroid.const import _EMPTY_OBJECT_MARKER
-from astroid.typing import InferenceErrorInfo
 from astroid.context import CallContext, InferenceContext, copy_context
 from astroid.exceptions import (
     AstroidBuildingError,
@@ -38,11 +37,12 @@ from astroid.manager import AstroidManager
 from astroid.nodes import _base_nodes
 from astroid.nodes.const import OP_PRECEDENCE
 from astroid.nodes.node_ng import NodeNG
+from astroid.typing import InferenceErrorInfo
 
 if TYPE_CHECKING:
     import sys
-    from typing import Any, ClassVar, Literal, Optional, Union
     from collections.abc import Callable, Generator, Iterable, Iterator, Mapping
+    from typing import Any, ClassVar, Literal, Optional, Union
 
     from astroid import nodes
     from astroid.const import Context

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import pprint
-
 import warnings
 from functools import cached_property
 from functools import singledispatch as _singledispatch
@@ -31,9 +30,9 @@ from astroid.nodes.as_string import AsStringVisitor
 from astroid.nodes.const import OP_PRECEDENCE
 
 if TYPE_CHECKING:
+    from collections.abc import Generator, Iterator
     from sys import version_info
     from typing import Any, ClassVar, Literal
-    from collections.abc import Generator, Iterator
 
     from astroid import nodes
     from astroid.nodes import _base_nodes

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -5,16 +5,12 @@
 from __future__ import annotations
 
 import pprint
-import sys
+
 import warnings
-from collections.abc import Generator, Iterator
 from functools import cached_property
 from functools import singledispatch as _singledispatch
 from typing import (
     TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Literal,
     TypeVar,
     Union,
     cast,
@@ -33,18 +29,21 @@ from astroid.exceptions import (
 from astroid.manager import AstroidManager
 from astroid.nodes.as_string import AsStringVisitor
 from astroid.nodes.const import OP_PRECEDENCE
-from astroid.nodes.utils import Position
-from astroid.typing import InferenceErrorInfo, InferenceResult, InferFn
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
-
 
 if TYPE_CHECKING:
+    from sys import version_info
+    from typing import Any, ClassVar, Literal
+    from collections.abc import Generator, Iterator
+
     from astroid import nodes
     from astroid.nodes import _base_nodes
+    from astroid.nodes.utils import Position
+    from astroid.typing import InferenceErrorInfo, InferenceResult, InferFn
+
+    if version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
 
 # Types for 'NodeNG.nodes_of_class()'

--- a/astroid/nodes/scoped_nodes/mixin.py
+++ b/astroid/nodes/scoped_nodes/mixin.py
@@ -6,18 +6,20 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, overload
+from typing import TYPE_CHECKING, overload
 
 from astroid.exceptions import ParentMissingError
 from astroid.filter_statements import _filter_stmts
 from astroid.nodes import _base_nodes, scoped_nodes
 from astroid.nodes.scoped_nodes.utils import builtin_lookup
-from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
 if TYPE_CHECKING:
-    from astroid import nodes
+    from typing import TypeVar
 
-_T = TypeVar("_T")
+    from astroid import nodes
+    from astroid.typing import InferenceResult, SuccessfulInferenceResult
+
+    _T = TypeVar("_T")
 
 
 class LocalsDictNodeNG(_base_nodes.LookupMixIn):

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -14,9 +14,8 @@ import io
 import itertools
 import os
 import warnings
-from collections.abc import Generator, Iterable, Iterator, Sequence
 from functools import cached_property, lru_cache
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, NoReturn, TypeVar
+from typing import TYPE_CHECKING
 
 from astroid import bases, protocols, util
 from astroid.context import (
@@ -43,7 +42,6 @@ from astroid.manager import AstroidManager
 from astroid.nodes import (
     Arguments,
     Const,
-    NodeNG,
     Unknown,
     _base_nodes,
     const_factory,
@@ -51,17 +49,23 @@ from astroid.nodes import (
 )
 from astroid.nodes.scoped_nodes.mixin import ComprehensionScope, LocalsDictNodeNG
 from astroid.nodes.scoped_nodes.utils import builtin_lookup
-from astroid.nodes.utils import Position
-from astroid.typing import (
-    InferBinaryOp,
-    InferenceErrorInfo,
-    InferenceResult,
-    SuccessfulInferenceResult,
-)
+from astroid.typing import InferenceErrorInfo
 
 if TYPE_CHECKING:
+    from typing import Any, ClassVar, Literal, NoReturn, TypeVar
+    from collections.abc import Generator, Iterable, Iterator, Sequence
+
     from astroid import nodes, objects
+    from astroid.nodes import NodeNG
+    from astroid.nodes.utils import Position
     from astroid.nodes._base_nodes import LookupMixIn
+    from astroid.typing import (
+        InferBinaryOp,
+        InferenceResult,
+        SuccessfulInferenceResult,
+    )
+
+    _T = TypeVar("_T")
 
 
 ITER_METHODS = ("__iter__", "__getitem__")
@@ -69,8 +73,6 @@ EXCEPTION_BASE_CLASSES = frozenset({"Exception", "BaseException"})
 BUILTIN_DESCRIPTORS = frozenset(
     {"classmethod", "staticmethod", "builtins.classmethod", "builtins.staticmethod"}
 )
-
-_T = TypeVar("_T")
 
 
 def _c3_merge(sequences, cls, context):
@@ -566,7 +568,7 @@ class Module(LocalsDictNodeNG):
             return default
 
         def str_const(node) -> bool:
-            return isinstance(node, node_classes.Const) and isinstance(node.value, str)
+            return isinstance(node, Const) and isinstance(node.value, str)
 
         for node in explicit.elts:
             if str_const(node):

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -52,13 +52,13 @@ from astroid.nodes.scoped_nodes.utils import builtin_lookup
 from astroid.typing import InferenceErrorInfo
 
 if TYPE_CHECKING:
-    from typing import Any, ClassVar, Literal, NoReturn, TypeVar
     from collections.abc import Generator, Iterable, Iterator, Sequence
+    from typing import Any, ClassVar, Literal, NoReturn, TypeVar
 
     from astroid import nodes, objects
     from astroid.nodes import NodeNG
-    from astroid.nodes.utils import Position
     from astroid.nodes._base_nodes import LookupMixIn
+    from astroid.nodes.utils import Position
     from astroid.typing import (
         InferBinaryOp,
         InferenceResult,

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -13,12 +13,10 @@ leads to an inferred FrozenSet:
 
 from __future__ import annotations
 
-from collections.abc import Generator, Iterator
+from typing import TYPE_CHECKING
 from functools import cached_property
-from typing import Any, Literal, NoReturn, TypeVar
 
 from astroid import bases, util
-from astroid.context import InferenceContext
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
@@ -28,9 +26,15 @@ from astroid.exceptions import (
 from astroid.interpreter import objectmodel
 from astroid.manager import AstroidManager
 from astroid.nodes import node_classes, scoped_nodes
-from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
-_T = TypeVar("_T")
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterator
+    from typing import Any, Literal, NoReturn, TypeVar
+
+    from astroid.context import InferenceContext
+    from astroid.typing import InferenceResult, SuccessfulInferenceResult
+
+    _T = TypeVar("_T")
 
 
 class FrozenSet(node_classes.BaseContainer):

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -13,8 +13,8 @@ leads to an inferred FrozenSet:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from functools import cached_property
+from typing import TYPE_CHECKING
 
 from astroid import bases, util
 from astroid.exceptions import (

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -26,8 +26,8 @@ from astroid.exceptions import (
 from astroid.nodes import node_classes
 
 if TYPE_CHECKING:
-    from typing import Any, TypeVar
     from collections.abc import Callable, Generator, Iterator, Sequence
+    from typing import Any, TypeVar
 
     from astroid.typing import (
         ConstFactoryResult,

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -11,8 +11,7 @@ from __future__ import annotations
 import collections
 import itertools
 import operator as operator_mod
-from collections.abc import Callable, Generator, Iterator, Sequence
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING
 
 from astroid import bases, decorators, nodes, util
 from astroid.const import Context
@@ -25,14 +24,19 @@ from astroid.exceptions import (
     NoDefault,
 )
 from astroid.nodes import node_classes
-from astroid.typing import (
-    ConstFactoryResult,
-    InferenceResult,
-    SuccessfulInferenceResult,
-)
 
 if TYPE_CHECKING:
+    from typing import Any, TypeVar
+    from collections.abc import Callable, Generator, Iterator, Sequence
+
+    from astroid.typing import (
+        ConstFactoryResult,
+        InferenceResult,
+        SuccessfulInferenceResult,
+    )
+
     _TupleListNodeT = TypeVar("_TupleListNodeT", nodes.Tuple, nodes.List)
+
 
 _CONTEXTLIB_MGR = "contextlib.contextmanager"
 

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -16,26 +16,29 @@ import os
 import sys
 import types
 import warnings
-from collections.abc import Iterable
 from contextlib import redirect_stderr, redirect_stdout
-from typing import Any, Union
+from typing import TYPE_CHECKING
 
 from astroid import bases, nodes
 from astroid.const import _EMPTY_OBJECT_MARKER, IS_PYPY
 from astroid.manager import AstroidManager
 from astroid.nodes import node_classes
 
+if TYPE_CHECKING:
+    from typing import Any, Union
+    from collections.abc import Iterable
+
+    _FunctionTypes = Union[
+        types.FunctionType,
+        types.MethodType,
+        types.BuiltinFunctionType,
+        types.WrapperDescriptorType,
+        types.MethodDescriptorType,
+        types.ClassMethodDescriptorType,
+    ]
+
 logger = logging.getLogger(__name__)
 
-
-_FunctionTypes = Union[
-    types.FunctionType,
-    types.MethodType,
-    types.BuiltinFunctionType,
-    types.WrapperDescriptorType,
-    types.MethodDescriptorType,
-    types.ClassMethodDescriptorType,
-]
 
 # the keys of CONST_CLS eg python builtin types
 _CONSTANTS = tuple(node_classes.CONST_CLS)

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -25,8 +25,8 @@ from astroid.manager import AstroidManager
 from astroid.nodes import node_classes
 
 if TYPE_CHECKING:
-    from typing import Any, Union
     from collections.abc import Iterable
+    from typing import Any, Union
 
     _FunctionTypes = Union[
         types.FunctionType,

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -13,7 +13,7 @@ import sys
 import token
 from io import StringIO
 from tokenize import generate_tokens
-from typing import TYPE_CHECKING, cast, overload, Union
+from typing import TYPE_CHECKING, Union, cast, overload
 
 from astroid import nodes
 from astroid._ast import get_parser_module, parse_function_type_comment
@@ -22,13 +22,13 @@ from astroid.nodes.node_classes import AssignName
 from astroid.nodes.utils import Position
 
 if TYPE_CHECKING:
-    from tokenize import TokenInfo
     from collections.abc import Callable, Generator
+    from tokenize import TokenInfo
     from typing import Final, TypeVar
 
-    from astroid.nodes import NodeNG
     from astroid._ast import ParserModule
     from astroid.manager import AstroidManager
+    from astroid.nodes import NodeNG
     from astroid.typing import InferenceResult
 
     T_Doc = TypeVar(

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -11,19 +11,37 @@ from __future__ import annotations
 import ast
 import sys
 import token
-from collections.abc import Callable, Generator
 from io import StringIO
-from tokenize import TokenInfo, generate_tokens
-from typing import TYPE_CHECKING, Final, TypeVar, Union, cast, overload
+from tokenize import generate_tokens
+from typing import TYPE_CHECKING, cast, overload, Union
 
 from astroid import nodes
-from astroid._ast import ParserModule, get_parser_module, parse_function_type_comment
+from astroid._ast import get_parser_module, parse_function_type_comment
 from astroid.const import PY312_PLUS, Context
-from astroid.manager import AstroidManager
-from astroid.nodes import NodeNG
 from astroid.nodes.node_classes import AssignName
 from astroid.nodes.utils import Position
-from astroid.typing import InferenceResult
+
+if TYPE_CHECKING:
+    from tokenize import TokenInfo
+    from collections.abc import Callable, Generator
+    from typing import Final, TypeVar
+
+    from astroid.nodes import NodeNG
+    from astroid._ast import ParserModule
+    from astroid.manager import AstroidManager
+    from astroid.typing import InferenceResult
+
+    T_Doc = TypeVar(
+        "T_Doc",
+        "ast.Module",
+        "ast.ClassDef",
+        Union["ast.FunctionDef", "ast.AsyncFunctionDef"],
+    )
+    _FunctionT = TypeVar("_FunctionT", nodes.FunctionDef, nodes.AsyncFunctionDef)
+    _ForT = TypeVar("_ForT", nodes.For, nodes.AsyncFor)
+    _WithT = TypeVar("_WithT", nodes.With, nodes.AsyncWith)
+    NodesWithDocsType = Union[nodes.Module, nodes.ClassDef, nodes.FunctionDef]
+
 
 REDIRECT: Final[dict[str, str]] = {
     "arguments": "Arguments",
@@ -34,18 +52,6 @@ REDIRECT: Final[dict[str, str]] = {
     "keyword": "Keyword",
     "match_case": "MatchCase",
 }
-
-
-T_Doc = TypeVar(
-    "T_Doc",
-    "ast.Module",
-    "ast.ClassDef",
-    Union["ast.FunctionDef", "ast.AsyncFunctionDef"],
-)
-_FunctionT = TypeVar("_FunctionT", nodes.FunctionDef, nodes.AsyncFunctionDef)
-_ForT = TypeVar("_ForT", nodes.For, nodes.AsyncFor)
-_WithT = TypeVar("_WithT", nodes.With, nodes.AsyncWith)
-NodesWithDocsType = Union[nodes.Module, nodes.ClassDef, nodes.FunctionDef]
 
 
 # noinspection PyMethodMayBeStatic

--- a/astroid/test_utils.py
+++ b/astroid/test_utils.py
@@ -10,11 +10,14 @@ import contextlib
 import functools
 import sys
 import warnings
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import pytest
 
 from astroid import manager, nodes, transforms
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def require_version(minver: str = "0.0.0", maxver: str = "4.0.0") -> Callable:

--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import warnings
 from collections import defaultdict
-from typing import TYPE_CHECKING, overload, cast
+from typing import TYPE_CHECKING, cast, overload
 
 from astroid.context import _invalidate_cache
 

--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -6,30 +6,34 @@ from __future__ import annotations
 
 import warnings
 from collections import defaultdict
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Optional, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, overload, cast
 
 from astroid.context import _invalidate_cache
-from astroid.typing import SuccessfulInferenceResult, TransformFn
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Optional, TypeVar, Union
+
     from astroid import nodes
+    from astroid.typing import SuccessfulInferenceResult, TransformFn
 
     _SuccessfulInferenceResultT = TypeVar(
         "_SuccessfulInferenceResultT", bound=SuccessfulInferenceResult
     )
+
     _Predicate = Optional[Callable[[_SuccessfulInferenceResultT], bool]]
 
-_Vistables = Union[
-    "nodes.NodeNG", list["nodes.NodeNG"], tuple["nodes.NodeNG", ...], str, None
-]
-_VisitReturns = Union[
-    SuccessfulInferenceResult,
-    list[SuccessfulInferenceResult],
-    tuple[SuccessfulInferenceResult, ...],
-    str,
-    None,
-]
+    _Vistables = Union[
+        "nodes.NodeNG", list["nodes.NodeNG"], tuple["nodes.NodeNG", ...], str, None
+    ]
+
+    _VisitReturns = Union[
+        SuccessfulInferenceResult,
+        list[SuccessfulInferenceResult],
+        tuple[SuccessfulInferenceResult, ...],
+        str,
+        None,
+    ]
 
 
 class TransformVisitor:

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from collections.abc import Callable, Generator
 from typing import (
     TYPE_CHECKING,
-    Any,
     Generic,
     Protocol,
     TypedDict,
@@ -16,6 +15,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
+    from typing import Any
     from collections.abc import Iterator
 
     from astroid import bases, exceptions, nodes, transforms, util

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -15,8 +15,8 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from typing import Any
     from collections.abc import Iterator
+    from typing import Any
 
     from astroid import bases, exceptions, nodes, transforms, util
     from astroid.context import InferenceContext

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -6,11 +6,13 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Final, Literal
+from typing import TYPE_CHECKING
 
 from astroid.exceptions import InferenceError
 
 if TYPE_CHECKING:
+    from typing import Any, Final, Literal
+
     from astroid import bases, nodes
     from astroid.context import InferenceContext
     from astroid.typing import InferenceResult


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Taking https://github.com/pylint-dev/pylint/pull/9964 for a spin. Idea here is that imports that are only used for typechecking should only be imported for typechecking. This will clarify module dependency structure and possibly also reduce startup time and memory use. Pylint / Astroid is slow and complicated, so this sort of change will feed two birds with one scone.

Mostly this changes imports. There are also some type definitions that are used only for typechecking. The new checker doesn't look at those (yet), so they have not been systematically moved under the type guard. But ultimately they should be.