### PR TITLE
Bump astroid to 4.0.3, update changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,9 +9,15 @@ Release date: TBA
 
 
 
-What's New in astroid 4.0.3?
+What's New in astroid 4.0.4?
 ============================
 Release date: TBA
+
+
+
+What's New in astroid 4.0.3?
+============================
+Release date: 2026-01-03
 
 * Fix inference of ``IfExp`` (ternary expression) nodes to avoid prematurely narrowing
   results in the face of inference ambiguity.

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "4.0.2"
+__version__ = "4.0.3"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "4.0.2"
+current = "4.0.3"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 4.0.3?
============================
Release date: 2026-01-03

* Fix inference of ``IfExp`` (ternary expression) nodes to avoid prematurely narrowing
  results in the face of inference ambiguity.

  Closes #2899

* Fix base class inference for dataclasses using the PEP 695 typing syntax.

  Refs pylint-dev/pylint#10788