### PR TITLE
[fix] Prevent crash on slice decorator for ``six`` decorated function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,11 @@ Release date: TBA
 
   Closes #2734
 
+* Fix a crash when parsing a slice called in a decorator on a function that is also decorated with
+  a known ``six`` decorator.
+
+  Closes #2721
+
 What's New in astroid 3.3.10?
 =============================
 Release date: 2025-05-10

--- a/astroid/brain/brain_six.py
+++ b/astroid/brain/brain_six.py
@@ -182,7 +182,11 @@ def transform_six_add_metaclass(node):  # pylint: disable=inconsistent-return-st
             func = next(decorator.func.infer())
         except (InferenceError, StopIteration):
             continue
-        if func.qname() == SIX_ADD_METACLASS and decorator.args:
+        if (
+            isinstance(func, (nodes.FunctionDef, nodes.ClassDef))
+            and func.qname() == SIX_ADD_METACLASS
+            and decorator.args
+        ):
             metaclass = decorator.args[0]
             node._metaclass = metaclass
             return node

--- a/tests/test_regrtest.py
+++ b/tests/test_regrtest.py
@@ -504,3 +504,19 @@ def test_regression_no_crash_during_build() -> None:
     node: nodes.Attribute = extract_node("__()")
     assert node.args == []
     assert node.as_string() == "__()"
+
+
+def test_regression_no_crash_on_called_slice() -> None:
+    """Regression test for issue #2721."""
+    node: nodes.Attribute = extract_node(
+        textwrap.dedent(
+            """
+        s = slice(-2)
+        @s()
+        @six.add_metaclass()
+        class a: ...
+        """
+        )
+    )
+    assert isinstance(node, nodes.ClassDef)
+    assert node.name == "a"


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #2721
