### PR TITLE
Invoke pylint test suite on PRs

### DIFF
--- a/.github/workflows/test-pylint.yml
+++ b/.github/workflows/test-pylint.yml
@@ -7,5 +7,4 @@ jobs:
   test-pylint-with-astroid-sha:
     uses: pylint-dev/pylint/.github/workflows/tests.yaml
     with:
-      repository: ${{ github.repository_owner }}/pylint
       astroid_sha: ${{ github.sha }}

--- a/.github/workflows/test-pylint.yml
+++ b/.github/workflows/test-pylint.yml
@@ -1,0 +1,11 @@
+name: Test pylint
+
+on:
+  pull_request:
+
+jobs:
+  test-pylint-with-astroid-sha:
+    uses: pylint-dev/pylint/.github/workflows/tests.yaml
+    with:
+      repository: ${{ github.repository_owner }}/pylint
+      astroid_sha: ${{ github.sha }}


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
This avoids the need for checking out astroid PRs locally, running pylint tests locally, and applying the "pylint-tested" label.

Companion pylint PR: https://github.com/pylint-dev/pylint/pull/10841

See example run: https://github.com/jacobtylerwalls/astroid/actions/runs/21800375771/job/62894806554

Action expected to fail until companion pylint PR merged.