### PR TITLE
Refactor Qt brain transforms to handle PyQt and PySide

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,6 @@ jobs:
           allow-prereleases: true
           check-latest: true
       - name: Install Qt
-        if: ${{ matrix.python-version == '3.10' }}
         run: |
           sudo apt-get update
           sudo apt-get install build-essential libgl1-mesa-dev

--- a/astroid/brain/brain_qt.py
+++ b/astroid/brain/brain_qt.py
@@ -2,70 +2,107 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-"""Astroid hooks for the PyQT library."""
+"""Astroid hooks for the Qt Python bindings (PyQt/PySide)."""
 
 from astroid import nodes
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder, parse
 from astroid.manager import AstroidManager
 
+_PYQT_ROOTS = {"PyQt5", "PyQt6"}
 
-def _looks_like_signal(
-    node: nodes.FunctionDef, signal_name: str = "pyqtSignal"
-) -> bool:
-    """Detect a Signal node."""
-    klasses = node.instance_attrs.get("__class__", [])
-    # On PySide2 or PySide6 (since  Qt 5.15.2) the Signal class changed locations
-    if node.qname().partition(".")[0] in {"PySide2", "PySide6"}:
-        return any(cls.qname() == "Signal" for cls in klasses)  # pragma: no cover
-    if klasses:
-        try:
-            return klasses[0].name == signal_name
-        except AttributeError:  # pragma: no cover
-            # return False if the cls does not have a name attribute
-            pass
+_PYQT_SIGNAL_QNAMES = {
+    "PyQt5.QtCore.pyqtSignal",
+    "PyQt6.QtCore.pyqtSignal",
+}
+
+_PYSIDE_ROOTS = {"PySide", "PySide2", "PySide6"}
+
+_PYSIDE_SIGNAL_QNAMES = {
+    "PySide.QtCore.Signal",
+    "PySide2.QtCore.Signal",
+    "PySide6.QtCore.Signal",
+}
+
+_PYQT_SIGNAL_TEMPLATE = parse(
+    """
+_UNSET = object()
+
+class _PyQtSignalTemplate(object):
+    def connect(self, slot, type=None, no_receiver_check=False):
+        pass
+    def disconnect(self, slot=_UNSET):
+        pass
+    def emit(self, *args):
+        pass
+"""
+)["_PyQtSignalTemplate"]
+
+_PYSIDE_SIGNAL_TEMPLATE = parse(
+    """
+class _PySideSignalTemplate(object):
+    def connect(self, receiver, type=None):
+        pass
+    def disconnect(self, receiver=None):
+        pass
+    def emit(self, *args):
+        pass
+"""
+)["_PySideSignalTemplate"]
+
+
+def _attach_signal_instance_attrs(node: nodes.NodeNG, template: nodes.ClassDef) -> None:
+    node.instance_attrs["connect"] = [template["connect"]]
+    node.instance_attrs["disconnect"] = [template["disconnect"]]
+    node.instance_attrs["emit"] = [template["emit"]]
+
+
+def _transform_signal_on_functiondef(node: nodes.FunctionDef) -> None:
+    root = node.qname().partition(".")[0]
+    if root in _PYQT_ROOTS:
+        template = _PYQT_SIGNAL_TEMPLATE
+    else:
+        template = _PYSIDE_SIGNAL_TEMPLATE  # pragma: no cover
+    _attach_signal_instance_attrs(node, template)
+
+
+def _transform_pyqt_signal_class(node: nodes.ClassDef) -> None:
+    _attach_signal_instance_attrs(node, _PYQT_SIGNAL_TEMPLATE)
+
+
+def _transform_pyside_signal_class(node: nodes.ClassDef) -> None:
+    _attach_signal_instance_attrs(node, _PYSIDE_SIGNAL_TEMPLATE)  # pragma: no cover
+
+
+def _is_pyside_signal_classdef(n: nodes.ClassDef) -> bool:
+    return n.qname() in _PYSIDE_SIGNAL_QNAMES
+
+
+def _is_pyqt_signal_classdef(n: nodes.ClassDef) -> bool:
+    return n.qname() in _PYQT_SIGNAL_QNAMES
+
+
+def _is_qt_signal_functiondef(n: nodes.FunctionDef) -> bool:
+    root = n.qname().partition(".")[0]
+    if root not in _PYQT_ROOTS | _PYSIDE_ROOTS:
+        return False
+
+    klasses = n.instance_attrs.get("__class__", [])
+    for cls in klasses:
+        name = getattr(cls, "name", "")
+        if name == "pyqtSignal" and root in _PYQT_ROOTS:
+            return True
+        if name == "Signal" and root in _PYSIDE_ROOTS:
+            return True  # pragma: no cover
+        qname = getattr(cls, "qname", None)
+        if callable(qname):
+            qualified = qname()
+            if qualified and qualified.rsplit(".", 1)[-1] == "Signal":
+                return True  # pragma: no cover
     return False
 
 
-def transform_pyqt_signal(node: nodes.FunctionDef) -> None:
-    module = parse(
-        """
-    _UNSET = object()
-
-    class pyqtSignal(object):
-        def connect(self, slot, type=None, no_receiver_check=False):
-            pass
-        def disconnect(self, slot=_UNSET):
-            pass
-        def emit(self, *args):
-            pass
-    """
-    )
-    signal_cls: nodes.ClassDef = module["pyqtSignal"]
-    node.instance_attrs["emit"] = [signal_cls["emit"]]
-    node.instance_attrs["disconnect"] = [signal_cls["disconnect"]]
-    node.instance_attrs["connect"] = [signal_cls["connect"]]
-
-
-def transform_pyside_signal(node: nodes.FunctionDef) -> None:
-    module = parse(
-        """
-    class NotPySideSignal(object):
-        def connect(self, receiver, type=None):
-            pass
-        def disconnect(self, receiver):
-            pass
-        def emit(self, *args):
-            pass
-    """
-    )
-    signal_cls: nodes.ClassDef = module["NotPySideSignal"]
-    node.instance_attrs["connect"] = [signal_cls["connect"]]
-    node.instance_attrs["disconnect"] = [signal_cls["disconnect"]]
-    node.instance_attrs["emit"] = [signal_cls["emit"]]
-
-
-def pyqt4_qtcore_transform():
+def _pyqt4_qtcore_transform():
     return AstroidBuilder(AstroidManager()).string_build(
         """
 
@@ -78,12 +115,20 @@ class QObject(object):
 
 
 def register(manager: AstroidManager) -> None:
-    register_module_extender(manager, "PyQt4.QtCore", pyqt4_qtcore_transform)
+    # PyQt4 legacy shim
+    register_module_extender(manager, "PyQt4.QtCore", _pyqt4_qtcore_transform)
+
+    # PyQt function style
     manager.register_transform(
-        nodes.FunctionDef, transform_pyqt_signal, _looks_like_signal
+        nodes.FunctionDef, _transform_signal_on_functiondef, _is_qt_signal_functiondef
     )
+
+    # PyQt class style
     manager.register_transform(
-        nodes.ClassDef,
-        transform_pyside_signal,
-        lambda node: node.qname() in {"PySide.QtCore.Signal", "PySide2.QtCore.Signal"},
+        nodes.ClassDef, _transform_pyqt_signal_class, _is_pyqt_signal_classdef
+    )
+
+    # PySide class style
+    manager.register_transform(
+        nodes.ClassDef, _transform_pyside_signal_class, _is_pyside_signal_classdef
     )


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This PR rewrites `astroid/brain/brain_qt.py` to correctly infer Qt signals for both PyQt and PySide, regardless of how the binding exposes them: Function-style signals (descriptor) or Class-style signals. Main changes:
- Reorganized `astroid/brain/brain_qt.py` to share explicit PyQt/PySide signal templates, restoring `connect`/`disconnect`/`emit` inference for both toolkits. I believe it also improves readability of code.
- Handle function-style vs class-style signals: Some bindings (e.g., PySide ≥ 5.15.2 / PySide6) expose `Signal` via the descriptor protocol, so it infers as a `FunctionDef`. The transform now catches that path and attaches the expected members. See Example 1 (subclassed `QTimer.timeout`) and Example 2 (class-style `Signal()` instance) below. Other bindings (e.g., PyQt5/6) expose `pyqtSignal` as a class, so it infers as a `ClassDef`. We register a matching class transform there as well.
- Enabled the PyQt6 brain tests across every supported Python version (Previously it was only for 3.10).

Please note that I tried to add tests to `PySide6` but it looks like PyQt6 and PySide6 cannot coexist in a single Linux process because their wheels bundle different Qt 6 library revisions (similiary to concolution in work made in PR pylint-dev/astroid#1654). Due to this limiation, I added `pragma: no cover` for the `PySide` code branches.

Previously failing examples - Example 1:

```python
from PySide6.QtCore import QTimer


class CustomTimer(QTimer):
    def __init__(self) -> None:
        super().__init__()
        self.timeout.connect(self.on_timeout)

    def on_timeout(self) -> None:
        pass


def build_timer() -> CustomTimer:
    timer = CustomTimer()
    timer.timeout.disconnect()
    return timer
```

Used to emit:

```
input.py:8:8: E1101: Method '<no-name>' has no 'connect' member (no-member)
input.py:16:4: E1101: Method '<no-name>' has no 'disconnect' member (no-member)
```

Example 2:

```python
from PySide6.QtCore import Signal


sig = Signal()
sig.connect(lambda: None)
```

Used to emit:

```
input.py:5:0: E1101: Instance of 'Signal' has no 'connect' member (no-member)
```

The same pattern affected PyQt5 and PyQt6 as well (with their appropriate API/syntax).

Fixes pylint-dev/pylint-qt#1.