### PR TITLE
Support boolean truthiness constraints in inference

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in astroid 4.0.0?
 ============================
 Release date: TBA
 
+* Add support for boolean truthiness constraints (`x`, `not x`) in inference.
+
+  Closes pylint-dev/pylint#9515
+
 * Fix false positive `invalid-name` on `attrs` classes with `ClassVar` annotated variables.
 
   Closes pylint-dev/pylint#10525

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -17,6 +17,8 @@ def common_params(node: str) -> pytest.MarkDecorator:
         (
             (f"{node} is None", None, 3),
             (f"{node} is not None", 3, None),
+            (f"{node}", 3, None),
+            (f"not {node}", None, 3),
         ),
     )
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -5491,7 +5491,7 @@ class CallSiteTest(unittest.TestCase):
             else:
                 kwargs = {}
 
-            if nums:
+            if nums is not None:
                 add(*nums)
                 print(**kwargs)
         """


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

This PR builds on #1189 by implementing the constraint interface to handle boolean constraints, similar to how `None` constraints are currently treated.

Previously, constraints only accounted for `None` checks:
```
x = 1

if x is None:
    x    # Uninferable, `1` is filtered out because x is not None
```

These changes support constraints derived from boolean truthiness:

1. If condition is `True`, keep the inferred value.
```
x = 1    # truthy

if x:
    x    # inferred as `1`
```

2. If condition is `False`, filter out the inferred value.
```
x = []    # falsy

if x:
    x    # Uninferable, `[]` filtered out
```

3. Negation rules are the same as `None` constraints.
```
x = 1

if x:
    pass
else:
    x    # Uninferable, `1` filtered out


y = []

if not y:
    y    # inferred as `[]`
```

4. If the boolean value cannot be inferred, assume constraint is satisfied.


Closes https://github.com/pylint-dev/pylint/issues/9515

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->
