### PR TITLE
Bump astroid to 3.3.5, update changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,9 +9,15 @@ Release date: TBA
 
 
 
-What's New in astroid 3.3.5?
+What's New in astroid 3.3.6?
 ============================
 Release date: TBA
+
+
+
+What's New in astroid 3.3.5?
+============================
+Release date: 2024-10-04
 
 * Control setting local nodes outside of the supposed local's constructor.
 

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.3.4"
+__version__ = "3.3.5"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.3.4"
+current = "3.3.5"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 3.3.5?
============================
Release date: 2024-10-04

* Control setting local nodes outside of the supposed local's constructor.

  Closes #1490

* Fix Python 3.13 compatibility re: `collections.abc`

  Closes pylint-dev/pylint#10000