### PR TITLE
Assign import nodes to module locals if used with global

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,10 @@ Release date: TBA
 * Suppress ``SyntaxWarning`` for invalid escape sequences and return in finally on
   Python 3.14 when parsing modules.
 
+* Assign ``Import`` and ``ImportFrom`` nodes to module locals if used with ``global``.
+
+  Closes pylint-dev/pylint#10632
+
 
 What's New in astroid 4.0.0?
 ============================

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -2803,6 +2803,31 @@ def test_slots_duplicate_bases_issue_1089() -> None:
         astroid["First"].slots()
 
 
+def test_import_with_global() -> None:
+    code = builder.parse(
+        """
+    def f1():
+        global platform
+        from sys import platform as plat
+        platform = plat
+
+    def f2():
+        global os, RE, deque, VERSION, Path
+        import os
+        import re as RE
+        from collections import deque
+        from sys import version as VERSION
+        from pathlib import *
+    """
+    )
+    assert "platform" in code.locals
+    assert "os" in code.locals
+    assert "RE" in code.locals
+    assert "deque" in code.locals
+    assert "VERSION" in code.locals
+    assert "Path" in code.locals
+
+
 class TestFrameNodes:
     @staticmethod
     def test_frame_node():


### PR DESCRIPTION
## Description
Similar to `AssignName` nodes, `Import` and `ImportFrom` nodes should add the name to the module locals if used with `global`.

This does resolve the `no-name-in-module` error seen for `concurrent.futures.ProcessPoolExecutor` in Python 3.14.
https://github.com/pylint-dev/pylint/issues/10632.