### PR TITLE
[Backport maintenance/3.3.x] Initial fixes for Python 3.14 (#2747)

### DIFF
--- a/astroid/brain/brain_pathlib.py
+++ b/astroid/brain/brain_pathlib.py
@@ -8,7 +8,7 @@ from collections.abc import Iterator
 
 from astroid import bases, context, inference_tip, nodes
 from astroid.builder import _extract_single_node
-from astroid.const import PY313_PLUS
+from astroid.const import PY313
 from astroid.exceptions import InferenceError, UseInferenceDefault
 from astroid.manager import AstroidManager
 
@@ -28,7 +28,7 @@ def _looks_like_parents_subscript(node: nodes.Subscript) -> bool:
         value = next(node.value.infer())
     except (InferenceError, StopIteration):
         return False
-    parents = "builtins.tuple" if PY313_PLUS else "pathlib._PathParents"
+    parents = "builtins.tuple" if PY313 else "pathlib._PathParents"
     return (
         isinstance(value, bases.Instance)
         and isinstance(value._proxied, nodes.ClassDef)

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -8,7 +8,9 @@ import sys
 PY310_PLUS = sys.version_info >= (3, 10)
 PY311_PLUS = sys.version_info >= (3, 11)
 PY312_PLUS = sys.version_info >= (3, 12)
+PY313 = sys.version_info[:2] == (3, 13)
 PY313_PLUS = sys.version_info >= (3, 13)
+PY314_PLUS = sys.version_info >= (3, 14)
 
 WIN32 = sys.platform == "win32"
 

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -15,7 +15,7 @@ import astroid
 from astroid import MANAGER, builder, nodes, objects, test_utils, util
 from astroid.bases import Instance
 from astroid.brain.brain_namedtuple_enum import _get_namedtuple_fields
-from astroid.const import PY312_PLUS, PY313_PLUS
+from astroid.const import PY312_PLUS, PY313_PLUS, PY314_PLUS
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
@@ -335,6 +335,9 @@ class CollectionsBrain(unittest.TestCase):
         with self.assertRaises(InferenceError):
             next(node.infer())
 
+    @pytest.mark.skipif(
+        PY314_PLUS, reason="collections.abc.ByteString was removed in 3.14"
+    )
     def test_collections_object_subscriptable_3(self):
         """With Python 3.9 the ByteString class of the collections module is subscriptable
         (but not the same class from typing module)"""
@@ -918,6 +921,7 @@ class TypingBrain(unittest.TestCase):
             ],
         )
 
+    @pytest.mark.skipif(PY314_PLUS, reason="typing.ByteString was removed in 3.14")
     def test_typing_object_notsubscriptable_3(self):
         """Until python39 ByteString class of the typing module is not
         subscriptable (whereas it is in the collections' module)"""

--- a/tests/brain/test_pathlib.py
+++ b/tests/brain/test_pathlib.py
@@ -5,7 +5,7 @@
 
 import astroid
 from astroid import bases
-from astroid.const import PY310_PLUS, PY313_PLUS
+from astroid.const import PY310_PLUS, PY313
 from astroid.util import Uninferable
 
 
@@ -23,7 +23,7 @@ def test_inference_parents() -> None:
     inferred = name_node.inferred()
     assert len(inferred) == 1
     assert isinstance(inferred[0], bases.Instance)
-    if PY313_PLUS:
+    if PY313:
         assert inferred[0].qname() == "builtins.tuple"
     else:
         assert inferred[0].qname() == "pathlib._PathParents"
@@ -43,7 +43,7 @@ def test_inference_parents_subscript_index() -> None:
     inferred = path.inferred()
     assert len(inferred) == 1
     assert isinstance(inferred[0], bases.Instance)
-    if PY313_PLUS:
+    if PY313:
         assert inferred[0].qname() == "pathlib._local.Path"
     else:
         assert inferred[0].qname() == "pathlib.Path"

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -34,7 +34,7 @@ from astroid import decorators as decoratorsmod
 from astroid.arguments import CallSite
 from astroid.bases import BoundMethod, Generator, Instance, UnboundMethod, UnionType
 from astroid.builder import AstroidBuilder, _extract_single_node, extract_node, parse
-from astroid.const import IS_PYPY, PY310_PLUS, PY312_PLUS
+from astroid.const import IS_PYPY, PY310_PLUS, PY312_PLUS, PY314_PLUS
 from astroid.context import CallContext, InferenceContext
 from astroid.exceptions import (
     AstroidTypeError,
@@ -1306,8 +1306,12 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             assert i0.bool_value() is True
             assert i0.pytype() == "types.UnionType"
             assert i0.display_type() == "UnionType"
-            assert str(i0) == "UnionType(UnionType)"
-            assert repr(i0) == f"<UnionType(UnionType) l.0 at 0x{id(i0)}>"
+            if PY314_PLUS:
+                assert str(i0) == "UnionType(Union)"
+                assert repr(i0) == f"<UnionType(Union) l.0 at 0x{id(i0)}>"
+            else:
+                assert str(i0) == "UnionType(UnionType)"
+                assert repr(i0) == f"<UnionType(UnionType) l.0 at 0x{id(i0)}>"
 
             i1 = ast_nodes[1].inferred()[0]
             assert isinstance(i1, UnionType)


### PR DESCRIPTION
Backport https://github.com/pylint-dev/astroid/commit/43111bb4e2b8ae618168a449dcabcd40d19e5c3a from https://github.com/pylint-dev/astroid/pull/2747.