### PR TITLE
Add missing parameters to `numpy.concatenate` inference

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -42,6 +42,10 @@ Release date: TBA
 
   Closes #457
 
+* Add missing ``dtype`` and ``casting`` parameters to ``numpy.concatenate`` brain.
+
+  Closes #2870
+
 
 
 What's New in astroid 4.0.4?

--- a/astroid/brain/brain_numpy_core_multiarray.py
+++ b/astroid/brain/brain_numpy_core_multiarray.py
@@ -39,7 +39,7 @@ METHODS_TO_BE_INFERRED = {
             return numpy.ndarray([0, 0])""",
     "empty_like": """def empty_like(a, dtype=None, order='K', subok=True):
             return numpy.ndarray((0, 0))""",
-    "concatenate": """def concatenate(arrays, axis=None, out=None):
+    "concatenate": """def concatenate(arrays, axis=None, out=None, dtype=None, casting='same_kind'):
             return numpy.ndarray((0, 0))""",
     "where": """def where(condition, x=None, y=None):
             return numpy.ndarray([0, 0])""",


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Pylint reports false `unexpected-keyword-arg` errors when using `numpy.concatenate()` with `dtype` or `casting` parameters. These parameters were added in NumPy 1.20 but the astroid brain stub was never updated. This adds the missing parameters to fix the false positives.

Closes #2870.
