### PR TITLE
Fix `collections.abc` imports on Python 3.13.0 and 3.13.1 (#2657)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,10 @@ What's New in astroid 3.3.7?
 ============================
 Release date: TBA
 
+* Fix inability to import `collections.abc` in python 3.13.1. The reported fix in astroid 3.3.6
+  did not actually fix this issue.
+
+  Closes pylint-dev/pylint#10112
 
 
 What's New in astroid 3.3.6?
@@ -20,6 +24,7 @@ What's New in astroid 3.3.6?
 Release date: 2024-12-08
 
 * Fix inability to import `collections.abc` in python 3.13.1.
+  _It was later found that this did not resolve the linked issue. It was fixed in astroid 3.3.7_
 
   Closes pylint-dev/pylint#10112
 

--- a/astroid/brain/brain_collections.py
+++ b/astroid/brain/brain_collections.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder, extract_node, parse
-from astroid.const import PY313_0, PY313_PLUS
+from astroid.const import PY313_PLUS
 from astroid.context import InferenceContext
 from astroid.exceptions import AttributeInferenceError
 from astroid.manager import AstroidManager
@@ -20,8 +20,7 @@ if TYPE_CHECKING:
 
 def _collections_transform():
     return parse(
-        ("    import _collections_abc as abc" if PY313_PLUS and not PY313_0 else "")
-        + """
+        """
     class defaultdict(dict):
         default_factory = None
         def __missing__(self, key): pass
@@ -33,7 +32,7 @@ def _collections_transform():
     )
 
 
-def _collections_abc_313_0_transform() -> nodes.Module:
+def _collections_abc_313_transform() -> nodes.Module:
     """See https://github.com/python/cpython/pull/124735"""
     return AstroidBuilder(AstroidManager()).string_build(
         "from _collections_abc import *"
@@ -133,7 +132,7 @@ def register(manager: AstroidManager) -> None:
         ClassDef, easy_class_getitem_inference, _looks_like_subscriptable
     )
 
-    if PY313_0:
+    if PY313_PLUS:
         register_module_extender(
-            manager, "collections.abc", _collections_abc_313_0_transform
+            manager, "collections.abc", _collections_abc_313_transform
         )

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -9,7 +9,6 @@ PY310_PLUS = sys.version_info >= (3, 10)
 PY311_PLUS = sys.version_info >= (3, 11)
 PY312_PLUS = sys.version_info >= (3, 12)
 PY313_PLUS = sys.version_info >= (3, 13)
-PY313_0 = sys.version_info[:3] == (3, 13, 0)
 
 WIN32 = sys.platform == "win32"
 

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -133,33 +133,59 @@ class ImportlibFinder(Finder):
         processed: list[str],
         submodule_path: Sequence[str] | None,
     ) -> ModuleSpec | None:
-        if submodule_path is not None:
-            submodule_path = list(submodule_path)
-        elif modname in sys.builtin_module_names:
+        # Although we should be able to use `find_spec` this doesn't work on PyPy for builtins.
+        # Therefore, we use the `builtin_module_nams` heuristic for these.
+        if submodule_path is None and modname in sys.builtin_module_names:
             return ModuleSpec(
                 name=modname,
                 location=None,
                 type=ModuleType.C_BUILTIN,
             )
-        else:
-            try:
-                with warnings.catch_warnings():
-                    warnings.filterwarnings("ignore", category=UserWarning)
-                    spec = importlib.util.find_spec(modname)
+
+        # sys.stdlib_module_names was added in Python 3.10
+        if PY310_PLUS:
+            # If the module is a stdlib module, check whether this is a frozen module. Note that
+            # `find_spec` actually imports the module, so we want to make sure we only run this code
+            # for stuff that can be expected to be frozen. For now this is only stdlib.
+            if modname in sys.stdlib_module_names or (
+                processed and processed[0] in sys.stdlib_module_names
+            ):
+                spec = importlib.util.find_spec(".".join((*processed, modname)))
                 if (
                     spec
                     and spec.loader  # type: ignore[comparison-overlap] # noqa: E501
                     is importlib.machinery.FrozenImporter
                 ):
-                    # No need for BuiltinImporter; builtins handled above
                     return ModuleSpec(
                         name=modname,
                         location=getattr(spec.loader_state, "filename", None),
                         type=ModuleType.PY_FROZEN,
                     )
-            except ValueError:
-                pass
-            submodule_path = sys.path
+        else:
+            # NOTE: This is broken code. It doesn't work on Python 3.13+ where submodules can also
+            # be frozen. However, we don't want to worry about this and we don't want to break
+            # support for older versions of Python. This is just copy-pasted from the old non
+            # working version to at least have no functional behaviour change on <=3.10.
+            # It can be removed after 3.10 is no longer supported in favour of the logic above.
+            if submodule_path is None:  # pylint: disable=else-if-used
+                try:
+                    with warnings.catch_warnings():
+                        warnings.filterwarnings("ignore", category=UserWarning)
+                        spec = importlib.util.find_spec(modname)
+                    if (
+                        spec
+                        and spec.loader  # type: ignore[comparison-overlap] # noqa: E501
+                        is importlib.machinery.FrozenImporter
+                    ):
+                        # No need for BuiltinImporter; builtins handled above
+                        return ModuleSpec(
+                            name=modname,
+                            location=getattr(spec.loader_state, "filename", None),
+                            type=ModuleType.PY_FROZEN,
+                        )
+                except ValueError:
+                    pass
+                submodule_path = sys.path
 
         suffixes = (".py", ".pyi", importlib.machinery.BYTECODE_SUFFIXES[0])
         for entry in submodule_path:

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -185,7 +185,11 @@ class ImportlibFinder(Finder):
                         )
                 except ValueError:
                     pass
-                submodule_path = sys.path
+
+        if submodule_path is not None:
+            search_paths = list(submodule_path)
+        else:
+            search_paths = sys.path
 
         suffixes = (".py", ".pyi", importlib.machinery.BYTECODE_SUFFIXES[0])
         for entry in submodule_path:

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -111,9 +111,7 @@ class Finder:
                   None, otherwise.
         """
 
-    def contribute_to_path(
-        self, spec: ModuleSpec, processed: list[str]
-    ) -> Sequence[str] | None:
+    def contribute_to_path(self, spec: ModuleSpec, processed: list[str]) -> Sequence[str] | None:
         """Get a list of extra paths where this finder can search."""
 
 
@@ -147,9 +145,7 @@ class ImportlibFinder(Finder):
             # If the module is a stdlib module, check whether this is a frozen module. Note that
             # `find_spec` actually imports the module, so we want to make sure we only run this code
             # for stuff that can be expected to be frozen. For now this is only stdlib.
-            if modname in sys.stdlib_module_names or (
-                processed and processed[0] in sys.stdlib_module_names
-            ):
+            if modname in sys.stdlib_module_names or (processed and processed[0] in sys.stdlib_module_names):
                 spec = importlib.util.find_spec(".".join((*processed, modname)))
                 if (
                     spec
@@ -192,7 +188,7 @@ class ImportlibFinder(Finder):
             search_paths = sys.path
 
         suffixes = (".py", ".pyi", importlib.machinery.BYTECODE_SUFFIXES[0])
-        for entry in submodule_path:
+        for entry in search_paths:
             package_directory = os.path.join(entry, modname)
             for suffix in suffixes:
                 package_file_name = "__init__" + suffix
@@ -210,9 +206,7 @@ class ImportlibFinder(Finder):
                     return ModuleSpec(name=modname, location=file_path, type=type_)
         return None
 
-    def contribute_to_path(
-        self, spec: ModuleSpec, processed: list[str]
-    ) -> Sequence[str] | None:
+    def contribute_to_path(self, spec: ModuleSpec, processed: list[str]) -> Sequence[str] | None:
         if spec.location is None:
             # Builtin.
             return None
@@ -221,13 +215,10 @@ class ImportlibFinder(Finder):
             # extend_path is called, search sys.path for module/packages
             # of this name see pkgutil.extend_path documentation
             path = [
-                os.path.join(p, *processed)
-                for p in sys.path
-                if os.path.isdir(os.path.join(p, *processed))
+                os.path.join(p, *processed) for p in sys.path if os.path.isdir(os.path.join(p, *processed))
             ]
         elif spec.name == "distutils" and not any(
-            spec.location.lower().startswith(ext_lib_dir.lower())
-            for ext_lib_dir in EXT_LIB_DIRS
+            spec.location.lower().startswith(ext_lib_dir.lower()) for ext_lib_dir in EXT_LIB_DIRS
         ):
             # virtualenv below 20.0 patches distutils in an unexpected way
             # so we just find the location of distutils that will be
@@ -237,9 +228,7 @@ class ImportlibFinder(Finder):
             # and can be triggered manually from GitHub Actions
             distutils_spec = importlib.util.find_spec("distutils")
             if distutils_spec and distutils_spec.origin:
-                origin_path = Path(
-                    distutils_spec.origin
-                )  # e.g. .../distutils/__init__.py
+                origin_path = Path(distutils_spec.origin)  # e.g. .../distutils/__init__.py
                 path = [str(origin_path.parent)]  # e.g. .../distutils
             else:
                 path = [spec.location]
@@ -261,19 +250,16 @@ class ExplicitNamespacePackageFinder(ImportlibFinder):
         if processed:
             modname = ".".join([*processed, modname])
         if util.is_namespace(modname) and modname in sys.modules:
-            submodule_path = sys.modules[modname].__path__
             return ModuleSpec(
                 name=modname,
                 location="",
                 origin="namespace",
                 type=ModuleType.PY_NAMESPACE,
-                submodule_search_locations=submodule_path,
+                submodule_search_locations=sys.modules[modname].__path__,
             )
         return None
 
-    def contribute_to_path(
-        self, spec: ModuleSpec, processed: list[str]
-    ) -> Sequence[str] | None:
+    def contribute_to_path(self, spec: ModuleSpec, processed: list[str]) -> Sequence[str] | None:
         return spec.submodule_search_locations
 
 
@@ -336,9 +322,7 @@ class PathSpecFinder(Finder):
             )
         return spec
 
-    def contribute_to_path(
-        self, spec: ModuleSpec, processed: list[str]
-    ) -> Sequence[str] | None:
+    def contribute_to_path(self, spec: ModuleSpec, processed: list[str]) -> Sequence[str] | None:
         if spec.type == ModuleType.PY_NAMESPACE:
             return spec.submodule_search_locations
         return None
@@ -359,9 +343,7 @@ def _is_setuptools_namespace(location: pathlib.Path) -> bool:
     except OSError:
         return False
     extend_path = b"pkgutil" in data and b"extend_path" in data
-    declare_namespace = (
-        b"pkg_resources" in data and b"declare_namespace(__name__)" in data
-    )
+    declare_namespace = b"pkg_resources" in data and b"declare_namespace(__name__)" in data
     return extend_path or declare_namespace
 
 
@@ -383,14 +365,10 @@ def _search_zip(
             if PY310_PLUS:
                 if not importer.find_spec(os.path.sep.join(modpath)):
                     raise ImportError(
-                        "No module named %s in %s/%s"
-                        % (".".join(modpath[1:]), filepath, modpath)
+                        "No module named %s in %s/%s" % (".".join(modpath[1:]), filepath, modpath)
                     )
             elif not importer.find_module(os.path.sep.join(modpath)):
-                raise ImportError(
-                    "No module named %s in %s/%s"
-                    % (".".join(modpath[1:]), filepath, modpath)
-                )
+                raise ImportError("No module named %s in %s/%s" % (".".join(modpath[1:]), filepath, modpath))
             return (
                 ModuleType.PY_ZIPMODULE,
                 os.path.abspath(filepath) + os.path.sep + os.path.sep.join(modpath),
@@ -408,9 +386,7 @@ def _find_spec_with_path(
 ) -> tuple[Finder | _MetaPathFinder, ModuleSpec]:
     for finder in _SPEC_FINDERS:
         finder_instance = finder(search_path)
-        spec = finder_instance.find_module(
-            modname, module_parts, processed, submodule_path
-        )
+        spec = finder_instance.find_module(modname, module_parts, processed, submodule_path)
         if spec is None:
             continue
         return finder_instance, spec
@@ -488,9 +464,7 @@ def _find_spec(module_path: tuple, path: tuple) -> ModuleSpec:
 
     while modpath:
         modname = modpath.pop(0)
-        finder, spec = _find_spec_with_path(
-            _path, modname, module_parts, processed, submodule_path or path
-        )
+        finder, spec = _find_spec_with_path(_path, modname, module_parts, processed, submodule_path or path)
         processed.append(modname)
         if modpath:
             if isinstance(finder, Finder):

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -111,7 +111,9 @@ class Finder:
                   None, otherwise.
         """
 
-    def contribute_to_path(self, spec: ModuleSpec, processed: list[str]) -> Sequence[str] | None:
+    def contribute_to_path(
+        self, spec: ModuleSpec, processed: list[str]
+    ) -> Sequence[str] | None:
         """Get a list of extra paths where this finder can search."""
 
 
@@ -145,7 +147,9 @@ class ImportlibFinder(Finder):
             # If the module is a stdlib module, check whether this is a frozen module. Note that
             # `find_spec` actually imports the module, so we want to make sure we only run this code
             # for stuff that can be expected to be frozen. For now this is only stdlib.
-            if modname in sys.stdlib_module_names or (processed and processed[0] in sys.stdlib_module_names):
+            if modname in sys.stdlib_module_names or (
+                processed and processed[0] in sys.stdlib_module_names
+            ):
                 spec = importlib.util.find_spec(".".join((*processed, modname)))
                 if (
                     spec
@@ -206,7 +210,9 @@ class ImportlibFinder(Finder):
                     return ModuleSpec(name=modname, location=file_path, type=type_)
         return None
 
-    def contribute_to_path(self, spec: ModuleSpec, processed: list[str]) -> Sequence[str] | None:
+    def contribute_to_path(
+        self, spec: ModuleSpec, processed: list[str]
+    ) -> Sequence[str] | None:
         if spec.location is None:
             # Builtin.
             return None
@@ -215,10 +221,13 @@ class ImportlibFinder(Finder):
             # extend_path is called, search sys.path for module/packages
             # of this name see pkgutil.extend_path documentation
             path = [
-                os.path.join(p, *processed) for p in sys.path if os.path.isdir(os.path.join(p, *processed))
+                os.path.join(p, *processed)
+                for p in sys.path
+                if os.path.isdir(os.path.join(p, *processed))
             ]
         elif spec.name == "distutils" and not any(
-            spec.location.lower().startswith(ext_lib_dir.lower()) for ext_lib_dir in EXT_LIB_DIRS
+            spec.location.lower().startswith(ext_lib_dir.lower())
+            for ext_lib_dir in EXT_LIB_DIRS
         ):
             # virtualenv below 20.0 patches distutils in an unexpected way
             # so we just find the location of distutils that will be
@@ -228,7 +237,9 @@ class ImportlibFinder(Finder):
             # and can be triggered manually from GitHub Actions
             distutils_spec = importlib.util.find_spec("distutils")
             if distutils_spec and distutils_spec.origin:
-                origin_path = Path(distutils_spec.origin)  # e.g. .../distutils/__init__.py
+                origin_path = Path(
+                    distutils_spec.origin
+                )  # e.g. .../distutils/__init__.py
                 path = [str(origin_path.parent)]  # e.g. .../distutils
             else:
                 path = [spec.location]
@@ -259,7 +270,9 @@ class ExplicitNamespacePackageFinder(ImportlibFinder):
             )
         return None
 
-    def contribute_to_path(self, spec: ModuleSpec, processed: list[str]) -> Sequence[str] | None:
+    def contribute_to_path(
+        self, spec: ModuleSpec, processed: list[str]
+    ) -> Sequence[str] | None:
         return spec.submodule_search_locations
 
 
@@ -322,7 +335,9 @@ class PathSpecFinder(Finder):
             )
         return spec
 
-    def contribute_to_path(self, spec: ModuleSpec, processed: list[str]) -> Sequence[str] | None:
+    def contribute_to_path(
+        self, spec: ModuleSpec, processed: list[str]
+    ) -> Sequence[str] | None:
         if spec.type == ModuleType.PY_NAMESPACE:
             return spec.submodule_search_locations
         return None
@@ -343,7 +358,9 @@ def _is_setuptools_namespace(location: pathlib.Path) -> bool:
     except OSError:
         return False
     extend_path = b"pkgutil" in data and b"extend_path" in data
-    declare_namespace = b"pkg_resources" in data and b"declare_namespace(__name__)" in data
+    declare_namespace = (
+        b"pkg_resources" in data and b"declare_namespace(__name__)" in data
+    )
     return extend_path or declare_namespace
 
 
@@ -365,10 +382,16 @@ def _search_zip(
             if PY310_PLUS:
                 if not importer.find_spec(os.path.sep.join(modpath)):
                     raise ImportError(
-                        "No module named %s in %s/%s" % (".".join(modpath[1:]), filepath, modpath)
+                        "No module named {} in {}/{}".format(
+                            ".".join(modpath[1:]), filepath, modpath
+                        )
                     )
             elif not importer.find_module(os.path.sep.join(modpath)):
-                raise ImportError("No module named %s in %s/%s" % (".".join(modpath[1:]), filepath, modpath))
+                raise ImportError(
+                    "No module named {} in {}/{}".format(
+                        ".".join(modpath[1:]), filepath, modpath
+                    )
+                )
             return (
                 ModuleType.PY_ZIPMODULE,
                 os.path.abspath(filepath) + os.path.sep + os.path.sep.join(modpath),
@@ -386,7 +409,9 @@ def _find_spec_with_path(
 ) -> tuple[Finder | _MetaPathFinder, ModuleSpec]:
     for finder in _SPEC_FINDERS:
         finder_instance = finder(search_path)
-        spec = finder_instance.find_module(modname, module_parts, processed, submodule_path)
+        spec = finder_instance.find_module(
+            modname, module_parts, processed, submodule_path
+        )
         if spec is None:
             continue
         return finder_instance, spec
@@ -464,7 +489,9 @@ def _find_spec(module_path: tuple, path: tuple) -> ModuleSpec:
 
     while modpath:
         modname = modpath.pop(0)
-        finder, spec = _find_spec_with_path(_path, modname, module_parts, processed, submodule_path or path)
+        finder, spec = _find_spec_with_path(
+            _path, modname, module_parts, processed, submodule_path or path
+        )
         processed.append(modname)
         if modpath:
             if isinstance(finder, Finder):

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -192,6 +192,22 @@ def check_metaclass_is_abc(node: nodes.ClassDef):
 
 
 class CollectionsBrain(unittest.TestCase):
+    def test_collections_abc_is_importable(self) -> None:
+        """
+        Test that we can import `collections.abc`.
+
+        The collections.abc has gone through various formats of being frozen. Therefore, we ensure
+        that we can still import it (correctly).
+        """
+        import_node = builder.extract_node("import collections.abc")
+        assert isinstance(import_node, nodes.Import)
+        imported_module = import_node.do_import_module(import_node.names[0][0])
+        # Make sure that the file we have imported is actually the submodule of collections and
+        # not the `abc` module. (Which would happen if you call `importlib.util.find_spec("abc")`
+        # instead of `importlib.util.find_spec("collections.abc")`)
+        assert isinstance(imported_module.file, str)
+        assert "collections" in imported_module.file
+
     def test_collections_object_not_subscriptable(self) -> None:
         """
         Test that unsubscriptable types are detected


### PR DESCRIPTION
Manual backport, conflicts were not so easy to solve, need a real review.