### PR TITLE
Fix `random.sample` crash when cloning `ClassDef` and `FunctionDef` nodes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -56,6 +56,10 @@ Release date: TBA
 
   Closes #2518
 
+* Fix ``random.sample`` crash when cloning ``ClassDef`` or ``FunctionDef`` nodes.
+
+  Closes #2923
+
 What's New in astroid 4.0.3?
 ============================
 Release date: 2026-01-03

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1108,6 +1108,23 @@ class RandomSampleTest(unittest.TestCase):
         assert isinstance(inferred.elts[0], nodes.ClassDef)
         assert inferred.elts[0].name == "dict"
 
+    def test_no_crash_on_functiondef_clone(self) -> None:
+        """Test that random.sample does not crash when cloning FunctionDef nodes.
+
+        Regression test for https://github.com/pylint-dev/astroid/issues/2923
+        """
+        node = astroid.extract_node(
+            """
+        import random
+        random.sample([len] * 2, 1)  #@
+        """
+        )
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.List)
+        assert len(inferred.elts) == 1
+        assert isinstance(inferred.elts[0], nodes.FunctionDef)
+        assert inferred.elts[0].name == "len"
+
 
 class SubprocessTest(unittest.TestCase):
     """Test subprocess brain"""

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1091,6 +1091,23 @@ class RandomSampleTest(unittest.TestCase):
         inferred = next(node.infer())
         assert inferred is astroid.Uninferable
 
+    def test_no_crash_on_classdef_clone(self) -> None:
+        """Test that random.sample does not crash when cloning ClassDef nodes.
+
+        Regression test for https://github.com/pylint-dev/astroid/issues/2923
+        """
+        node = astroid.extract_node(
+            """
+        import random
+        random.sample([dict] * 2, 1)  #@
+        """
+        )
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.List)
+        assert len(inferred.elts) == 1
+        assert isinstance(inferred.elts[0], nodes.ClassDef)
+        assert inferred.elts[0].name == "dict"
+
 
 class SubprocessTest(unittest.TestCase):
     """Test subprocess brain"""


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The `_clone_node_with_lineno` function assumed all `_other_fields` were valid `__init__` parameters, but fields like `is_dataclass` on `ClassDef` and position on `FunctionDef` are set inside `__init__`, not passed to it. This caused a crash when inferring for example `random.sample([dict] * 2, 1)`. The fix uses `inspect.signature` to determine which fields are actual `__init__` parameters and copies the rest via `setattr` after node creation.

Closes #2923
