### PR TITLE
Handle `Uninferable` when calling `bool_value`

### DIFF
--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -80,7 +80,7 @@ def dataclass_transform(node: nodes.ClassDef) -> None:
                 break
             for keyword in decorator.keywords:
                 if keyword.arg == "kw_only":
-                    kw_only_decorated = keyword.value.bool_value()
+                    kw_only_decorated = keyword.value.bool_value() is True
 
     init_str = _generate_dataclass_init(
         node,
@@ -156,7 +156,7 @@ def _check_generate_dataclass_init(node: nodes.ClassDef) -> bool:
     # Check for keyword arguments of the form init=False
     return not any(
         keyword.arg == "init"
-        and not keyword.value.bool_value()  # type: ignore[union-attr] # value is never None
+        and keyword.value.bool_value() is False  # type: ignore[union-attr] # value is never None
         for keyword in found.keywords
     )
 
@@ -272,7 +272,7 @@ def _generate_dataclass_init(
         if is_field:
             # Skip any fields that have `init=False`
             if any(
-                keyword.arg == "init" and not keyword.value.bool_value()
+                keyword.arg == "init" and (keyword.value.bool_value() is False)
                 for keyword in value.keywords  # type: ignore[union-attr] # value is never None
             ):
                 # Also remove the name from the previous arguments to be inserted later
@@ -342,7 +342,7 @@ def _generate_dataclass_init(
         if is_field:
             kw_only = [k for k in value.keywords if k.arg == "kw_only"]  # type: ignore[union-attr]
             if kw_only:
-                if kw_only[0].value.bool_value():
+                if kw_only[0].value.bool_value() is True:
                     kw_only_params.append(param_str)
                 else:
                     params.append(param_str)

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -204,9 +204,10 @@ def infer_named_tuple(
     )
     assert isinstance(func, nodes.NodeNG)
     try:
-        rename = next(
+        rename_arg_bool_value = next(
             call_site.infer_argument(func, "rename", context or InferenceContext())
         ).bool_value()
+        rename = rename_arg_bool_value is True
     except (InferenceError, StopIteration):
         rename = False
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3121,8 +3121,11 @@ class IfExp(NodeNG):
         except (InferenceError, StopIteration):
             both_branches = True
         else:
-            if not isinstance(test, util.UninferableBase):
-                if test.bool_value():
+            test_bool_value = test.bool_value()
+            if not isinstance(test, util.UninferableBase) and not isinstance(
+                test_bool_value, util.UninferableBase
+            ):
+                if test_bool_value:
                     yield from self.body.infer(context=lhs_context)
                 else:
                     yield from self.orelse.infer(context=rhs_context)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
|    | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

After https://github.com/pylint-dev/astroid/pull/2831, I went through current usages of `bool_value()` (which may return `Uninferable`) and noticed some cases where `Uninferable` is evaluated in a boolean context. `Uninferable` is falsy but I think that we should handle it explicitly and not rely on its booleaness.

<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

