### PR TITLE
Reduce flakiness of test_transform_aborted_if_recursion_limited

### DIFF
--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -14,7 +14,6 @@ import pytest
 
 from astroid import MANAGER, builder, nodes, parse, transforms
 from astroid.brain.brain_dataclasses import _looks_like_dataclass_field_call
-from astroid.const import IS_PYPY
 from astroid.manager import AstroidManager
 from astroid.nodes.node_classes import Call, Compare, Const, Name
 from astroid.nodes.scoped_nodes import FunctionDef, Module
@@ -274,7 +273,7 @@ class TestTransforms(unittest.TestCase):
         )
 
         original_limit = sys.getrecursionlimit()
-        sys.setrecursionlimit(500 if IS_PYPY else 1000)
+        sys.setrecursionlimit(1000)
 
         try:
             with pytest.warns(UserWarning) as records:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -14,6 +14,7 @@ import pytest
 
 from astroid import MANAGER, builder, nodes, parse, transforms
 from astroid.brain.brain_dataclasses import _looks_like_dataclass_field_call
+from astroid.const import IS_PYPY
 from astroid.manager import AstroidManager
 from astroid.nodes.node_classes import Call, Compare, Const, Name
 from astroid.nodes.scoped_nodes import FunctionDef, Module
@@ -273,7 +274,7 @@ class TestTransforms(unittest.TestCase):
         )
 
         original_limit = sys.getrecursionlimit()
-        sys.setrecursionlimit(1000)
+        sys.setrecursionlimit(300 if IS_PYPY else 1000)
 
         try:
             with pytest.warns(UserWarning) as records:


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
This test is frequently flaky on PyPy, so try adjusting the recursion limit.