### PR TITLE
make constants have synthetic root as their parent

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,8 @@ Release date: TBA
 * Removed internal functions ``infer_numpy_member``, ``name_looks_like_numpy_member``, and
   ``attribute_looks_like_numpy_member`` from ``astroid.brain.brain_numpy_utils``.
 
+* Constants now have a parent of ``nodes.SYNTHETIC_ROOT``.
+
 * Fix crashes with large positive and negative list multipliers.
 
   Closes #2521

--- a/astroid/brain/brain_argparse.py
+++ b/astroid/brain/brain_argparse.py
@@ -21,7 +21,7 @@ def infer_namespace(node, context: InferenceContext | None = None):
         "Namespace",
         lineno=node.lineno,
         col_offset=node.col_offset,
-        parent=AstroidManager().synthetic_root,  # this class is not real
+        parent=nodes.SYNTHETIC_ROOT,  # this class is not real
         end_lineno=node.end_lineno,
         end_col_offset=node.end_col_offset,
     )

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -24,7 +24,6 @@ from astroid.exceptions import (
 from astroid.inference_tip import inference_tip
 from astroid.manager import AstroidManager
 from astroid.nodes import scoped_nodes
-from astroid.raw_building import build_module
 from astroid.typing import (
     ConstFactoryResult,
     InferenceResult,
@@ -165,8 +164,6 @@ def _extend_builtins(class_transforms):
 
 def on_bootstrap():
     """Called by astroid_bootstrapping()."""
-    AstroidManager().cache_module(build_module("__astroid_synthetic"))
-
     _extend_builtins(
         {
             "bytes": partial(_extend_string_class, code=BYTES_CLASS, rvalue="b''"),
@@ -653,7 +650,7 @@ def infer_property(
         # node.frame. It's somewhere in the builtins module, but we are special
         # casing it for each "property()" call, so we are making up the
         # definition on the spot, ad-hoc.
-        parent=AstroidManager().synthetic_root,
+        parent=scoped_nodes.SYNTHETIC_ROOT,
     )
     prop_func.postinit(
         body=[],

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -24,6 +24,7 @@ from astroid.exceptions import (
 )
 from astroid.inference_tip import inference_tip
 from astroid.manager import AstroidManager
+from astroid.nodes.scoped_nodes.scoped_nodes import SYNTHETIC_ROOT
 
 ENUM_QNAME: Final[str] = "enum.Enum"
 TYPING_NAMEDTUPLE_QUALIFIED: Final = {
@@ -194,7 +195,7 @@ def infer_named_tuple(
     """Specific inference function for namedtuple Call node."""
     tuple_base: nodes.Name = _extract_single_node("tuple")
     class_node, name, attributes = infer_func_form(
-        node, tuple_base, parent=AstroidManager().synthetic_root, context=context
+        node, tuple_base, parent=SYNTHETIC_ROOT, context=context
     )
 
     call_site = arguments.CallSite.from_call(node, context=context)
@@ -360,7 +361,7 @@ def infer_enum(
     class_node = infer_func_form(
         node,
         enum_meta,
-        parent=AstroidManager().synthetic_root,
+        parent=SYNTHETIC_ROOT,
         context=context,
         enum=True,
     )[0]

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -116,10 +116,6 @@ class AstroidManager:
         return self.astroid_cache["builtins"]
 
     @property
-    def synthetic_root(self) -> nodes.Module:
-        return self.astroid_cache["__astroid_synthetic"]
-
-    @property
     def prefer_stubs(self) -> bool:
         return AstroidManager.brain["prefer_stubs"]
 

--- a/astroid/nodes/__init__.py
+++ b/astroid/nodes/__init__.py
@@ -93,6 +93,7 @@ from astroid.nodes.node_classes import (
     unpack_infer,
 )
 from astroid.nodes.scoped_nodes import (
+    SYNTHETIC_ROOT,
     AsyncFunctionDef,
     ClassDef,
     ComprehensionScope,
@@ -276,6 +277,7 @@ __all__ = (
     "Position",
     "Raise",
     "Return",
+    "SYNTHETIC_ROOT",
     "Set",
     "SetComp",
     "Slice",

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -46,6 +46,7 @@ from astroid.manager import AstroidManager
 from astroid.nodes import _base_nodes
 from astroid.nodes.const import OP_PRECEDENCE
 from astroid.nodes.node_ng import NodeNG
+from astroid.nodes.scoped_nodes import SYNTHETIC_ROOT
 from astroid.typing import (
     ConstFactoryResult,
     InferenceErrorInfo,
@@ -2038,7 +2039,7 @@ class Const(_base_nodes.NoChildrenNode, Instance):
         value: Any,
         lineno: int | None = None,
         col_offset: int | None = None,
-        parent: NodeNG | None = None,
+        parent: NodeNG = SYNTHETIC_ROOT,
         kind: str | None = None,
         *,
         end_lineno: int | None = None,
@@ -2550,7 +2551,7 @@ class EmptyNode(_base_nodes.NoChildrenNode):
         self,
         lineno: None = None,
         col_offset: None = None,
-        parent: None = None,
+        parent: NodeNG = SYNTHETIC_ROOT,
         *,
         end_lineno: None = None,
         end_col_offset: None = None,
@@ -5535,7 +5536,7 @@ def const_factory(value: Any) -> ConstFactoryResult:
         instance = initializer_cls(
             lineno=None,
             col_offset=None,
-            parent=None,
+            parent=SYNTHETIC_ROOT,
             end_lineno=None,
             end_col_offset=None,
         )
@@ -5545,7 +5546,7 @@ def const_factory(value: Any) -> ConstFactoryResult:
         instance = initializer_cls(
             lineno=None,
             col_offset=None,
-            parent=None,
+            parent=SYNTHETIC_ROOT,
             end_lineno=None,
             end_col_offset=None,
         )

--- a/astroid/nodes/scoped_nodes/__init__.py
+++ b/astroid/nodes/scoped_nodes/__init__.py
@@ -11,6 +11,7 @@ Module, ClassDef, FunctionDef (and Lambda, GeneratorExp, DictComp and SetComp to
 
 from astroid.nodes.scoped_nodes.mixin import ComprehensionScope, LocalsDictNodeNG
 from astroid.nodes.scoped_nodes.scoped_nodes import (
+    SYNTHETIC_ROOT,
     AsyncFunctionDef,
     ClassDef,
     DictComp,
@@ -37,6 +38,7 @@ __all__ = (
     "ListComp",
     "LocalsDictNodeNG",
     "Module",
+    "SYNTHETIC_ROOT",
     "SetComp",
     "builtin_lookup",
     "function_to_method",

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -279,7 +279,7 @@ class PartialFunction(scoped_nodes.FunctionDef):
             name,
             lineno=lineno,
             col_offset=col_offset,
-            parent=AstroidManager().synthetic_root,
+            parent=scoped_nodes.SYNTHETIC_ROOT,
             end_col_offset=0,
             end_lineno=0,
         )

--- a/tests/test_regrtest.py
+++ b/tests/test_regrtest.py
@@ -248,7 +248,7 @@ def test(val):
             class metaclass(meta):
                 def __new__(cls, name, this_bases, d):
                     return meta(name, bases, d)
-        return type.__new__(metaclass, 'temporary_class', (), {})
+            return type.__new__(metaclass, 'temporary_class', (), {})
 
         import lala
 


### PR DESCRIPTION
that fixes a bunch of tests in pylint.

We also make the synthetic root a singleton, as opposed to a module
   built in the astroid manager. That allows us to use it as a default
   value in Const constructors.

Note the changes to the test. Before, we in fact tested that constants
   don't have a parent. Is that reasonable? In fact, it seems like
   there are a variety of interpretations and we shouldn't commit to
   one by explicitly testing for a certain parent or lack thereof.

<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


