### PR TITLE
Fix `random.sample` crash on uninferable sequence elements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -46,7 +46,9 @@ Release date: TBA
   described by a UNC path with a trailing backslash (`\`)
     - Example: modutils.modpath_from_file(filename=r"\\Mac\Code\tests\test_resources.py", path=["\\mac\code\"]) == ['tests', 'test_resources']
 
+* Fix ``random.sample`` inference crash when sequence contains uninferable elements.
 
+  Closes #2518
 
 What's New in astroid 4.0.3?
 ============================

--- a/astroid/brain/brain_random.py
+++ b/astroid/brain/brain_random.py
@@ -11,7 +11,7 @@ from astroid.context import InferenceContext
 from astroid.exceptions import UseInferenceDefault
 from astroid.inference_tip import inference_tip
 from astroid.manager import AstroidManager
-from astroid.util import safe_infer
+from astroid.util import UninferableBase, safe_infer
 
 ACCEPTED_ITERABLES_FOR_SAMPLE = (nodes.List, nodes.Set, nodes.Tuple)
 
@@ -57,6 +57,9 @@ def infer_random_sample(node, context: InferenceContext | None = None):
 
     if inferred_length.value > len(inferred_sequence.elts):
         # In this case, this will raise a ValueError
+        raise UseInferenceDefault
+
+    if any(isinstance(elt, UninferableBase) for elt in inferred_sequence.elts):
         raise UseInferenceDefault
 
     try:

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1077,6 +1077,20 @@ class RandomSampleTest(unittest.TestCase):
         assert len(inferred.elts) == 1
         assert isinstance(inferred.elts[0], nodes.Call)
 
+    def test_no_crash_on_uninferable_element(self) -> None:
+        """Test that random.sample does not crash when elements are Uninferable.
+
+        Regression test for https://github.com/pylint-dev/astroid/issues/2518
+        """
+        node = astroid.extract_node(
+            """
+        import random
+        random.sample(1*[b], 1)  #@
+        """
+        )
+        inferred = next(node.infer())
+        assert inferred is astroid.Uninferable
+
 
 class SubprocessTest(unittest.TestCase):
     """Test subprocess brain"""


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

When `random.sample()` is called with a sequence containing uninferable elements (e.g. `random.sample(1*[undefined_var], 1)`), the inference crashes with `TypeError: 'UninferableBase' object is not iterable`. This adds a check to bail out early when any element is Uninferable.

Closes #2518.
