### PR TITLE
Fix crashes with large positive and negative list multipliers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in astroid 4.0.0?
 ============================
 Release date: TBA
 
+* Fix crashes with large positive and negative list multipliers.
+
+  Closes #2521
+  Closes #2523
 
 
 What's New in astroid 3.3.5?

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -142,7 +142,10 @@ def _multiply_seq_by_int(
     context: InferenceContext,
 ) -> _TupleListNodeT:
     node = self.__class__(parent=opnode)
-    if value > 1e8:
+    if value <= 0:
+        node.elts = []
+        return node
+    if len(self.elts) * value > 1e8:
         node.elts = [util.Uninferable]
         return node
     filtered_elts = (

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -286,6 +286,23 @@ class ProtocolTests(unittest.TestCase):
         element = parsed.inferred()[0].elts[0]
         assert element.value is Uninferable
 
+    @staticmethod
+    def test_uninferable_list_multiplication_with_multiple_operands() -> None:
+        """Attempting to calculate the result is prohibitively expensive."""
+        parsed = extract_node("[0] * 825 * 16547118")
+        element = parsed.inferred()[0].elts[0]
+        assert element.value is Uninferable
+
+    @staticmethod
+    def test_list_multiplication_with_zero_multiplier() -> None:
+        parsed = extract_node("[0] * 0")
+        assert parsed.inferred()[0].elts == []
+
+    @staticmethod
+    def test_list_multiplication_with_negative_multiplier() -> None:
+        parsed = extract_node("[0] * -9223372036854775809")
+        assert parsed.inferred()[0].elts == []
+
 
 def test_named_expr_inference() -> None:
     code = """


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

#2523 is causing coverage builds to fail on OSS-Fuzz (https://github.com/pylint-dev/astroid/issues/2511#issuecomment-2311387720)

Closes #2521
Closes #2523

## References

Previous fix in this area: https://github.com/pylint-dev/astroid/pull/2228

Python docs on list multiplication:

> Values of n less than 0 are treated as 0 (which yields an empty sequence of the same type as s).
-- https://docs.python.org/3.14/library/stdtypes.html#sequence-types-list-tuple-range