### PR TITLE
[Backport maintenance/3.3.x] Another attempt at fixing the `collections.abc` issue for Python 3.13 (#2665)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 env:
   CACHE_VERSION: 3
   KEY_PREFIX: venv
-  DEFAULT_PYTHON: "3.12"
+  DEFAULT_PYTHON: "3.13"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
 
 concurrency:
@@ -242,11 +242,11 @@ jobs:
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4.1.7
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         id: python
         uses: actions/setup-python@v5.1.1
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           check-latest: true
       - name: Install dependencies
         run: pip install -U -r requirements_minimal.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13-dev"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
@@ -138,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13-dev"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Set temp directory
         run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - published
 
 env:
-  DEFAULT_PYTHON: "3.12"
+  DEFAULT_PYTHON: "3.13"
 
 permissions:
   contents: read

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,11 +13,17 @@ What's New in astroid 3.3.8?
 ============================
 Release date: TBA
 
+* Fix inability to import `collections.abc` in python 3.13.1. The reported fixes in astroid 3.3.6
+  and 3.3.7 did not actually fix this issue.
+
+  Closes pylint-dev/pylint#10112
 
 
 What's New in astroid 3.3.7?
 ============================
 Release date: 2024-12-20
+
+This release was yanked.
 
 * Fix inability to import `collections.abc` in python 3.13.1. The reported fix in astroid 3.3.6
   did not actually fix this issue.


### PR DESCRIPTION
* Fix issue with importing of frozen submodules

(cherry picked from commit f94e855268895bf995fe8eb258ea7ff7d7ccd9cf)