### PR TITLE
feat: add HTTPMethod enum support to brain_http

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,10 @@ Release date: TBA
 
   Refs #2860
 
+* Add ``HTTPMethod`` enum support to brain module for Python 3.11+.
+
+  Closes #4135
+
 
 What's New in astroid 4.0.2?
 ============================

--- a/astroid/brain/brain_http.py
+++ b/astroid/brain/brain_http.py
@@ -14,9 +14,20 @@ from astroid.manager import AstroidManager
 def _http_transform() -> nodes.Module:
     code = textwrap.dedent(
         """
-    from enum import IntEnum
+    from enum import IntEnum, StrEnum
     from collections import namedtuple
     _HTTPStatus = namedtuple('_HTTPStatus', 'value phrase description')
+
+    class HTTPMethod(StrEnum):
+        GET = "GET"
+        POST = "POST"
+        PUT = "PUT"
+        DELETE = "DELETE"
+        HEAD = "HEAD"
+        OPTIONS = "OPTIONS"
+        PATCH = "PATCH"
+        TRACE = "TRACE"
+        CONNECT = "CONNECT"
 
     class HTTPStatus(IntEnum):
 


### PR DESCRIPTION
## Description
HTTPMethod was added in Python 3.11 but wasn't included in the brain hints. This was raising a error mentioned on [this pylint issue](https://github.com/pylint-dev/pylint/issues/10624). This PR add that to brain_http

Closes #2877

