### PR TITLE
Skip flaky recursion test on PyPy

### DIFF
--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -265,6 +265,9 @@ class TestTransforms(unittest.TestCase):
         """
         )
 
+    @pytest.mark.skipif(
+        IS_PYPY, reason="Could not find a useful recursion limit on all versions"
+    )
     def test_transform_aborted_if_recursion_limited(self):
         def transform_call(node: Call) -> Const:
             return node
@@ -274,7 +277,7 @@ class TestTransforms(unittest.TestCase):
         )
 
         original_limit = sys.getrecursionlimit()
-        sys.setrecursionlimit(300 if IS_PYPY else 1000)
+        sys.setrecursionlimit(1000)
 
         try:
             with pytest.warns(UserWarning) as records:


### PR DESCRIPTION
Follow-up to 03cd54c.

No one has the time or inclination to find a stable recursion limit that is low enough to reliably trigger the UserWarning without actually causing core dumps or other problems, esp. when running with coverage.