### PR TITLE
Correct assert usage in interface test

### DIFF
--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1503,7 +1503,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
 
     def test_python25_no_relative_import(self) -> None:
         ast = resources.build_file("data/package/absimport.py")
-        self.assertTrue(ast.absolute_import_activated(), True)
+        self.assertTrue(ast.absolute_import_activated())
         inferred = next(
             test_utils.get_name_node(ast, "import_package_subpackage_module").infer()
         )
@@ -1512,7 +1512,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
 
     def test_nonregr_absolute_import(self) -> None:
         ast = resources.build_file("data/absimp/string.py", "data.absimp.string")
-        self.assertTrue(ast.absolute_import_activated(), True)
+        self.assertTrue(ast.absolute_import_activated())
         inferred = next(test_utils.get_name_node(ast, "string").infer())
         self.assertIsInstance(inferred, nodes.Module)
         self.assertEqual(inferred.name, "string")


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

This PR fixes minor assertion misuse in the inference tests - Some `assertTrue` calls were incorrectly passing `True` as a second argument (interpreted as a message rather than a value). Just something I noticed while working on another fix - uploading it now so I don’t forget.
