### PR TITLE
Fix incorrect type inference for super() calls returning Self

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -36,6 +36,12 @@ Release date: TBA
 * Add simple command line interface for astroid to output generated AST.
   Use with ``python -m astroid``.
 
+* Fix incorrect type inference for ``super().method()`` calls that return ``Self``.
+  Previously, astroid would infer the parent class type instead of the child class type,
+  causing pylint E1101 false positives in method chaining scenarios.
+
+  Closes #457
+
 
 
 What's New in astroid 4.0.4?

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -194,7 +194,8 @@ class Super(node_classes.NodeNG):
                 # We can obtain different descriptors from a super depending
                 # on what we are accessing and where the super call is.
                 if inferred.type == "classmethod":
-                    yield bases.BoundMethod(inferred, cls)
+                    # Pass original caller for classmethod too
+                    yield bases.BoundMethod(inferred, cls, original_caller=self.type)
                 elif self._scope.type == "classmethod" and inferred.type == "method":
                     yield inferred
                 elif self._class_based or inferred.type == "staticmethod":
@@ -214,7 +215,9 @@ class Super(node_classes.NodeNG):
                     except InferenceError:
                         yield util.Uninferable
                 else:
-                    yield bases.BoundMethod(inferred, cls)
+                    # Pass original caller (self.type) so infer_call_result can
+                    # correctly resolve Self return types to the actual caller type
+                    yield bases.BoundMethod(inferred, cls, original_caller=self.type)
 
         # Only if we haven't found any explicit overwrites for the
         # attribute we look it up in the special attributes


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #457

### Problem

When a child class calls `super().method()` and the method returns `cls()` or `self`, astroid incorrectly infers the parent class type instead of the child class type.

**Original reproduction from #457:**

```python
class A:
    @classmethod
    def new(cls):
        return cls()

class B(A):
    @classmethod
    def new(cls):
        inst = super().new()
        return inst

B.new()  # Incorrectly inferred as "Instance of A" instead of "Instance of B"
```

This causes pylint E1101 false positives in method chaining scenarios.

### Root Cause

In `Super.igetattr`, when creating a `BoundMethod`, the `bound` parameter is set to the parent class found in the MRO. Later, `BoundMethod.infer_call_result` uses `bind_context_to_node(context, self.bound)`, which causes `self` or `cls()` to be inferred as the parent type.

### Solution

Add an optional `original_caller` parameter to `BoundMethod` to track the actual caller (child instance/class) separate from the bound class (parent class from MRO). When inferring call results, use `original_caller` for context binding if available.

This preserves backward compatibility:
- `bound` attribute unchanged (existing tests pass)
- `original_caller` defaults to `None` (existing behavior for non-super calls)

### Changes

- `astroid/bases.py`: Add `original_caller` parameter to `BoundMethod.__init__` and use it in `infer_call_result`
- `astroid/objects.py`: Pass `self.type` as `original_caller` when creating `BoundMethod` from `Super.igetattr` (both instance methods and classmethods)
- `tests/test_objects.py`: Add regression tests
- `ChangeLog`: Add entry

### Verification

This fix resolves all cases mentioned in #457 and related issues:

| Case | Source | `main` | This PR |
|------|--------|--------|---------|
| classmethod `cls()` | [#457 original](https://github.com/pylint-dev/astroid/issues/457) | Instance of A ✗ | Instance of B ✓ |
| instance method `self.__class__()` | [#457 comment](https://github.com/pylint-dev/astroid/issues/457#issuecomment-1083712596) | Instance of A ✗ | Instance of B ✓ |
| `super().clone()` chaining | [pylint#6033](https://github.com/pylint-dev/pylint/issues/6033) | Instance of ParentClass ✗ | Instance of MyClass ✓ |
| classmethod with explicit super | [pylint#981](https://github.com/pylint-dev/pylint/issues/981) | Instance of Foo ✗ | Instance of Bar ✓ |
| `__deepcopy__` with super | [pylint#4639](https://github.com/pylint-dev/pylint/issues/4639) | Instance of ParentClass ✗ | Instance of ChildClass ✓ |