### PR TITLE
Cache _is_setuptools_namespace results to avoid repetitive I/O

### DIFF
--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -367,6 +367,7 @@ _SPEC_FINDERS = (
 )
 
 
+@lru_cache(maxsize=1024)
 def _is_setuptools_namespace(location: pathlib.Path) -> bool:
     try:
         with open(location / "__init__.py", "rb") as stream:

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -439,7 +439,10 @@ class AstroidManager:
         # pylint: disable=import-outside-toplevel
         from astroid.brain.helpers import register_all_brains
         from astroid.inference_tip import clear_inference_tip_cache
-        from astroid.interpreter._import.spec import _find_spec
+        from astroid.interpreter._import.spec import (
+            _find_spec,
+            _is_setuptools_namespace,
+        )
         from astroid.interpreter.objectmodel import ObjectModel
         from astroid.nodes._base_nodes import LookupMixIn
         from astroid.nodes.scoped_nodes import ClassDef
@@ -462,6 +465,7 @@ class AstroidManager:
             ObjectModel.attributes,
             ClassDef._metaclass_lookup_attribute,
             _find_spec,
+            _is_setuptools_namespace,
         ):
             lru_cache.cache_clear()  # type: ignore[attr-defined]
 


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

`_is_setuptools_namespace` can end up reading the same files over and over.

For example, when running pylint's import-error checks on yt-dlp, ~23,500 redundant `open()` calls were performed prior to caching.

Closes pylint-dev/pylint#9603.

## Stats

### Before

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pylint --recursive=y .` | 17.126 ± 0.084 | 17.047 | 17.292 | 1.00 |

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    28477    0.140    0.000    0.512    0.000 {built-in method _io.open}
```


### After

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pylint --recursive=y .` | 16.969 ± 0.065 | 16.882 | 17.079 | 1.00 |

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     4949    0.047    0.000    0.064    0.000 {built-in method _io.open}
```

### Cache stats at Pylint exit
```
CacheInfo(hits=23528, misses=1165, maxsize=1024, currsize=1024)
```