### PR TITLE
Handle deprecated boolean cast of `NotImplemented`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ What's New in astroid 4.0.0?
 ============================
 Release date: TBA
 
+* Handle deprecated `bool(NotImplemented)` cast in const nodes.
+
 * Add support for boolean truthiness constraints (`x`, `not x`) in inference.
 
   Closes pylint-dev/pylint#9515

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, Union
 
 from astroid import decorators, protocols, util
 from astroid.bases import Instance, _infer_stmts
-from astroid.const import _EMPTY_OBJECT_MARKER, Context, PY314_PLUS
+from astroid.const import _EMPTY_OBJECT_MARKER, PY314_PLUS, Context
 from astroid.context import CallContext, InferenceContext, copy_context
 from astroid.exceptions import (
     AstroidBuildingError,

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2168,6 +2168,9 @@ class Const(_base_nodes.NoChildrenNode, Instance):
         :returns: The boolean value of this node.
         :rtype: bool
         """
+        # Guard against DeprecationWarning: bool(NotImplemented) is deprecated since Python 3.9
+        if self.value is NotImplemented:
+            return True
         return bool(self.value)
 
     def _infer(

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, Union
 
 from astroid import decorators, protocols, util
 from astroid.bases import Instance, _infer_stmts
-from astroid.const import _EMPTY_OBJECT_MARKER, Context
+from astroid.const import _EMPTY_OBJECT_MARKER, Context, PY314_PLUS
 from astroid.context import CallContext, InferenceContext, copy_context
 from astroid.exceptions import (
     AstroidBuildingError,
@@ -2166,11 +2166,12 @@ class Const(_base_nodes.NoChildrenNode, Instance):
         """Determine the boolean value of this node.
 
         :returns: The boolean value of this node.
-        :rtype: bool
+        :rtype: bool or Uninferable
         """
-        # Guard against DeprecationWarning: bool(NotImplemented) is deprecated since Python 3.9
+        # bool(NotImplemented) is deprecated; it raises TypeError starting from Python 3.14
+        # and returns True for versions under 3.14
         if self.value is NotImplemented:
-            return True
+            return util.Uninferable if PY314_PLUS else True
         return bool(self.value)
 
     def _infer(

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2987,7 +2987,10 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
     def test_bool_value_not_implemented(self) -> None:
         node = extract_node("""NotImplemented""")
         inferred = next(node.infer())
-        self.assertIs(inferred.bool_value(), True)
+        if PY314_PLUS:
+            self.assertIs(inferred.bool_value(), util.Uninferable)
+        else:
+            self.assertIs(inferred.bool_value(), True)
 
     def test_infer_coercion_rules_for_floats_complex(self) -> None:
         ast_nodes = extract_node(

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2984,6 +2984,11 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         inferred = next(instance.infer())
         self.assertIs(inferred.bool_value(), util.Uninferable)
 
+    def test_bool_value_not_implemented(self) -> None:
+        node = extract_node("""NotImplemented""")
+        inferred = next(node.infer())
+        self.assertIs(inferred.bool_value(), True)
+
     def test_infer_coercion_rules_for_floats_complex(self) -> None:
         ast_nodes = extract_node(
             """


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
|    | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

Related to https://github.com/pylint-dev/pylint/pull/10585, to address CI test failures encountered when linting Python `stdlib`. From my understanding, the failures were caused by `DeprecatedWarning` emissions when casting `NotImplemented` to boolean in `Const` nodes.

These changes introduce a guard clause to explicitly return `True` when calling `bool_value` on `NotImplemented` nodes. It seems like future Python versions will raise an error when evaluating `NotImplemented` in a boolean context, but the current behavior is to resolve to `True`.

Refer to https://docs.python.org/3.13/library/constants.html#NotImplemented.

<!-- If this PR references an issue without fixing it: -->

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->
