### PR TITLE
Fix RuntimeError caused by analyzing live objects with `__getattribute__` or descriptors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -42,6 +42,10 @@ Release date: TBA
 
   Closes pylint-dev/pylint#10112
 
+* Fix crash when `sys.modules` contains lazy loader objects during checking.
+
+  Closes #2686
+  Closes pylint-dev/pylint#8589
 
 
 What's New in astroid 3.3.8?

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -5514,6 +5514,7 @@ def _create_basic_elements(
     """Create a list of nodes to function as the elements of a new node."""
     elements: list[NodeNG] = []
     for element in value:
+        # NOTE: avoid accessing any attributes of element in the loop.
         element_node = const_factory(element)
         element_node.parent = node
         elements.append(element_node)
@@ -5526,6 +5527,7 @@ def _create_dict_items(
     """Create a list of node pairs to function as the items of a new dict node."""
     elements: list[tuple[SuccessfulInferenceResult, SuccessfulInferenceResult]] = []
     for key, value in values.items():
+        # NOTE: avoid accessing any attributes of both key and value in the loop.
         key_node = const_factory(key)
         key_node.parent = node
         value_node = const_factory(value)
@@ -5536,18 +5538,23 @@ def _create_dict_items(
 
 def const_factory(value: Any) -> ConstFactoryResult:
     """Return an astroid node for a python value."""
-    assert not isinstance(value, NodeNG)
+    # NOTE: avoid accessing any attributes of value until it is known that value
+    # is of a const type, to avoid possibly triggering code for a live object.
+    # Accesses include value.__class__ and isinstance(value, ...), but not type(value).
+    # See: https://github.com/pylint-dev/astroid/issues/2686
+    value_type = type(value)
+    assert not issubclass(value_type, NodeNG)
 
     # This only handles instances of the CONST types. Any
     # subclasses get inferred as EmptyNode.
     # TODO: See if we should revisit these with the normal builder.
-    if value.__class__ not in CONST_CLS:
+    if value_type not in CONST_CLS:
         node = EmptyNode()
         node.object = value
         return node
 
     instance: List | Set | Tuple | Dict
-    initializer_cls = CONST_CLS[value.__class__]
+    initializer_cls = CONST_CLS[value_type]
     if issubclass(initializer_cls, (List, Set, Tuple)):
         instance = initializer_cls(
             lineno=None,

--- a/tests/test_raw_building.py
+++ b/tests/test_raw_building.py
@@ -22,6 +22,7 @@ from unittest import mock
 import pytest
 
 import tests.testdata.python3.data.fake_module_with_broken_getattr as fm_getattr
+import tests.testdata.python3.data.fake_module_with_collection_getattribute as fm_collection
 import tests.testdata.python3.data.fake_module_with_warnings as fm
 from astroid.builder import AstroidBuilder
 from astroid.const import IS_PYPY, PY312_PLUS
@@ -120,6 +121,14 @@ class RawBuildingTC(unittest.TestCase):
 
         # This should not raise an exception
         AstroidBuilder(AstroidManager()).inspect_build(fm_getattr, "test")
+
+    def test_module_collection_with_object_getattribute(self) -> None:
+        # Tests https://github.com/pylint-dev/astroid/issues/2686
+        # When astroid live inspection of module's collection raises
+        # error when element __getattribute__ causes collection to change size.
+
+        # This should not raise an exception
+        AstroidBuilder(AstroidManager()).inspect_build(fm_collection, "test")
 
 
 @pytest.mark.skipif(

--- a/tests/testdata/python3/data/fake_module_with_collection_getattribute.py
+++ b/tests/testdata/python3/data/fake_module_with_collection_getattribute.py
@@ -1,0 +1,11 @@
+class Changer:
+    def __getattribute__(self, name):
+        list_collection.append(self)
+        set_collection.add(self)
+        dict_collection[self] = self
+        return object.__getattribute__(self, name)
+
+
+list_collection = [Changer()]
+set_collection = {Changer()}
+dict_collection = {Changer(): Changer()}


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ x ] Write a good description on what the PR does.
- [ x ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ x ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

During checking, lazy module objects may get loaded during analysis of `sys.modules`, causing a crash. (In general, when an object executes code from an attribute access, making its containing collection change size.)
Avoid some attribute accesses in `const_factory()` to avoid executing `__getattribute__` code.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #2686
Closes pylint-dev/pylint#8589
