### PR TITLE
Define separate pre-commit job for pylint ci runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Run pre-commit checks
         run: |
           . venv/bin/activate
-          pre-commit run pylint --all-files
+          pre-commit run --hook-stage manual pylint-ci --all-files
 
   tests-linux:
     name: tests / run / ${{ matrix.python-version }} / Linux

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,9 +49,24 @@ repos:
             "-rn",
             "-sn",
             "--rcfile=pylintrc",
+            # "--load-plugins=pylint.extensions.docparams", We're not ready for that
+          ]
+      # We define an additional manual step to allow running pylint
+      # with the proper output for CI.
+      - id: pylint
+        alias: pylint-ci
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        args: [
+            "-rn",
+            "-sn",
+            "--rcfile=pylintrc",
             "--output-format=github",
             # "--load-plugins=pylint.extensions.docparams", We're not ready for that
           ]
+        stages: [manual]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.17.1
     hooks:


### PR DESCRIPTION
For local runs `--output-format=github` isn't well suited. Add a separate pylint job just for CI runs.