### PR TITLE
Update setuptools to 75.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0", "wheel>=0.37.1"]
+requires = ["setuptools>=75.2.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Description
https://setuptools.pypa.io/en/stable/history.html#v75-2-0

Since setuptools `70.1` the `bdist_wheel` command is shipped with setuptools directly. It's no longer necessary to specify `wheel` as a build system requirement.