### PR TITLE
control setting nodes as local outside of the constructor

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,10 @@ What's New in astroid 3.3.5?
 ============================
 Release date: TBA
 
+* Control setting local nodes outside of the supposed local's constructor.
+
+  Closes pylint-dev/astroid/issues/1490
+
 * Fix regression with f-string inference.
 
   Closes pylint-dev/pylint#9947

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -815,6 +815,7 @@ class TreeRebuilder:
                 else []
             ),
         )
+        parent.set_local(newnode.name, newnode)
         return newnode
 
     def visit_continue(self, node: ast.Continue, parent: NodeNG) -> nodes.Continue:
@@ -1112,6 +1113,7 @@ class TreeRebuilder:
             ),
         )
         self._global_names.pop()
+        parent.set_local(newnode.name, newnode)
         return newnode
 
     def visit_functiondef(

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -6880,20 +6880,15 @@ def test_inferring_properties_multiple_time_does_not_mutate_locals() -> None:
         @property
         def a(self):
             return 42
-
-    A()
     """
-    node = extract_node(code)
-    # Infer the class
-    cls = next(node.infer())
+    cls = extract_node(code)
     (prop,) = cls.getattr("a")
 
-    # Try to infer the property function *multiple* times. `A.locals` should be modified only once
+    assert len(cls.locals["a"]) == 1
     for _ in range(3):
         prop.inferred()
     a_locals = cls.locals["a"]
-    # [FunctionDef, Property]
-    assert len(a_locals) == 2
+    assert len(a_locals) == 1
 
 
 def test_getattr_fails_on_empty_values() -> None:


### PR DESCRIPTION
1. The main reason is that a node might be assigned to its parent via an «alias»:

Sometimes a class accesses a member by a different name than
   "__name__" of that member: in pypy3 `list.__mul__.__name__ ==
   "__rmul__"`.

As a result, in the example above we weren't able to find
   "list.__mul__", because it was recorded only as "list.__rmul__".

2. Sometimes we want to have a parent semantically, but we don't want to add it to the list of locals. For example, when inferring properties we are creating ad-hoc properties. We wouldn't want to add another symbol to the locals every time we do an inference. (actually, there's a very good question as to why we are doing those ad-hoc properties but that's out of scope)

it's a part of the campaign to get rid of non-module roots

No pylint regressions.