### PR TITLE
Add missing docstring on enum name property

### DIFF
--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -516,11 +516,12 @@ def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
         # know that it should be a string, so infer that as a guess.
         if "name" not in target_names:
             code = dedent(
-                """
-            @property
-            def name(self):
-                return ''
-            """
+                '''
+                @property
+                def name(self):
+                    """The name of the Enum member."""
+                    return ''
+                '''
             )
             name_dynamicclassattr = AstroidBuilder(AstroidManager()).string_build(code)[
                 "name"

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -519,7 +519,11 @@ def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
                 '''
                 @property
                 def name(self):
-                    """The name of the Enum member."""
+                    """The name of the Enum member.
+                    
+                    This is a reconstruction by astroid: enums are too dynamic to understand, but we at least
+                    know 'name' should be a string, so this is astroid's best guess.
+                    """
                     return ''
                 '''
             )

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -520,7 +520,7 @@ def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
                 @property
                 def name(self):
                     """The name of the Enum member.
-                    
+
                     This is a reconstruction by astroid: enums are too dynamic to understand, but we at least
                     know 'name' should be a string, so this is astroid's best guess.
                     """

--- a/tests/brain/test_enum.py
+++ b/tests/brain/test_enum.py
@@ -303,6 +303,18 @@ class EnumBrainTest(unittest.TestCase):
         next(i_value.infer())
         next(c_value.infer())
 
+    def test_enum_name_property_has_docstring(self) -> None:
+        code = """
+        from enum import Enum
+        class EmptyEnum(Enum): #@
+            ...
+        """
+        node = astroid.extract_node(code)
+        name_property = next(node.mymethods())
+
+        assert name_property.name == "name"
+        assert name_property.doc_node is not None
+
     def test_enum_name_and_value_members_override_dynamicclassattr(self) -> None:
         code = """
         from enum import Enum


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

I maintain a custom lint rule implementation that checks that every class property has a docstring. It works well, except for  enum classes. The problem is that a `ClassDef` representation of an enum class always contains this mysterious  property `name`, even though `name` is only defined in the base class, and the property doesn't have a docstring. Hence, my lint rule keeps reporting a missing docstring for every enum class.

The reason for the issue is that `astroid/brain/brain_namedtuple_enum.py` artificially adds `name` property to a node representation for every enum class. I'm not sure if such implementation is the best, but at least the added `name` property should have a docstring.

This PR therefore adds a docstring to the `name` property, which is the same docstring used in the Python standard library ([here](https://github.com/python/cpython/blob/v3.13.1/Lib/enum.py#L1330)). It also adds a unit test that checks the `name` property really has the docstring.


