### PR TITLE
Fix OverflowError with empty list and large multiplier

### DIFF
--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -142,7 +142,7 @@ def _multiply_seq_by_int(
     context: InferenceContext,
 ) -> _TupleListNodeT:
     node = self.__class__(parent=opnode)
-    if value <= 0:
+    if value <= 0 or not self.elts:
         node.elts = []
         return node
     if len(self.elts) * value > 1e8:

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -294,12 +294,17 @@ class ProtocolTests(unittest.TestCase):
         assert element.value is Uninferable
 
     @staticmethod
+    def test_list_multiplication_with_empty_list_and_overflowing_multiplier() -> None:
+        parsed = extract_node("[] * 1163845194457646539560")
+        assert parsed.inferred()[0].elts == []
+
+    @staticmethod
     def test_list_multiplication_with_zero_multiplier() -> None:
         parsed = extract_node("[0] * 0")
         assert parsed.inferred()[0].elts == []
 
     @staticmethod
-    def test_list_multiplication_with_negative_multiplier() -> None:
+    def test_list_multiplication_with_negative_overflowing_multiplier() -> None:
         parsed = extract_node("[0] * -9223372036854775809")
         assert parsed.inferred()[0].elts == []
 


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This regressed in dfe1ccce8576 (https://github.com/pylint-dev/astroid/pull/2596).

I missed this in my first patch, but noticed it later while retesting with OSS-Fuzz corpus files.