### PR TITLE
[ci] Use setup-python output for pypy cache key

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -217,7 +217,7 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-${{ matrix.python-version }}-${{
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             steps.generate-python-key.outputs.key }}
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Description
All other jobs use the `setup-python` output already. Furthermore the pypy fix was just release in `v6.0`.
- https://github.com/pylint-dev/astroid/pull/2814
- https://github.com/actions/setup-python/pull/1110