### PR TITLE
Bump astroid to 3.3.10, update changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,9 +9,15 @@ Release date: TBA
 
 
 
-What's New in astroid 3.3.10?
+What's New in astroid 3.3.11?
 =============================
 Release date: TBA
+
+
+
+What's New in astroid 3.3.10?
+=============================
+Release date: 2025-05-07
 
 * Avoid importing submodules sharing names with standard library modules.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -17,7 +17,7 @@ Release date: TBA
 
 What's New in astroid 3.3.10?
 =============================
-Release date: 2025-05-07
+Release date: 2025-05-10
 
 * Avoid importing submodules sharing names with standard library modules.
 

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.3.9"
+__version__ = "3.3.10"
 version = __version__

--- a/script/.contributors_aliases.json
+++ b/script/.contributors_aliases.json
@@ -1,8 +1,4 @@
 {
-  "c.ringstrom@gmail.com": {
-    "mails": ["c.ringstrom@gmail.com"],
-    "name": "Charlie Ringström"
-  },
   "134317971+correctmost@users.noreply.github.com": {
     "mails": ["134317971+correctmost@users.noreply.github.com"],
     "name": "correctmost"
@@ -73,6 +69,10 @@
     "mails": ["bryce.paul.guinta@gmail.com", "bryce.guinta@protonmail.com"],
     "name": "Bryce Guinta",
     "team": "Maintainers"
+  },
+  "c.ringstrom@gmail.com": {
+    "mails": ["c.ringstrom@gmail.com"],
+    "name": "Charlie Ringström"
   },
   "calen.pennington@gmail.com": {
     "mails": ["cale@edx.org", "calen.pennington@gmail.com"],

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.3.9"
+current = "3.3.10"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION

* Avoid importing submodules sharing names with standard library modules.

  Closes #2684

* Fix bug where ``pylint code.custom_extension`` would analyze ``code.py`` or ``code.pyi`` instead if they existed.
   Closes pylint-dev/pylint#3631