### PR TITLE
Suppress SyntaxWarnings for Python 3.14 when parsing modules

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,9 @@ Release date: TBA
 
 * Make `type.__new__()` raise clear errors instead of returning `None`
 
+* Suppress ``SyntaxWarning`` for invalid escape sequences and return in finally on
+  Python 3.14 when parsing modules.
+
 
 What's New in astroid 4.0.0?
 ============================

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 
 from astroid import bases, modutils, nodes, raw_building, rebuilder, util
 from astroid._ast import ParserModule, get_parser_module
-from astroid.const import PY312_PLUS
+from astroid.const import PY312_PLUS, PY314_PLUS
 from astroid.exceptions import AstroidBuildingError, AstroidSyntaxError, InferenceError
 
 if TYPE_CHECKING:
@@ -39,7 +39,11 @@ _TRANSIENT_FUNCTION = "__"
 _STATEMENT_SELECTOR = "#@"
 
 if PY312_PLUS:
-    warnings.filterwarnings("ignore", "invalid escape sequence", SyntaxWarning)
+    warnings.filterwarnings("ignore", ".*invalid escape sequence", SyntaxWarning)
+if PY314_PLUS:
+    warnings.filterwarnings(
+        "ignore", "'(return|continue|break)' in a 'finally'", SyntaxWarning
+    )
 
 
 def open_source_file(filename: str) -> tuple[TextIOWrapper, str, str]:


### PR DESCRIPTION
## Description
Similar to https://github.com/pylint-dev/astroid/pull/2386
Python 3.14 added a few more syntax warnings for `return in finally` [PEP 765](https://peps.python.org/pep-0765/) which are emitted during AST parsing. Similarly the message for `invalid escape sequence` changed slightly so the regex didn't match anymore.

```py
# test.py
def func() -> None:
    try:
        x = 1/0
    finally:
        return None  # return in finally

"Hello \P world"  # invalid escape sequence
```

Python 3.13
```py
# python3.13 test.py
test.py:7: SyntaxWarning: invalid escape sequence '\P'
  "Hello \P world"  # invalid escape sequence
```

Python3.13
```py
# python3.14 test.py
test.py:7: SyntaxWarning: "\P" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\P"? A raw string is also an option.
  "Hello \P world"  # invalid escape sequence
test.py:5: SyntaxWarning: 'return' in a 'finally' block
  return None  # return in finally
```