### PR TITLE
Bump astroid to 4.1.0, update changelog

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -14,8 +14,8 @@ Ex-maintainers
 Maintainers
 -----------
 - Pierre Sassoulas <pierre.sassoulas@gmail.com>
-- Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
 - Jacob Walls <jacobtylerwalls@gmail.com>
+- Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
 - Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 - Hippo91 <guillaume.peillex@gmail.com>
 - Bryce Guinta <bryce.paul.guinta@gmail.com>
@@ -39,7 +39,9 @@ Contributors
 - David Liu <david@cs.toronto.edu>
 - Alexandre Fayolle <alexandre.fayolle@logilab.fr>
 - Eevee (Alex Munroe) <amunroe@yelp.com>
+- Emmanuel Ferdman <emmanuelferdman@gmail.com>
 - David Gilman <davidgilman1@gmail.com>
+- Zen Lee <53538590+zenlyj@users.noreply.github.com>
 - Tushar Sadhwani <tushar.sadhwani000@gmail.com>
 - Matus Valo <matusvalo@users.noreply.github.com>
 - Julien Jehannet <julien.jehannet@logilab.fr>
@@ -47,7 +49,6 @@ Contributors
 - Calen Pennington <calen.pennington@gmail.com>
 - Antonio <antonio@zoftko.com>
 - Akhil Kamat <akhil.kamat@gmail.com>
-- Zen Lee <53538590+zenlyj@users.noreply.github.com>
 - Tim Martin <tim@asymptotic.co.uk>
 - Phil Schaf <flying-sheep@web.de>
 - Alex Hall <alex.mojaki@gmail.com>
@@ -97,11 +98,11 @@ Contributors
 - Keichi Takahashi <keichi.t@me.com>
 - Kavins Singh <kavinsingh@hotmail.com>
 - Karthikeyan Singaravelan <tir.karthi@gmail.com>
+- Kai Mueller <15907922+kasium@users.noreply.github.com>
 - Joshua Cannon <joshdcannon@gmail.com>
 - John Vandenberg <jayvdb@gmail.com>
 - Jacob Bogdanov <jacob@bogdanov.dev>
 - Google, Inc. <no-reply@google.com>
-- Emmanuel Ferdman <emmanuelferdman@gmail.com>
 - David Euresti <github@euresti.com>
 - David Douard <david.douard@logilab.fr>
 - David Cain <davidjosephcain@gmail.com>
@@ -119,12 +120,14 @@ Contributors
 - nathannaveen <42319948+nathannaveen@users.noreply.github.com>
 - mathieui <mathieui@users.noreply.github.com>
 - markmcclain <markmcclain@users.noreply.github.com>
+- jkmnt <git@firewood.fastmail.com>
 - ioanatia <ioanatia@users.noreply.github.com>
 - alm <alonme@users.noreply.github.com>
 - adam-grant-hendry <59346180+adam-grant-hendry@users.noreply.github.com>
 - aatle <168398276+aatle@users.noreply.github.com>
 - Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>
 - Zac Hatfield-Dodds <Zac-HD@users.noreply.github.com>
+- Youngwook Kim <youngwook.kim@gmail.com>
 - Vilnis Termanis <vilnis.termanis@iotics.com>
 - Valentin Valls <valentin.valls@esrf.fr>
 - Uilian Ries <uilianries@gmail.com>
@@ -143,6 +146,7 @@ Contributors
 - Peter de Blanc <peter@standard.ai>
 - Peter Talley <peterctalley@gmail.com>
 - Ovidiu Sabou <ovidiu@sabou.org>
+- Oliver Reiche <oliver.reiche@gmail.com>
 - Oleh Prypin <oleh@pryp.in>
 - Nicolas Noirbent <nicolas@noirbent.fr>
 - Neil Girdhar <mistersheik@gmail.com>
@@ -151,16 +155,17 @@ Contributors
 - Mateusz Bysiek <mb@mbdev.pl>
 - Matej Aleksandrov <matej.aleksandrov@gmail.com>
 - Marcelo Trylesinski <marcelotryle@gmail.com>
+- Low, Zhi Hao <lowzhao@gmail.com>
 - Leandro T. C. Melo <ltcmelo@gmail.com>
 - Konrad Weihmann <kweihmann@outlook.com>
 - Kian Meng, Ang <kianmeng.ang@gmail.com>
-- Kai Mueller <15907922+kasium@users.noreply.github.com>
 - Jörg Thalheim <Mic92@users.noreply.github.com>
 - Jérome Perrin <perrinjerome@gmail.com>
 - JulianJvn <128477611+JulianJvn@users.noreply.github.com>
 - Josef Kemetmüller <josef.kemetmueller@gmail.com>
 - Jonathan Striebel <jstriebel@users.noreply.github.com>
 - John Belmonte <john@neggie.net>
+- Joao Faria <joaovitorfaria.dev@gmail.com>
 - Jeff Widman <jeff@jeffwidman.com>
 - Jeff Quast <contact@jeffquast.com>
 - Jarrad Hope <me@jarradhope.com>
@@ -185,6 +190,7 @@ Contributors
 - Denis Laxalde <denis.laxalde@logilab.fr>
 - Deepyaman Datta <deepyaman.datta@utexas.edu>
 - David Poirier <david-poirier-csn@users.noreply.github.com>
+- David Foster <david@dafoster.net>
 - Dave Hirschfeld <dave.hirschfeld@gmail.com>
 - Dave Baum <dbaum@google.com>
 - Daniel Martin <daniel.martin@crowdstrike.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,9 +3,21 @@ astroid's ChangeLog
 ===================
 
 
-What's New in astroid 4.1.0?
+What's New in astroid 4.2.0?
 ============================
 Release date: TBA
+
+
+
+What's New in astroid 4.1.1?
+============================
+Release date: TBA
+
+
+
+What's New in astroid 4.1.0?
+============================
+Release date: 2026-02-08
 
 * Add support for equality constraints (``==``, ``!=``) in inference.
   Closes pylint-dev/pylint#3632
@@ -57,12 +69,6 @@ Release date: TBA
 
   Closes #2870
 
-
-
-What's New in astroid 4.0.5?
-============================
-Release date: TBA
-
 * Fix ability to detect .py modules inside PATH directories on Windows
   described by a UNC path with a trailing backslash (`\`)
     - Example: modutils.modpath_from_file(filename=r"\\Mac\Code\tests\test_resources.py", path=["\\mac\code\"]) == ['tests', 'test_resources']
@@ -75,9 +81,6 @@ Release date: TBA
 
   Closes #2923
 
-* Fix ``is_namespace()`` crash when search locations contain ``pathlib.Path`` objects.
-
-  Closes #2942
 
 What's New in astroid 4.0.4?
 ============================

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "4.1.0"
+__version__ = "4.2.0-dev0"
 version = __version__

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "4.1.0-dev0"
+__version__ = "4.1.0"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "4.1.0-dev0"
+current = "4.1.0"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "4.1.0"
+current = "4.2.0-dev0"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 4.1.0?
============================
Release date: 2026-02-08

* Add support for equality constraints (``==``, ``!=``) in inference.
  Closes pylint-dev/pylint#3632
  Closes pylint-dev/pylint#3633

* Ensure ``ast.JoinedStr`` nodes are ``Uninferable`` when the ``ast.FormattedValue`` is
  ``Uninferable``. This prevents ``unexpected-keyword-arg`` messages in Pylint
  where the ``Uninferable`` string appeared in function arguments that were
  constructed dynamically.

  Closes pylint-dev/pylint#10822

* Add support for type constraints (`isinstance(x, y)`) in inference.

  Closes pylint-dev/pylint#1162
  Closes pylint-dev/pylint#4635
  Closes pylint-dev/pylint#10469

* Make `type.__new__()` raise clear errors instead of returning `None`

* Move object dunder methods from ``FunctionModel`` to ``ObjectModel`` to make them
  available on all object types, not just functions.

  Closes #2742
  Closes #2741
  Closes pylint-dev/pylint#6094

* ``lineno`` and ``end_lineno`` are now available on ``Arguments``.

* Add helper to iterate over all annotations nodes of function arguments,
  ``Arguments.get_annotations()``.

  Refs #2860

* Skip direct parent when determining the ``Decorator`` frame.

  Refs pylint-dev/pylint#8425

* Add simple command line interface for astroid to output generated AST.
  Use with ``python -m astroid``.

* Fix incorrect type inference for ``super().method()`` calls that return ``Self``.
  Previously, astroid would infer the parent class type instead of the child class type,
  causing pylint E1101 false positives in method chaining scenarios.

  Closes #457

* Add missing ``dtype`` and ``casting`` parameters to ``numpy.concatenate`` brain.

  Closes #2870

* Fix ability to detect .py modules inside PATH directories on Windows
  described by a UNC path with a trailing backslash (`\`)
    - Example: modutils.modpath_from_file(filename=r"\\Mac\Code\tests\test_resources.py", path=["\\mac\code\"]) == ['tests', 'test_resources']

* Fix ``random.sample`` inference crash when sequence contains uninferable elements.

  Closes #2518

* Fix ``random.sample`` crash when cloning ``ClassDef`` or ``FunctionDef`` nodes.

  Closes #2923