### PR TITLE
Make ``JoinedStr`` nodes ``Uninferable`` when the ``FormattedValue`` is ``Uninferable``.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,13 @@ What's New in astroid 4.1.0?
 ============================
 Release date: TBA
 
+* Ensure ``ast.JoinedStr`` nodes are ``Uninferable`` when the ``ast.FormattedValue`` is
+  ``Uninferable``. This prevents ``unexpected-keyword-arg`` messages in Pylint
+  where the ``Uninferable`` string appeared in function arguments that were
+  constructed dynamically.
+
+  Closes pylint-dev/pylint#10822
+
 * Add support for type constraints (`isinstance(x, y)`) in inference.
 
   Closes pylint-dev/pylint#1162

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4740,6 +4740,9 @@ class FormattedValue(NodeNG):
                     uninferable_already_generated = True
                 continue
             for value in self.value.infer(context, **kwargs):
+                if value is util.Uninferable:
+                    yield util.Uninferable
+                    return
                 value_to_format = value
                 if isinstance(value, Const):
                     value_to_format = value.value

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7154,3 +7154,21 @@ def test_joined_str_returns_string(source, expected) -> None:
         inferred[0].value.startswith(expected)
     else:
         assert inferred[0] is Uninferable
+
+
+def test_joined_str_uninferable() -> None:
+    """`thing` is not known, therefore the joinedstring should be
+    Uninferable
+    """
+    code = """
+        def hey(thing):
+            return thing
+
+        f"Hello {hey()}"
+    """
+    joined_str = extract_node(code)
+    constant_value, formatted_value = joined_str.values
+    assert constant_value.value == "Hello "
+    assert formatted_value.value.as_string() == "hey()"
+    inferred = next(joined_str.infer())
+    assert inferred is util.Uninferable


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

Ensure ``ast.JoinedStr`` nodes are ``Uninferable`` when the ``ast.FormattedValue`` is

``Uninferable``. This prevents ``unexpected-keyword-arg`` messages in Pylint where the ``Uninferable`` string appeared in function arguments that were constructed dynamically.
<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes pylint-dev/pylint#10822
