### PR TITLE
Fix issue parsing `_CallableType` & `_TupleType` with no args

### DIFF
--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -345,16 +345,20 @@ def _looks_like_special_alias(node: nodes.Call) -> bool:
     PY37: Callable = _VariadicGenericAlias(collections.abc.Callable, (), special=True)
     PY39: Callable = _CallableType(collections.abc.Callable, 2)
     """
-    return isinstance(node.func, nodes.Name) and (
-        (
-            node.func.name == "_TupleType"
-            and isinstance(node.args[0], nodes.Name)
-            and node.args[0].name == "tuple"
-        )
-        or (
-            node.func.name == "_CallableType"
-            and isinstance(node.args[0], nodes.Attribute)
-            and node.args[0].as_string() == "collections.abc.Callable"
+    return (
+        isinstance(node.func, nodes.Name)
+        and node.args
+        and (
+            (
+                node.func.name == "_TupleType"
+                and isinstance(node.args[0], nodes.Name)
+                and node.args[0].name == "tuple"
+            )
+            or (
+                node.func.name == "_CallableType"
+                and isinstance(node.args[0], nodes.Attribute)
+                and node.args[0].as_string() == "collections.abc.Callable"
+            )
         )
     )
 

--- a/tests/brain/test_typing.py
+++ b/tests/brain/test_typing.py
@@ -70,3 +70,23 @@ class TestTypingAlias:
         inferred = next(node.value.infer())
         assert isinstance(inferred, bases.Instance)
         assert inferred.name == "_SpecialGenericAlias"
+
+
+class TestSpecialAlias:
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "_CallableType()",
+            "_TupleType()",
+        ],
+    )
+    def test_special_alias_no_crash_on_empty_args(self, code: str) -> None:
+        """
+        Regression test for: https://github.com/pylint-dev/astroid/issues/2772
+
+        Test that _CallableType() and _TupleType() calls with no arguments
+        do not cause an IndexError.
+        """
+        # Should not raise IndexError
+        module = builder.parse(code)
+        assert isinstance(module, nodes.Module)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

This PR fixes an `IndexError` crash when parsing `_CallableType()` or `_TupleType()` calls with no arguments. The `_looks_like_special_alias()` predicate was attempting to access `node.args[0]` without first checking if the arguments list was empty. The fix adds a simple guard condition and `node.args` using short-circuit evaluation to ensure the list is non-empty before indexing.

Example:
```python
_CallableType()
_TupleType()
```
Current Output:
```
IndexError: list index out of range
File "astroid/brain/brain_typing.py", line 368, in _looks_like_special_alias
      and isinstance(node.args[0], Attribute)
                     ~~~~~~~~~^^^
```

Closes #2772
