### PR TITLE
[Backport maintenance/3.3.x] Fix python 3.13 compatibility re: collections.abc (#2598)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,13 @@ What's New in astroid 3.3.5?
 ============================
 Release date: TBA
 
+* Control setting local nodes outside of the supposed local's constructor.
+
+  Closes #1490
+
+* Fix Python 3.13 compatibility re: `collections.abc`
+
+  Closes pylint-dev/pylint#10000
 
 
 What's New in astroid 3.3.4?


### PR DESCRIPTION
(cherry picked from commit f63a39368dd422d49d77c42a7dd6dad00ee1a986)
