### PR TITLE
Bump astroid to 4.1.1, update changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,15 +9,26 @@ Release date: TBA
 
 
 
-What's New in astroid 4.1.1?
+What's New in astroid 4.1.2?
 ============================
 Release date: TBA
+
+
+
+What's New in astroid 4.1.1?
+============================
+Release date: 2026-02-22
 
 * Let `UnboundMethodModel` inherit from `FunctionModel` to improve inference of
   dunder methods for unbound methods.
 
+  Refs #2741
+
 * Filter ``Unknown`` from ``UnboundMethod`` and ``Super`` special attribute
   lookup to prevent placeholder nodes from leaking during inference.
+
+  Refs #2741
+
 
 What's New in astroid 4.1.0?
 ============================

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "4.1.0"
+__version__ = "4.1.1"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "4.1.0"
+current = "4.1.1"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 4.1.1?
============================
Release date: 2026-02-22

* Let `UnboundMethodModel` inherit from `FunctionModel` to improve inference of
  dunder methods for unbound methods.

  Refs #2741

* Filter ``Unknown`` from ``UnboundMethod`` and ``Super`` special attribute
  lookup to prevent placeholder nodes from leaking during inference.

  Refs #2741