### PR TITLE
Support `isinstance` constraints in inference

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,12 @@ What's New in astroid 4.0.0?
 ============================
 Release date: TBA
 
+* Add support for type constraints (`isinstance(x, y)`) in inference.
+
+  Closes pylint-dev/pylint#1162
+  Closes pylint-dev/pylint#4635
+  Closes pylint-dev/pylint#10469
+
 * Support constraints from ternary expressions in inference.
 
   Closes pylint-dev/pylint#9729

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -763,7 +763,7 @@ def infer_issubclass(callnode, context: InferenceContext | None = None):
     # The right hand argument is the class(es) that the given
     # object is to be checked against.
     try:
-        class_container = _class_or_tuple_to_container(
+        class_container = helpers.class_or_tuple_to_container(
             class_or_tuple_node, context=context
         )
     except InferenceError as exc:
@@ -798,7 +798,7 @@ def infer_isinstance(
     # The right hand argument is the class(es) that the given
     # obj is to be check is an instance of
     try:
-        class_container = _class_or_tuple_to_container(
+        class_container = helpers.class_or_tuple_to_container(
             class_or_tuple_node, context=context
         )
     except InferenceError as exc:
@@ -812,30 +812,6 @@ def infer_isinstance(
     if isinstance(isinstance_bool, util.UninferableBase):
         raise UseInferenceDefault
     return nodes.Const(isinstance_bool)
-
-
-def _class_or_tuple_to_container(
-    node: InferenceResult, context: InferenceContext | None = None
-) -> list[InferenceResult]:
-    # Move inferences results into container
-    # to simplify later logic
-    # raises InferenceError if any of the inferences fall through
-    try:
-        node_infer = next(node.infer(context=context))
-    except StopIteration as e:
-        raise InferenceError(node=node, context=context) from e
-    # arg2 MUST be a type or a TUPLE of types
-    # for isinstance
-    if isinstance(node_infer, nodes.Tuple):
-        try:
-            class_container = [
-                next(node.infer(context=context)) for node in node_infer.elts
-            ]
-        except StopIteration as e:
-            raise InferenceError(node=node, context=context) from e
-    else:
-        class_container = [node_infer]
-    return class_container
 
 
 def infer_len(node, context: InferenceContext | None = None) -> nodes.Const:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

These changes implements the constraint interface to add a new constraint - `TypeConstraint` to improve the accuracy of inference for objects used in type-narrowing guards.

Currently, the implementation only supports the `isinstance` pattern, but it should be relatively straightforward to extend it to support the negated case (`not isinstance`) in the future.

To determine whether an object is an instance of the given types, the implementation reuses existing inference mechanism for `isinstance` in `brains`.

<!-- If this PR references an issue without fixing it: -->

Refs https://github.com/pylint-dev/pylint/issues/1162
Refs https://github.com/pylint-dev/pylint/issues/4635
Refs https://github.com/pylint-dev/pylint/issues/10469

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->
