### PR TITLE
[Backport maintenance/3.3.x] Partial backport of (#2765)

### DIFF
--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -3,7 +3,6 @@
 
 # Packages used to run additional tests
 attrs
-nose
 numpy>=1.17.0,<2; python_version<"3.12"
 python-dateutil
 PyQt6

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -120,8 +120,15 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
     def test_identify_old_namespace_package_protocol(self) -> None:
         # Like the above cases, this package follows the old namespace package protocol
         # astroid currently assumes such packages are in sys.modules, so import it
-        # pylint: disable-next=import-outside-toplevel
-        import tests.testdata.python3.data.path_pkg_resources_1.package.foo as _  # noqa
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=UserWarning,
+                message=".*pkg_resources is deprecated.*",
+            )
+
+            # pylint: disable-next=import-outside-toplevel
+            import tests.testdata.python3.data.path_pkg_resources_1.package.foo as _  # noqa
 
         self.assertTrue(
             util.is_namespace("tests.testdata.python3.data.path_pkg_resources_1")


### PR DESCRIPTION
## Description
Partial backport of #2765 to fix CI on maintenance branch (just in case).

* Remove nose test dependency
* Filter warnings for the test for old namespace package based on pkg_resource