### PR TITLE
[fix] Crash when parsing an empty arbitrary expression with ``extract_node``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37,7 +37,9 @@ What's New in astroid 3.3.11?
 =============================
 Release date: TBA
 
+* Fix a crash when parsing what look like the internal "transient function" (``__``) without any args.
 
+  Closes #2734
 
 What's New in astroid 3.3.10?
 =============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -37,7 +37,7 @@ What's New in astroid 3.3.11?
 =============================
 Release date: TBA
 
-* Fix a crash when parsing what look like the internal "transient function" (``__``) without any args.
+* Fix a crash when parsing an empty arbitrary expression with ``extract_node`` (``extract_node("__()")``).
 
   Closes #2734
 

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -317,6 +317,7 @@ def _extract_expressions(node: nodes.NodeNG) -> Iterator[nodes.NodeNG]:
         isinstance(node, nodes.Call)
         and isinstance(node.func, nodes.Name)
         and node.func.name == _TRANSIENT_FUNCTION
+        and node.args
     ):
         real_expr = node.args[0]
         assert node.parent

--- a/tests/test_regrtest.py
+++ b/tests/test_regrtest.py
@@ -498,3 +498,9 @@ def test_regression_missing_callcontext() -> None:
         )
     )
     assert node.inferred()[0].value == "mystr"
+
+
+def test_regression_no_crash_during_build() -> None:
+    node: nodes.Attribute = extract_node("__()")
+    assert node.args == []
+    assert node.as_string() == "__()"


### PR DESCRIPTION


<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

To be fair I'm not exactly sure of what the transient function is. It seems internal. But the fix seems self evident.

https://github.com/pylint-dev/astroid/blob/3636bc299a5792dc2a421cf6951438a396fd9a6e/astroid/builder.py#L32-L35

https://github.com/pylint-dev/astroid/blob/3636bc299a5792dc2a421cf6951438a396fd9a6e/astroid/builder.py#L303-L315

https://github.com/pylint-dev/astroid/blob/3636bc299a5792dc2a421cf6951438a396fd9a6e/astroid/builder.py#L324-L328

Closes #2734
