### PR TITLE
Bump astroid to 3.3.6, update changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,9 +9,15 @@ Release date: TBA
 
 
 
-What's New in astroid 3.3.6?
+What's New in astroid 3.3.7?
 ============================
 Release date: TBA
+
+
+
+What's New in astroid 3.3.6?
+============================
+Release date: 2024-12-08
 
 * Fix inability to import `collections.abc` in python 3.13.1.
 

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.3.5"
+__version__ = "3.3.6"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.3.5"
+current = "3.3.6"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 3.3.6?
============================
Release date: 2024-12-08

* Fix inability to import `collections.abc` in python 3.13.1.
  Closes pylint-dev/pylint#10112

* Fix crash when typing._alias() call is missing arguments.
  Closes #2513