### PR TITLE
[Backport maintenance/3.3.x] Fix RuntimeError caused by analyzing live objects with `__getattribute__` or descriptors (#2687)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,11 @@ What's New in astroid 3.3.9?
 Release date: TBA
 
 
+* Fix crash when `sys.modules` contains lazy loader objects during checking.
+
+  Closes #2686
+  Closes pylint-dev/pylint#8589
+
 
 What's New in astroid 3.3.8?
 ============================

--- a/tests/test_raw_building.py
+++ b/tests/test_raw_building.py
@@ -22,6 +22,7 @@ from unittest import mock
 import pytest
 
 import tests.testdata.python3.data.fake_module_with_broken_getattr as fm_getattr
+import tests.testdata.python3.data.fake_module_with_collection_getattribute as fm_collection
 import tests.testdata.python3.data.fake_module_with_warnings as fm
 from astroid.builder import AstroidBuilder
 from astroid.const import IS_PYPY, PY312_PLUS
@@ -117,6 +118,14 @@ class RawBuildingTC(unittest.TestCase):
 
         # This should not raise an exception
         AstroidBuilder().inspect_build(fm_getattr, "test")
+
+    def test_module_collection_with_object_getattribute(self) -> None:
+        # Tests https://github.com/pylint-dev/astroid/issues/2686
+        # When astroid live inspection of module's collection raises
+        # error when element __getattribute__ causes collection to change size.
+
+        # This should not raise an exception
+        AstroidBuilder().inspect_build(fm_collection, "test")
 
 
 @pytest.mark.skipif(

--- a/tests/testdata/python3/data/fake_module_with_collection_getattribute.py
+++ b/tests/testdata/python3/data/fake_module_with_collection_getattribute.py
@@ -1,0 +1,11 @@
+class Changer:
+    def __getattribute__(self, name):
+        list_collection.append(self)
+        set_collection.add(self)
+        dict_collection[self] = self
+        return object.__getattribute__(self, name)
+
+
+list_collection = [Changer()]
+set_collection = {Changer()}
+dict_collection = {Changer(): Changer()}


### PR DESCRIPTION
Avoid some attribute accesses in const_factory

(cherry picked from commit 71dc6b2412f95e0ad01cefdd6ee0d8e9ea551376)