### PR TITLE
Use `.get` method instead of `in` operator to get value from inference cache safely

### DIFF
--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -155,8 +155,9 @@ class NodeNG:
                 pass
 
         key = (self, context.lookupname, context.callcontext, context.boundnode)
-        if key in context.inferred:
-            yield from context.inferred[key]
+        cached_result = context.inferred.get(key)
+        if cached_result is not None:
+            yield from cached_result
             return
 
         results = []


### PR DESCRIPTION
## Linked Issues

https://github.com/databrickslabs/ucx/issues/2908 and https://github.com/databrickslabs/ucx/pull/2919

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Description

Use `.get` method instead of `in` operator to get value from inference cache safely

## Motivation

We ran into a `KeyError` when calling `NodeNG.inferred` (see stack trace below). Unfortunately, I do not have the code that results in the `KeyError` when inferring - yet. 

<details>
<summary>Stack trace</summary>

``` python
 File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/databricks/labs/ucx/source_code/python/python_infer.py", line 78, in _unsafe_infer_internal
    all_inferred = node.inferred()
                   ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 584, in inferred
    return list(self.infer())
           ^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/bases.py", line 177, in _infer_stmts
    for inf in stmt.infer(context=context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/bases.py", line 177, in _infer_stmts
    for inf in stmt.infer(context=context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_classes.py", line 1760, in _infer
    for callee in self.func.infer(context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_classes.py", line 1108, in _infer_attribute
    yield from owner.igetattr(node.attrname, context)
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/bases.py", line 177, in _infer_stmts
    for inf in stmt.infer(context=context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/bases.py", line 177, in _infer_stmts
    for inf in stmt.infer(context=context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_classes.py", line 2867, in _infer
    module = self.do_import_module()
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/_base_nodes.py", line 168, in do_import_module
    return mymodule.import_module(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 462, in import_module
    return AstroidManager().ast_from_module_name(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/manager.py", line 276, in ast_from_module_name
    return self.ast_from_file(found_spec.location, modname, fallback=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/manager.py", line 166, in ast_from_file
    return AstroidBuilder(self).file_build(filepath, modname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/builder.py", line 145, in file_build
    return self._post_build(module, builder, encoding)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/builder.py", line 169, in _post_build
    self.delayed_assattr(delayed)
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/builder.py", line 243, in delayed_assattr
    for inferred in node.expr.infer():
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/bases.py", line 177, in _infer_stmts
    for inf in stmt.infer(context=context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/bases.py", line 177, in _infer_stmts
    for inf in stmt.infer(context=context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_classes.py", line 1760, in _infer
    for callee in self.func.infer(context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_classes.py", line 1091, in _infer_attribute
    for owner in node.expr.infer(context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/bases.py", line 177, in _infer_stmts
    for inf in stmt.infer(context=context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_classes.py", line 456, in _infer
    stmts = list(self.assigned_stmts(context=context))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/protocols.py", line 368, in _arguments_infer_argname
    is_metaclass = isinstance(cls, nodes.ClassDef) and cls.type == "metaclass"
                                                       ^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 1785, in _class_type
    if _is_metaclass(klass, context=context):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 1752, in _is_metaclass
    for baseobj in base.infer(context=context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/bases.py", line 177, in _infer_stmts
    for inf in stmt.infer(context=context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_classes.py", line 2867, in _infer
    module = self.do_import_module()
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/_base_nodes.py", line 168, in do_import_module
    return mymodule.import_module(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 462, in import_module
    return AstroidManager().ast_from_module_name(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/manager.py", line 276, in ast_from_module_name
    return self.ast_from_file(found_spec.location, modname, fallback=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/manager.py", line 166, in ast_from_file
    return AstroidBuilder(self).file_build(filepath, modname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/builder.py", line 145, in file_build
    return self._post_build(module, builder, encoding)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/builder.py", line 169, in _post_build
    self.delayed_assattr(delayed)
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/builder.py", line 243, in delayed_assattr
    for inferred in node.expr.infer():
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/bases.py", line 177, in _infer_stmts
    for inf in stmt.infer(context=context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_classes.py", line 456, in _infer
    stmts = list(self.assigned_stmts(context=context))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/protocols.py", line 368, in _arguments_infer_argname
    is_metaclass = isinstance(cls, nodes.ClassDef) and cls.type == "metaclass"
                                                       ^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 1785, in _class_type
    if _is_metaclass(klass, context=context):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 1752, in _is_metaclass
    for baseobj in base.infer(context=context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/bases.py", line 177, in _infer_stmts
    for inf in stmt.infer(context=context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_classes.py", line 2867, in _infer
    module = self.do_import_module()
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/_base_nodes.py", line 168, in do_import_module
    return mymodule.import_module(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 462, in import_module
    return AstroidManager().ast_from_module_name(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/manager.py", line 276, in ast_from_module_name
    return self.ast_from_file(found_spec.location, modname, fallback=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/manager.py", line 166, in ast_from_file
    return AstroidBuilder(self).file_build(filepath, modname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/builder.py", line 145, in file_build
    return self._post_build(module, builder, encoding)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/builder.py", line 173, in _post_build
    module = self._manager.visit_transforms(module)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/manager.py", line 127, in visit_transforms
    return self._transform.visit(node)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/transforms.py", line 158, in visit
    return self._visit(node)
           ^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/transforms.py", line 82, in _visit
    visited = self._visit_generic(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/transforms.py", line 108, in _visit_generic
    return [self._visit_generic(child) for child in node]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/transforms.py", line 108, in <listcomp>
    return [self._visit_generic(child) for child in node]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/transforms.py", line 115, in _visit_generic
    return self._visit(node)
           ^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/transforms.py", line 85, in _visit
    return self._transform(node)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/transforms.py", line 66, in _transform
    if predicate is None or predicate(node):
                            ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/brain/brain_namedtuple_enum.py", line 647, in _is_enum_subclass
    return cls.is_subtype_of("enum.Enum")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 2070, in is_subtype_of
    return any(anc.qname() == type_name for anc in self.ancestors(context=context))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 2070, in <genexpr>
    return any(anc.qname() == type_name for anc in self.ancestors(context=context))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 2245, in ancestors
    for baseobj in stmt.infer(context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 147, in infer
    for result in self._explicit_inference(
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/inference_tip.py", line 70, in inner
    raise e from None
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/inference_tip.py", line 66, in inner
    func(node, context, **kwargs)
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/brain/brain_typing.py", line 162, in infer_typing_attr
    value = next(node.value.infer())  # type: ignore[union-attr] # value shouldn't be None for Subscript.
            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/bases.py", line 177, in _infer_stmts
    for inf in stmt.infer(context=context):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 168, in infer
    for i, result in enumerate(self._infer(context=context, **kwargs)):
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 86, in inner
    yield next(generator)
          ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/decorators.py", line 49, in wrapped
    for res in _func(node, context, **kwargs):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_classes.py", line 2867, in _infer
    module = self.do_import_module()
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/_base_nodes.py", line 168, in do_import_module
    return mymodule.import_module(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 462, in import_module
    return AstroidManager().ast_from_module_name(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/manager.py", line 276, in ast_from_module_name
    return self.ast_from_file(found_spec.location, modname, fallback=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/manager.py", line 166, in ast_from_file
    return AstroidBuilder(self).file_build(filepath, modname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/builder.py", line 145, in file_build
    return self._post_build(module, builder, encoding)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/builder.py", line 173, in _post_build
    module = self._manager.visit_transforms(module)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/manager.py", line 127, in visit_transforms
    return self._transform.visit(node)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/transforms.py", line 158, in visit
    return self._visit(node)
           ^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/transforms.py", line 82, in _visit
    visited = self._visit_generic(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/transforms.py", line 108, in _visit_generic
    return [self._visit_generic(child) for child in node]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/transforms.py", line 108, in <listcomp>
    return [self._visit_generic(child) for child in node]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/transforms.py", line 115, in _visit_generic
    return self._visit(node)
           ^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/transforms.py", line 85, in _visit
    return self._transform(node)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/transforms.py", line 66, in _transform
    if predicate is None or predicate(node):
                            ^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/brain/brain_dataclasses.py", line 50, in is_decorated_with_dataclass
    return any(
           ^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/brain/brain_dataclasses.py", line 51, in <genexpr>
    _looks_like_dataclass_decorator(decorator_attribute, decorator_names)
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/brain/brain_dataclasses.py", line 441, in _looks_like_dataclass_decorator
    inferred = next(node.infer())
               ^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.11/site-packages/astroid/nodes/node_ng.py", line 160, in infer
    yield from context.inferred[key]
               ~~~~~~~~~~~~~~~~^^^^^
KeyError: (<Name.runtime_checkable l.2757 at 0x7f06aa9ae910>, None, None, None)
```

</details>

## Theory

I have the following theory, the code fails with a `KeyError` on the `yield `here:

``` python
if key in context.inferred:
    yield from context.inferred[key]
    return
```

Which is odd, as first the `key` is checked to be in the inference cache. Maybe, the `key in context.inferred` checks if the `key` is in the cache, but invalidates the cache at the same time - somehow? There is an `_invalidate_cache()` in the `TransformVisitor._transform()` that is in the stack trace and the `runtime_checkable` is a builtin for which Astroid has a custom lookup that may invalidate the cache. 

Or, we thread astroid. The thread is probably not thread safe since it is a plain dict, maybe the `KeyError` was unlucky timing.

## Solution

Use the key once on the inference cache by using `.get`
