### PR TITLE
Bump astroid to 4.0.4, update changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,11 +9,15 @@ Release date: TBA
 
 
 
-What's New in astroid 4.0.4?
+What's New in astroid 4.0.5?
 ============================
 Release date: TBA
 
 
+
+What's New in astroid 4.0.4?
+============================
+Release date: 2026-02-07
 
 * Fix ``is_namespace()`` crash when search locations contain ``pathlib.Path`` objects.
 

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "4.0.3"
+__version__ = "4.0.4"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "4.0.3"
+current = "4.0.4"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 4.0.4?
============================
Release date: 2026-02-07

* Fix ``is_namespace()`` crash when search locations contain ``pathlib.Path`` objects.

  Closes #2942