### PR TITLE
Fix `__doc__` on unbound method

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,7 +13,8 @@ What's New in astroid 4.1.1?
 ============================
 Release date: TBA
 
-
+* Let `UnboundMethodModel` inherit from `FunctionModel` to improve inference of
+  dunder methods for unbound methods.
 
 What's New in astroid 4.1.0?
 ============================

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -413,7 +413,7 @@ class FunctionModel(ObjectModel):
                     )
 
                 # The `func` can already be a Unbound or BoundMethod. If the former, make sure to
-                # wrap as a BoundMethod like we do below whe constructing the function from scratch.
+                # wrap as a BoundMethod like we do below when constructing the function from scratch.
                 if isinstance(func, bases.UnboundMethod):
                     yield bases.BoundMethod(proxy=func, bound=cls)
                     return

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -412,8 +412,12 @@ class FunctionModel(ObjectModel):
                         "Invalid class inferred", target=self, context=context
                     )
 
-                # For some reason func is a Node that the below
-                # code is not expecting
+                # The `func` can already be a Unbound or BoundMethod. If the former, make sure to
+                # wrap as a BoundMethod like we do below whe constructing the function from scratch.
+                if isinstance(func, bases.UnboundMethod):
+                    yield bases.BoundMethod(proxy=func, bound=cls)
+                    return
+
                 if isinstance(func, bases.BoundMethod):
                     yield func
                     return
@@ -629,7 +633,7 @@ class SuperModel(ObjectModel):
         return self._instance._proxied
 
 
-class UnboundMethodModel(ObjectModel):
+class UnboundMethodModel(FunctionModel):
     @property
     def attr___class__(self):
         # pylint: disable=import-outside-toplevel; circular import

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -101,6 +101,7 @@ class UnboundMethodModelTest(unittest.TestCase):
         t.im_class #@
         t.im_func #@
         t.im_self #@
+        t.__doc__ #@
         """)
         assert isinstance(ast_nodes, list)
         cls = next(ast_nodes[0].infer())
@@ -120,6 +121,10 @@ class UnboundMethodModelTest(unittest.TestCase):
         self.assertEqual(cls.name, next(ast_nodes[3].infer()).name)
         self.assertEqual(func, next(ast_nodes[4].infer()))
         self.assertIsNone(next(ast_nodes[5].infer()).value)
+
+        doc = next(ast_nodes[6].infer())
+        self.assertIsInstance(doc, nodes.Const)
+        self.assertIsNone(doc.value)
 
 
 class ClassModelTest(unittest.TestCase):


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fixes the issue as described in https://github.com/pylint-dev/astroid/pull/2847

The reproducer for the crash is:

```python
class Executor:
    def submit(self): ...


class ThreadPoolExecutor(Executor):
    def submit(self): ...

    submit.__doc__ = Executor.submit.__doc__
```

That could be fixed in `pylint` (by not calling `pytype()` on `NodeNG` subclasses that don't have it), but that seems unnecessary.

Instead we can (I hope/think) better represent the actual object model by letting `UnboundMethodModel` inherit from `FunctionModel`. That feels like it would make sense? The test doesn't pass without this fix.

We could add `attr___doc__` on `UnboundMethodModel` but for me this feels like it better fits at least my own mental model of Python objects 😅 