### PR TITLE
Bump astroid to 3.3.11, update changelog

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -133,6 +133,7 @@ Contributors
 - Oleh Prypin <oleh@pryp.in>
 - Nicolas Noirbent <nicolas@noirbent.fr>
 - Neil Girdhar <mistersheik@gmail.com>
+- Mitch Harding <mitchell.harding@hpe.com>
 - Miro Hrončok <miro@hroncok.cz>
 - Michał Masłowski <m.maslowski@clearcode.cc>
 - Mateusz Bysiek <mb@mbdev.pl>

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,9 +14,10 @@ Release date: TBA
 
 * Modify ``astroid.bases`` and ``tests.test_nodes`` to reflect that `enum.property` was added in Python 3.11, not 3.10
 
+
 What's New in astroid 3.3.11?
 =============================
-Release date: TBA
+Release date: 2025-07-13
 
 * Fix a crash when parsing an empty arbitrary expression with ``extract_node`` (``extract_node("__()")``).
 

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "3.3.10"
+__version__ = "3.3.11"
 version = __version__

--- a/script/.contributors_aliases.json
+++ b/script/.contributors_aliases.json
@@ -61,7 +61,8 @@
     "mails": [
       "66853113+pre-commit-ci[bot]@users.noreply.github.com",
       "49699333+dependabot[bot]@users.noreply.github.com",
-      "41898282+github-actions[bot]@users.noreply.github.com"
+      "41898282+github-actions[bot]@users.noreply.github.com",
+      "212256041+pylint-backport-bot[bot]@users.noreply.github.com"
     ],
     "name": "bot"
   },

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "3.3.10"
+current = "3.3.11"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
Last release for astroid 3.x (let's release even if the pipeline on the maintenance branch fail)

* Fix a crash when parsing an empty arbitrary expression with ``extract_node`` (``extract_node("__()")``).

  Closes #2734

* Fix a crash when parsing a slice called in a decorator on a function that is also decorated with
  a known ``six`` decorator.

  Closes #2721