### PR TITLE
Bump astroid to 4.0.0a0, update changelog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,8 +60,8 @@ repos:
         pass_filenames: false
         require_serial: true
         additional_dependencies: ["types-typed-ast"]
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.4.2
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -36,16 +36,16 @@ Contributors
 - Andrew Haigh <hello@nelf.in>
 - Julien Cristau <julien.cristau@logilab.fr>
 - David Liu <david@cs.toronto.edu>
+- Artem Yurchenko <44875844+temyurchenko@users.noreply.github.com>
 - Alexandre Fayolle <alexandre.fayolle@logilab.fr>
 - Eevee (Alex Munroe) <amunroe@yelp.com>
-- temyurchenko <44875844+temyurchenko@users.noreply.github.com>
 - David Gilman <davidgilman1@gmail.com>
 - Tushar Sadhwani <tushar.sadhwani000@gmail.com>
 - Julien Jehannet <julien.jehannet@logilab.fr>
 - Calen Pennington <calen.pennington@gmail.com>
 - Antonio <antonio@zoftko.com>
 - Hugo van Kemenade <hugovk@users.noreply.github.com>
-- Artem Yurchenko <artemyurchenko@zoho.com>
+- Akhil Kamat <akhil.kamat@gmail.com>
 - Tim Martin <tim@asymptotic.co.uk>
 - Phil Schaf <flying-sheep@web.de>
 - Alex Hall <alex.mojaki@gmail.com>
@@ -58,7 +58,6 @@ Contributors
 - David Shea <dshea@redhat.com>
 - Daniel Harding <dharding@gmail.com>
 - Christian Clauss <cclauss@me.com>
-- Akhil Kamat <akhil.kamat@gmail.com>
 - Ville Skyttä <ville.skytta@iki.fi>
 - Rene Zhang <rz99@cornell.edu>
 - Philip Lorenz <philip@bithub.de>
@@ -76,7 +75,6 @@ Contributors
 - emile@crater.logilab.fr <emile@crater.logilab.fr>
 - doranid <ddandd@gmail.com>
 - brendanator <brendan.maginnis@gmail.com>
-- akamat10 <akhil.kamat@gmail.com>
 - Tomas Gavenciak <gavento@ucw.cz>
 - Tim Paine <t.paine154@gmail.com>
 - Thomas Hisch <t.hisch@gmail.com>
@@ -215,9 +213,3 @@ under this name, or we did not manage to find their commits in the history.
 - carl
 - alain lefroy
 - Mark Gius
-- Jérome Perrin <perrinjerome@gmail.com>
-- Jamie Scott <jamie@jami.org.uk>
-- correctmost <134317971+correctmost@users.noreply.github.com>
-- Oleh Prypin <oleh@pryp.in>
-- Eric Vergnaud <eric.vergnaud@wanadoo.fr>
-- Hashem Nasarat <Hnasar@users.noreply.github.com>

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "4.0.0-dev0"
+__version__ = "4.0.0a0"
 version = __version__

--- a/script/.contributors_aliases.json
+++ b/script/.contributors_aliases.json
@@ -18,6 +18,13 @@
     "name": "Mark Byrne",
     "team": "Maintainers"
   },
+  "44875844+temyurchenko@users.noreply.github.com": {
+    "mails": [
+      "artemyurchenko@zoho.com",
+      "44875844+temyurchenko@users.noreply.github.com"
+    ],
+    "name": "Artem Yurchenko"
+  },
   "55152140+jayaddison@users.noreply.github.com": {
     "mails": ["55152140+jayaddison@users.noreply.github.com", "jay@jp-hosting.net"],
     "name": "James Addison"
@@ -29,6 +36,10 @@
   "adam.grant.hendry@gmail.com": {
     "mails": ["adam.grant.hendry@gmail.com"],
     "name": "Adam Hendry"
+  },
+  "akhil.kamat@gmail.com": {
+    "mails": ["akhil.kamat@gmail.com"],
+    "name": "Akhil Kamat"
   },
   "androwiiid@gmail.com": {
     "mails": ["androwiiid@gmail.com"],

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "4.0.0-dev0"
+current = "4.0.0a0"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
* Removed internal functions ``infer_numpy_member``, ``name_looks_like_numpy_member``, and
  ``attribute_looks_like_numpy_member`` from ``astroid.brain.brain_numpy_utils``.

* To alleviate circular imports, the ``manager`` argument to ``AstroidBuilder()`` is now required.

* Constants now have a parent of ``nodes.SYNTHETIC_ROOT``.

* Fix crashes with large positive and negative list multipliers.

  Closes #2521
  Closes #2523

* Fix precedence of `path` arg in `modpath_from_file_with_callback` to be higher than `sys.path`

* Following a deprecation period, the ``future`` argument was removed from ``statement()`` and ``frame()``.

* Improve consistency of ``JoinedStr`` inference by not raising ``InferenceError`` and
  returning either ``Uninferable`` or a fully resolved ``Const``.

  Closes #2621

* Fix crash when typing._alias() call is missing arguments.

  Closes #2513