### PR TITLE
Fix namespace detection crash

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -64,6 +64,10 @@ Release date: TBA
 
   Closes #2923
 
+* Fix ``is_namespace()`` crash when search locations contain ``pathlib.Path`` objects.
+
+  Closes #2942
+
 What's New in astroid 4.0.3?
 ============================
 Release date: 2026-01-03

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -95,7 +95,10 @@ def is_namespace(modname: str) -> bool:
             # But immediately return False if we can detect we are in stdlib
             # or external lib (e.g site-packages)
             if any(
-                any(location.startswith(lib_dir) for lib_dir in STD_AND_EXT_LIB_DIRS)
+                any(
+                    str(location).startswith(lib_dir)
+                    for lib_dir in STD_AND_EXT_LIB_DIRS
+                )
                 for location in found_spec.submodule_search_locations
             ):
                 return False


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The `is_namespace()` function assumed that `submodule_search_locations` always contains strings. However, setuptools editable finders (PEP 660) can return `pathlib.Path` objects instead. Since `Path` objects don't have a `startswith()` method that accepts strings the way the code expected, this caused an `AttributeError`. The fix converts locations to strings before comparison.

Closes #2942 
