### PR TITLE
Improve self argument typing

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1039,7 +1039,7 @@ class Arguments(
 
     @decorators.raise_if_nothing_inferred
     def _infer(
-        self: nodes.Arguments, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Any
     ) -> Generator[InferenceResult]:
         # pylint: disable-next=import-outside-toplevel
         from astroid.protocols import _arguments_infer_argname
@@ -1458,7 +1458,7 @@ class AugAssign(
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self: nodes.AugAssign, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Any
     ) -> Generator[InferenceResult]:
         return self._filter_operation_errors(
             self._infer_augassign, context, util.BadBinaryOperationMessage
@@ -1573,7 +1573,7 @@ class BinOp(_base_nodes.OperatorNode):
     @decorators.yes_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self: nodes.BinOp, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Any
     ) -> Generator[InferenceResult]:
         return self._filter_operation_errors(
             self._infer_binop, context, util.BadBinaryOperationMessage
@@ -1650,7 +1650,7 @@ class BoolOp(NodeNG):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self: nodes.BoolOp, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Any
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         """Infer a boolean operation (and / or / not).
 
@@ -4335,7 +4335,7 @@ class UnaryOp(_base_nodes.OperatorNode):
         return super().op_precedence()
 
     def _infer_unaryop(
-        self: nodes.UnaryOp, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Any
     ) -> Generator[
         InferenceResult | util.BadUnaryOperationMessage, None, InferenceErrorInfo
     ]:
@@ -4401,7 +4401,7 @@ class UnaryOp(_base_nodes.OperatorNode):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self: nodes.UnaryOp, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Any
     ) -> Generator[InferenceResult, None, InferenceErrorInfo]:
         """Infer what an UnaryOp should return when evaluated."""
         yield from self._filter_operation_errors(

--- a/astroid/nodes/scoped_nodes/mixin.py
+++ b/astroid/nodes/scoped_nodes/mixin.py
@@ -6,7 +6,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, overload
+from typing import TYPE_CHECKING, overload
+
+from typing_extensions import Self
 
 from astroid.exceptions import ParentMissingError
 from astroid.filter_statements import _filter_stmts
@@ -16,8 +18,6 @@ from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
 if TYPE_CHECKING:
     from astroid import nodes
-
-_T = TypeVar("_T")
 
 
 class LocalsDictNodeNG(_base_nodes.LookupMixIn):
@@ -46,7 +46,7 @@ class LocalsDictNodeNG(_base_nodes.LookupMixIn):
         except ParentMissingError:
             return self.name
 
-    def scope(self: _T) -> _T:
+    def scope(self) -> Self:
         """The first parent node defining a new scope.
 
         :returns: The first parent scope node.

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -15,7 +15,9 @@ import itertools
 import os
 from collections.abc import Generator, Iterable, Iterator, Sequence
 from functools import cached_property, lru_cache
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, NoReturn, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, NoReturn
+
+from typing_extensions import Self
 
 from astroid import bases, protocols, util
 from astroid.context import (
@@ -61,8 +63,6 @@ EXCEPTION_BASE_CLASSES = frozenset({"Exception", "BaseException"})
 BUILTIN_DESCRIPTORS = frozenset(
     {"classmethod", "staticmethod", "builtins.classmethod", "builtins.staticmethod"}
 )
-
-_T = TypeVar("_T")
 
 
 def _c3_merge(sequences, cls, context):
@@ -587,7 +587,7 @@ class Module(LocalsDictNodeNG):
     def get_children(self):
         yield from self.body
 
-    def frame(self: _T, *, future: Literal[None, True] = None) -> _T:
+    def frame(self, *, future: Literal[None, True] = None) -> Self:
         """The node's frame node.
 
         A frame node is a :class:`Module`, :class:`FunctionDef`,
@@ -1030,7 +1030,7 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
         yield self.args
         yield self.body
 
-    def frame(self: _T, *, future: Literal[None, True] = None) -> _T:
+    def frame(self, *, future: Literal[None, True] = None) -> Self:
         """The node's frame node.
 
         A frame node is a :class:`Module`, :class:`FunctionDef`,
@@ -1687,7 +1687,7 @@ class FunctionDef(
             frame = self
         return frame._scope_lookup(node, name, offset)
 
-    def frame(self: _T, *, future: Literal[None, True] = None) -> _T:
+    def frame(self, *, future: Literal[None, True] = None) -> Self:
         """The node's frame node.
 
         A frame node is a :class:`Module`, :class:`FunctionDef`,
@@ -2896,7 +2896,7 @@ class ClassDef(
         )
         return list(itertools.chain.from_iterable(children_assign_nodes))
 
-    def frame(self: _T, *, future: Literal[None, True] = None) -> _T:
+    def frame(self, *, future: Literal[None, True] = None) -> Self:
         """The node's frame node.
 
         A frame node is a :class:`Module`, :class:`FunctionDef`,

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 
 from collections.abc import Generator, Iterator
 from functools import cached_property
-from typing import Any, Literal, NoReturn, TypeVar
+from typing import Any, Literal, NoReturn
+
+from typing_extensions import Self
 
 from astroid import bases, util
 from astroid.context import InferenceContext
@@ -29,8 +31,6 @@ from astroid.interpreter import objectmodel
 from astroid.manager import AstroidManager
 from astroid.nodes import node_classes, scoped_nodes
 from astroid.typing import InferenceResult, SuccessfulInferenceResult
-
-_T = TypeVar("_T")
 
 
 class FrozenSet(node_classes.BaseContainer):
@@ -355,6 +355,6 @@ class Property(scoped_nodes.FunctionDef):
         raise InferenceError("Properties are not callable")
 
     def _infer(
-        self: _T, context: InferenceContext | None = None, **kwargs: Any
-    ) -> Generator[_T]:
+        self, context: InferenceContext | None = None, **kwargs: Any
+    ) -> Generator[Self]:
         yield self


### PR DESCRIPTION
`typing.Self` was added in Python 3.11. It is available in `typing_extensions` since `v4.0.0`.
https://typing-extensions.readthedocs.io/en/latest/#typing_extensions.Self

https://github.com/pylint-dev/astroid/blob/29667191d106ea7248160ba91b32652c0f4b6977/pyproject.toml#L35-L37