### PR TITLE
Return the ``FunctionDef`` node when a call is made to a decorated function.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,14 @@ Release date: TBA
 * Let `UnboundMethodModel` inherit from `FunctionModel` to improve inference of
   dunder methods for unbound methods.
 
+* Return the ``FunctionDef`` node when a call is made to a decorated function
+  instead of returning the inferred ``FunctionDef`` node.
+  This prevents ``no-member`` messages in Pylint when a decorated function is
+  called and then is missing expected attributes; Pylint recognizes when a
+  ``FunctionDef`` node has any decorators and suppresses the message.
+
+  Closes pylint-dev/pylint#10848
+
 What's New in astroid 4.1.0?
 ============================
 Release date: 2026-02-08

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1771,7 +1771,7 @@ class Call(NodeNG):
             callcontext.extra_context = self._populate_context_lookup(context.clone())
 
         for callee in self.func.infer(context):
-            if isinstance(callee, util.UninferableBase):
+            if isinstance(callee, util.UninferableBase) or callee.decorators:
                 yield callee
                 continue
             try:

--- a/tests/test_inference_calls.py
+++ b/tests/test_inference_calls.py
@@ -547,10 +547,10 @@ def test_chained_attribute_inherited() -> None:
 
 def test_decorated_function() -> None:
     """Test that a call to a function, which has a decorator,
-       returns the function itself.
+    returns the function itself.
 
-       Currently we do not consider the result of a function after it's
-       decorator is applied to it.
+    Currently we do not consider the result of a function after it's
+    decorator is applied to it.
     """
     node = builder.extract_node("""
     from typing import Callable

--- a/tests/test_inference_calls.py
+++ b/tests/test_inference_calls.py
@@ -543,3 +543,32 @@ def test_chained_attribute_inherited() -> None:
     assert len(inferred) == 1
     assert isinstance(inferred[0], nodes.Const)
     assert inferred[0].value == 42
+
+
+def test_decorated_function() -> None:
+    """Test that a call to a function, which has a decorator,
+       returns the function itself.
+
+       Currently we do not consider the result of a function after it's
+       decorator is applied to it.
+    """
+    node = builder.extract_node("""
+    from typing import Callable
+
+    def type_changing_decorator(func: Callable[[int], int]) -> Callable[[int], str]:
+        def wrapper(val: int) -> str:
+            res = func(val)
+            return f"the result is {res:d}"
+        return wrapper
+
+    @type_changing_decorator
+    def add1(val: int) -> int:
+        return val+1
+
+    add1(5)  #@
+    """)
+    assert isinstance(node, nodes.NodeNG)
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.FunctionDef)
+    assert inferred[0].name == "add1"


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->
Return the ``FunctionDef`` node when a call is made to a decorated function.

instead of returning the inferred ``FunctionDef`` node. This prevents ``no-member`` messages in Pylint when a decorated function is called and then is missing expected attributes; Pylint recognizes when a ``FunctionDef`` node has any decorators and suppresses the message (https://github.com/pylint-dev/pylint/blob/main/pylint/checkers/typecheck.py#L1133-L1139)

Closes pylint-dev/pylint#10848



