### PR TITLE
Prevent Unknown from leaking via special attribute lookup

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,9 @@ Release date: TBA
 * Let `UnboundMethodModel` inherit from `FunctionModel` to improve inference of
   dunder methods for unbound methods.
 
+* Filter ``Unknown`` from ``UnboundMethod`` and ``Super`` special attribute
+  lookup to prevent placeholder nodes from leaking during inference.
+
 What's New in astroid 4.1.0?
 ============================
 Release date: 2026-02-08

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -462,14 +462,18 @@ class UnboundMethod(Proxy):
 
     def getattr(self, name: str, context: InferenceContext | None = None):
         if name in self.special_attributes:
-            return [self.special_attributes.lookup(name)]
+            special_attr = self.special_attributes.lookup(name)
+            if not isinstance(special_attr, nodes.Unknown):
+                return [special_attr]
         return self._proxied.getattr(name, context)
 
     def igetattr(
         self, name: str, context: InferenceContext | None = None
     ) -> Iterator[InferenceResult]:
         if name in self.special_attributes:
-            return iter((self.special_attributes.lookup(name),))
+            special_attr = self.special_attributes.lookup(name)
+            if not isinstance(special_attr, nodes.Unknown):
+                return iter((special_attr,))
         return self._proxied.igetattr(name, context)
 
     def infer_call_result(

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -222,8 +222,10 @@ class Super(node_classes.NodeNG):
         # Only if we haven't found any explicit overwrites for the
         # attribute we look it up in the special attributes
         if not found and name in self.special_attributes:
-            yield self.special_attributes.lookup(name)
-            return
+            special_attr = self.special_attributes.lookup(name)
+            if not isinstance(special_attr, node_classes.Unknown):
+                yield special_attr
+                return
 
         if not found:
             raise AttributeInferenceError(target=self, attribute=name, context=context)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

PR #2847 added `Unknown` filtering to `BaseInstance.getattr()` and `ClassDef.getattr()` so that `Unknown` placeholders from `ObjectModel` don't leak out. But the same filtering was missing from `UnboundMethod.getattr/igetattr` and `Super.igetattr`.

ObjectModel-only dunders on unbound methods return `Unknown` instead of `Uninferable`:

```python
class A:
    def test(self): pass

A.test.__eq__   # Returns Unknown, should be Uninferable
A.test.__hash__ # Returns Unknown, should be Uninferable
A.test.__repr__ # Returns Unknown, should be Uninferable
```

Same problem with `super()`:

```python
class Base:
    def method(self):
        return super().__doc__

Base().method()  # Returns Unknown, should be Uninferable
```

cc @jacobtylerwalls @DanielNoord 