### PR TITLE
Fix base class inference for dataclasses with PEP 695 syntax

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,10 @@ What's New in astroid 4.0.3?
 ============================
 Release date: TBA
 
+* Fix base class inference for dataclasses using the PEP 695 typing syntax.
+
+  Refs pylint-dev/pylint#10788
+
 
 
 What's New in astroid 4.0.2?

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -54,7 +54,7 @@ def is_decorated_with_dataclass(
     )
 
 
-def dataclass_transform(node: nodes.ClassDef) -> None:
+def dataclass_transform(node: nodes.ClassDef) -> nodes.ClassDef | None:
     """Rewrite a dataclass to be easily understood by pylint."""
     node.is_dataclass = True
 
@@ -70,7 +70,7 @@ def dataclass_transform(node: nodes.ClassDef) -> None:
         node.instance_attrs[name] = [rhs_node]
 
     if not _check_generate_dataclass_init(node):
-        return
+        return None
 
     kw_only_decorated = False
     if node.decorators.nodes:
@@ -102,6 +102,7 @@ def dataclass_transform(node: nodes.ClassDef) -> None:
             new_assign = parse(f"{DEFAULT_FACTORY} = object()").body[0]
             new_assign.parent = root
             root.locals[DEFAULT_FACTORY] = [new_assign.targets[0]]
+    return node
 
 
 def _get_dataclass_attributes(


### PR DESCRIPTION
The dataclass transform should return the node on success so that followup transforms could be run as well. Mainly the typing one which will add `__class_getitem__` if it detects a PEP 695 generic.

Refs https://github.com/pylint-dev/pylint/issues/10788