### PR TITLE
Fix DuplicateBasesError crash in dataclass transform

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,7 +7,12 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Fix ``DuplicateBasesError`` crash in dataclass transform when a class has
+  duplicate bases in its MRO (e.g., ``Protocol`` appearing both directly and
+  indirectly). Catch ``MroError`` at ``.mro()`` call sites in
+  ``brain_dataclasses.py``, consistent with the existing pattern elsewhere.
 
+  Closes #2628
 
 What's New in astroid 4.1.2?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,18 +7,18 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
-* Fix ``DuplicateBasesError`` crash in dataclass transform when a class has
-  duplicate bases in its MRO (e.g., ``Protocol`` appearing both directly and
-  indirectly). Catch ``MroError`` at ``.mro()`` call sites in
-  ``brain_dataclasses.py``, consistent with the existing pattern elsewhere.
-
-  Closes #2628
 
 
 What's New in astroid 4.1.2?
 ============================
 Release date: TBA
 
+* Fix ``DuplicateBasesError`` crash in dataclass transform when a class has
+  duplicate bases in its MRO (e.g., ``Protocol`` appearing both directly and
+  indirectly). Catch ``MroError`` at ``.mro()`` call sites in
+  ``brain_dataclasses.py``, consistent with the existing pattern elsewhere.
+
+  Closes #2628
 
 
 What's New in astroid 4.1.1?

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ Release date: TBA
 
   Closes #2628
 
+
 What's New in astroid 4.1.2?
 ============================
 Release date: TBA

--- a/tests/brain/test_dataclasses.py
+++ b/tests/brain/test_dataclasses.py
@@ -1274,9 +1274,9 @@ def test_dataclass_with_duplicate_bases_no_crash():
 def test_dataclass_with_duplicate_bases_field_default():
     """Regression test for _get_previous_field_default with broken MRO.
 
-    When a parent dataclass defines a field and a child (with duplicate bases
-    in its MRO) overrides that field with init=False, _get_previous_field_default
-    should not crash with DuplicateBasesError.
+    When a parent dataclass defines a field with a default and a child (with
+    duplicate bases in its MRO) re-annotates that field without a value,
+    _get_previous_field_default should not crash with DuplicateBasesError.
 
     See https://github.com/pylint-dev/astroid/issues/2628.
     """
@@ -1299,7 +1299,7 @@ def test_dataclass_with_duplicate_bases_field_default():
 
     @dataclasses.dataclass
     class ChildConfig(BaseConfig[T]):
-        name: str = dataclasses.field(default="child", init=False)
+        name: str
 
     ChildConfig.__init__  #@
     """


### PR DESCRIPTION
## Summary
- Catch `MroError` in `brain_dataclasses.py` when computing MRO for dataclass field inheritance
- Classes with duplicate bases in MRO (e.g., `Protocol` appearing both directly and indirectly via `ConfigBase`) caused an unhandled `DuplicateBasesError` during AST transformation, crashing pylint
- Follows the existing pattern used at 3 other `.mro()` call sites in the codebase (`scoped_nodes.py:2321`, `scoped_nodes.py:2800`, `helpers.py:222`)

## Approach
Per @jacobtylerwalls's [suggestion](https://github.com/pylint-dev/astroid/issues/2628#issuecomment-2456753270): catch `MroError` at both `.mro()` call sites in `brain_dataclasses.py` and fall back gracefully:
- `_find_arguments_from_base_classes`: returns empty stores (no inherited fields)
- `_get_previous_field_default`: returns `None` (no previous default)

## Test
Added `test_dataclass_with_duplicate_bases_no_crash` — reproduces the exact crash from #2628 (dataclass inheriting from a class with Protocol in MRO both directly and indirectly).

All 1935 existing tests pass with no regressions.

Fixes #2628.