### PR TITLE
Change order of search path to fix inconsistency between pylint and astroid.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,7 +20,8 @@ What's New in astroid 3.3.6?
 ============================
 Release date: TBA
 
-
+* Change precedece of `path` arg in `modpath_from_file_with_callback` to be higher than `sys.path`
+  
 
 What's New in astroid 3.3.5?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,7 +20,7 @@ What's New in astroid 3.3.6?
 ============================
 Release date: TBA
 
-* Change precedece of `path` arg in `modpath_from_file_with_callback` to be higher than `sys.path`
+* Fix precedence of `path` arg in `modpath_from_file_with_callback` to be higher than `sys.path`
 
 
 What's New in astroid 3.3.5?

--- a/ChangeLog
+++ b/ChangeLog
@@ -21,7 +21,7 @@ What's New in astroid 3.3.6?
 Release date: TBA
 
 * Change precedece of `path` arg in `modpath_from_file_with_callback` to be higher than `sys.path`
-  
+
 
 What's New in astroid 3.3.5?
 ============================

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -278,7 +278,7 @@ def modpath_from_file_with_callback(
     filename = os.path.expanduser(_path_from_filename(filename))
     paths_to_check = sys.path.copy()
     if path:
-        paths_to_check += path
+        paths_to_check = path + paths_to_check
     for pathname in itertools.chain(
         paths_to_check, map(_cache_normalize_path, paths_to_check)
     ):

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import contextlib
 import sys
 import warnings
+from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Any, Final, Literal
 
 from astroid.exceptions import InferenceError

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import contextlib
+import sys
 import warnings
 from typing import TYPE_CHECKING, Any, Final, Literal
 
@@ -157,3 +159,24 @@ def safe_infer(
         return None  # there is some kind of ambiguity
     except StopIteration:
         return value
+
+def _augment_sys_path(additional_paths: Sequence[str]) -> list[str]:
+    original = list(sys.path)
+    changes = []
+    seen = set()
+    for additional_path in additional_paths:
+        if additional_path not in seen:
+            changes.append(additional_path)
+            seen.add(additional_path)
+
+    sys.path[:] = changes + sys.path
+    return original
+
+@contextlib.contextmanager
+def augmented_sys_path(additional_paths: Sequence[str]) -> Iterator[None]:
+    """Augment 'sys.path' by adding entries from additional_paths."""
+    original = _augment_sys_path(additional_paths)
+    try:
+        yield
+    finally:
+        sys.path[:] = original

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -160,6 +160,7 @@ def safe_infer(
     except StopIteration:
         return value
 
+
 def _augment_sys_path(additional_paths: Sequence[str]) -> list[str]:
     original = list(sys.path)
     changes = []
@@ -171,6 +172,7 @@ def _augment_sys_path(additional_paths: Sequence[str]) -> list[str]:
 
     sys.path[:] = changes + sys.path
     return original
+
 
 @contextlib.contextmanager
 def augmented_sys_path(additional_paths: Sequence[str]) -> Iterator[None]:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

<!-- If this PR references an issue without fixing it: -->

While testing https://github.com/pylint-dev/pylint/issues/9967, I noticed that the qualified package names are incorrect when linted files are outside of the source-roots specified. This PR changes the priority of the search path which then correctly picks up the right qualified module name. It makes sense to give higher priority to the additional search paths over `sys.path`. This is in line with priority order of [expand_modules](https://github.com/pylint-dev/pylint/blob/c0ecd70e6ff9e92ee686671c7e0f152ab643f25e/pylint/lint/expand_modules.py#L92) function in pylint. Hopefully the maintainers agree that this inconsistency needs to be fixed.

Refs https://github.com/pylint-dev/pylint/issues/9955

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

