### PR TITLE
Set lineno and end_lineno on Arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,8 @@ Release date: TBA
   Closes #2741
   Closes pylint-dev/pylint#6094
 
+* ``lineno`` and ``end_lineno`` are now available on ``Arguments``.
+
 * Add helper to iterate over all annotations nodes of function arguments,
   ``Arguments.get_annotations()``.
 

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -9,6 +9,7 @@ order to get a single Astroid representation.
 from __future__ import annotations
 
 import ast
+import itertools
 import sys
 import token
 from collections.abc import Callable, Collection, Generator
@@ -589,6 +590,16 @@ class TreeRebuilder:
             type_comment_kwonlyargs=type_comment_kwonlyargs,
             type_comment_posonlyargs=type_comment_posonlyargs,
         )
+        if start_end_lineno_pairs := [
+            (arg.lineno, arg.end_lineno)
+            for arg in itertools.chain(
+                node.args, node.posonlyargs, node.kwonlyargs, [node.vararg, node.kwarg]
+            )
+            if arg
+        ]:
+            newnode.lineno = min(startend[0] for startend in start_end_lineno_pairs)
+            newnode.end_lineno = max(startend[1] for startend in start_end_lineno_pairs)
+
         # save argument names in locals:
         assert newnode.parent
         if vararg:

--- a/tests/test_nodes_lineno.py
+++ b/tests/test_nodes_lineno.py
@@ -589,6 +589,8 @@ class TestLinenoColOffset:
         assert (f1.body[0].lineno, f1.body[0].col_offset) == (6, 4)
         assert (f1.body[0].end_lineno, f1.body[0].end_col_offset) == (6, 8)
 
+        assert (f1.args.lineno, f1.args.end_lineno) == (2, 4)
+
         # pos only arguments
         # TODO fix column offset: arg -> arg (AssignName)
         assert isinstance(f1.args.posonlyargs[0], nodes.AssignName)


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description
I have an idea for a performance enhancement in pylint that will require having this information set correctly on `Arguments` nodes.

Essentially, when pylint walks the AST to parse disable comments, we can avoid deeply recursing into child nodes that exist on the same line, since there is no point

```diff
diff --git a/pylint/utils/file_state.py b/pylint/utils/file_state.py
index 45217bb7e..0293ea6a4 100644
--- a/pylint/utils/file_state.py
+++ b/pylint/utils/file_state.py
@@ -63,8 +63,9 @@ class FileState:
         """Recursively walk (depth first) AST to collect block level options
         line numbers and set the state correctly.
         """
-        for child in node.get_children():
-            self._set_state_on_block_lines(msgs_store, child, msg, msg_state)
+        if node.lineno != node.end_lineno:
+            for child in node.get_children():
+                self._set_state_on_block_lines(msgs_store, child, msg, msg_state)
         # first child line number used to distinguish between disable
         # which are the first child of scoped node with those defined later.
         # For instance in the code below:
diff --git a/tests/functional/u/unsupported/unsupported_version_for_posonly_args.txt b/tests/functional/u/unsupported/unsupported_version_for_posonly_args.txt
index 4ae1b2756..fa7661536 100644
--- a/tests/functional/u/unsupported/unsupported_version_for_posonly_args.txt
+++ b/tests/functional/u/unsupported/unsupported_version_for_posonly_args.txt
@@ -1 +1 @@
-using-positional-only-args-in-unsupported-version:2:0:None:None:add:Positional-only arguments are not supported by all versions included in the py-version setting:HIGH
+using-positional-only-args-in-unsupported-version:2:0:2:None:add:Positional-only arguments are not supported by all versions included in the py-version setting:HIGH
diff --git a/tests/functional/u/unused/unused_argument.txt b/tests/functional/u/unused/unused_argument.txt
index bca2700ac..50f6c6694 100644
--- a/tests/functional/u/unused/unused_argument.txt
+++ b/tests/functional/u/unused/unused_argument.txt
@@ -3,8 +3,8 @@ unused-argument:3:23:3:29:test_unused:Unused argument 'second':HIGH
 unused-argument:32:29:32:32:Sub.newmethod:Unused argument 'aay':INFERENCE
 unused-argument:59:13:59:16:function:Unused argument 'arg':HIGH
 unused-argument:66:21:66:24:AAAA.method:Unused argument 'arg':INFERENCE
-unused-argument:73:0:None:None:AAAA.selected:Unused argument 'args':INFERENCE
-unused-argument:73:0:None:None:AAAA.selected:Unused argument 'kwargs':INFERENCE
+unused-argument:73:0:73:None:AAAA.selected:Unused argument 'args':INFERENCE
+unused-argument:73:0:73:None:AAAA.selected:Unused argument 'kwargs':INFERENCE
 unused-argument:92:23:92:26:BBBB.__init__:Unused argument 'arg':INFERENCE
 unused-argument:103:34:103:39:Ancestor.set_thing:Unused argument 'other':INFERENCE
 unused-argument:129:21:129:25:TestClassWithOnlyNew.__new__:Unused argument 'argA':INFERENCE
```