### PR TITLE
Initial fixes for Python 3.14

### DIFF
--- a/astroid/brain/brain_pathlib.py
+++ b/astroid/brain/brain_pathlib.py
@@ -8,7 +8,7 @@ from collections.abc import Iterator
 
 from astroid import bases, context, nodes
 from astroid.builder import _extract_single_node
-from astroid.const import PY313_PLUS
+from astroid.const import PY313
 from astroid.exceptions import InferenceError, UseInferenceDefault
 from astroid.inference_tip import inference_tip
 from astroid.manager import AstroidManager
@@ -29,7 +29,7 @@ def _looks_like_parents_subscript(node: nodes.Subscript) -> bool:
         value = next(node.value.infer())
     except (InferenceError, StopIteration):
         return False
-    parents = "builtins.tuple" if PY313_PLUS else "pathlib._PathParents"
+    parents = "builtins.tuple" if PY313 else "pathlib._PathParents"
     return (
         isinstance(value, bases.Instance)
         and isinstance(value._proxied, nodes.ClassDef)

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -15,7 +15,7 @@ from typing import Final
 from astroid import context
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder, _extract_single_node, extract_node
-from astroid.const import PY312_PLUS, PY313_PLUS
+from astroid.const import PY312_PLUS, PY313_PLUS, PY314_PLUS
 from astroid.exceptions import (
     AstroidSyntaxError,
     AttributeInferenceError,
@@ -78,7 +78,7 @@ TYPING_ALIAS = frozenset(
         "typing.MutableMapping",
         "typing.Sequence",
         "typing.MutableSequence",
-        "typing.ByteString",
+        "typing.ByteString",  # removed in 3.14
         "typing.Tuple",
         "typing.List",
         "typing.Deque",
@@ -431,9 +431,8 @@ def infer_typing_cast(
 
 
 def _typing_transform():
-    return AstroidBuilder(AstroidManager()).string_build(
-        textwrap.dedent(
-            """
+    code = textwrap.dedent(
+        """
     class Generic:
         @classmethod
         def __class_getitem__(cls, item):  return cls
@@ -467,8 +466,16 @@ def _typing_transform():
         @classmethod
         def __class_getitem__(cls, item):  return cls
     """
-        )
     )
+    if PY314_PLUS:
+        code += textwrap.dedent(
+            """
+    class Union:
+        @classmethod
+        def __class_getitem__(cls, item): return cls
+    """
+        )
+    return AstroidBuilder(AstroidManager()).string_build(code)
 
 
 def register(manager: AstroidManager) -> None:

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -8,7 +8,9 @@ import sys
 PY310_PLUS = sys.version_info >= (3, 10)
 PY311_PLUS = sys.version_info >= (3, 11)
 PY312_PLUS = sys.version_info >= (3, 12)
+PY313 = sys.version_info[:2] == (3, 13)
 PY313_PLUS = sys.version_info >= (3, 13)
+PY314_PLUS = sys.version_info >= (3, 14)
 
 WIN32 = sys.platform == "win32"
 

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -15,7 +15,7 @@ import astroid
 from astroid import MANAGER, builder, nodes, objects, test_utils, util
 from astroid.bases import Instance
 from astroid.brain.brain_namedtuple_enum import _get_namedtuple_fields
-from astroid.const import PY312_PLUS, PY313_PLUS
+from astroid.const import PY312_PLUS, PY313_PLUS, PY314_PLUS
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
@@ -335,6 +335,9 @@ class CollectionsBrain(unittest.TestCase):
         with self.assertRaises(InferenceError):
             next(node.infer())
 
+    @pytest.mark.skipif(
+        PY314_PLUS, reason="collections.abc.ByteString was removed in 3.14"
+    )
     def test_collections_object_subscriptable_3(self):
         """With Python 3.9 the ByteString class of the collections module is subscriptable
         (but not the same class from typing module)"""
@@ -918,6 +921,7 @@ class TypingBrain(unittest.TestCase):
             ],
         )
 
+    @pytest.mark.skipif(PY314_PLUS, reason="typing.ByteString was removed in 3.14")
     def test_typing_object_notsubscriptable_3(self):
         """Until python39 ByteString class of the typing module is not
         subscriptable (whereas it is in the collections' module)"""

--- a/tests/brain/test_pathlib.py
+++ b/tests/brain/test_pathlib.py
@@ -5,7 +5,7 @@
 
 import astroid
 from astroid import bases
-from astroid.const import PY310_PLUS, PY313_PLUS
+from astroid.const import PY310_PLUS, PY313
 from astroid.util import Uninferable
 
 
@@ -23,7 +23,7 @@ def test_inference_parents() -> None:
     inferred = name_node.inferred()
     assert len(inferred) == 1
     assert isinstance(inferred[0], bases.Instance)
-    if PY313_PLUS:
+    if PY313:
         assert inferred[0].qname() == "builtins.tuple"
     else:
         assert inferred[0].qname() == "pathlib._PathParents"
@@ -43,7 +43,7 @@ def test_inference_parents_subscript_index() -> None:
     inferred = path.inferred()
     assert len(inferred) == 1
     assert isinstance(inferred[0], bases.Instance)
-    if PY313_PLUS:
+    if PY313:
         assert inferred[0].qname() == "pathlib._local.Path"
     else:
         assert inferred[0].qname() == "pathlib.Path"

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -34,7 +34,7 @@ from astroid import decorators as decoratorsmod
 from astroid.arguments import CallSite
 from astroid.bases import BoundMethod, Generator, Instance, UnboundMethod, UnionType
 from astroid.builder import AstroidBuilder, _extract_single_node, extract_node, parse
-from astroid.const import IS_PYPY, PY310_PLUS, PY312_PLUS
+from astroid.const import IS_PYPY, PY310_PLUS, PY312_PLUS, PY314_PLUS
 from astroid.context import CallContext, InferenceContext
 from astroid.exceptions import (
     AstroidTypeError,
@@ -1308,8 +1308,12 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             assert i0.bool_value() is True
             assert i0.pytype() == "types.UnionType"
             assert i0.display_type() == "UnionType"
-            assert str(i0) == "UnionType(UnionType)"
-            assert repr(i0) == f"<UnionType(UnionType) l.0 at 0x{id(i0)}>"
+            if PY314_PLUS:
+                assert str(i0) == "UnionType(Union)"
+                assert repr(i0) == f"<UnionType(Union) l.0 at 0x{id(i0)}>"
+            else:
+                assert str(i0) == "UnionType(UnionType)"
+                assert repr(i0) == f"<UnionType(UnionType) l.0 at 0x{id(i0)}>"
 
             i1 = ast_nodes[1].inferred()[0]
             assert isinstance(i1, UnionType)


### PR DESCRIPTION
Tested against `3.14.0b1` locally. We might still need to adjust some things as more pre-release versions come out but this provides a good starting point in combination with #2731.

Relevant changes for Python 3.14
- `typing.ByteString` and `collections.abc.ByteString` were removed
https://docs.python.org/3.13/library/typing.html#typing.ByteString
- The inference for pathlib `parents` changed back to `pathlib._PathParents`
- `typing.Union` was implemented in C and `types.UnionType` is now an alias for `typing.Union`
https://github.com/python/cpython/pull/105511
In theory we could think about renaming the `UnionType` class or at least think about if we want to change the `pytype` attribute
https://github.com/pylint-dev/astroid/blob/5937f3d5cf3a0974ae184b042cd0232b9427c15b/astroid/bases.py#L738-L742
https://github.com/pylint-dev/astroid/blob/5937f3d5cf3a0974ae184b042cd0232b9427c15b/astroid/bases.py#L761-L762