### PR TITLE
Fix cyclic inference by constraints

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,8 @@ What's New in astroid 4.1.2?
 ============================
 Release date: TBA
 
+* Fix infinite recursion caused by cyclic inference in ``Constraint``. 
+
 * Fix ``RecursionError`` in ``_compute_mro()`` when circular class hierarchies
   are created through runtime name rebinding. Circular bases are now resolved
   to the original class instead of recursing.

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,7 +12,7 @@ What's New in astroid 4.1.2?
 ============================
 Release date: TBA
 
-* Fix infinite recursion caused by cyclic inference in ``Constraint``. 
+* Fix infinite recursion caused by cyclic inference in ``Constraint``.
 
 * Fix ``RecursionError`` in ``_compute_mro()`` when circular class hierarchies
   are created through runtime name rebinding. Circular bases are now resolved

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -183,7 +183,10 @@ def _infer_stmts(
                 if not constraint_stmt.parent_of(stmt):
                     stmt_constraints.update(potential_constraints)
             for inf in stmt.infer(context=context):
-                if all(constraint.satisfied_by(inf) for constraint in stmt_constraints):
+                if all(
+                    constraint.satisfied_by(inf, context)
+                    for constraint in stmt_constraints
+                ):
                     yield inf
                     inferred = True
                 else:

--- a/astroid/constraint.py
+++ b/astroid/constraint.py
@@ -12,6 +12,7 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 from astroid import helpers, nodes, util
+from astroid.context import InferenceContext
 from astroid.exceptions import AstroidTypeError, InferenceError, MroError
 from astroid.typing import InferenceResult
 
@@ -47,7 +48,9 @@ class Constraint(ABC):
         """
 
     @abstractmethod
-    def satisfied_by(self, inferred: InferenceResult) -> bool:
+    def satisfied_by(
+        self, inferred: InferenceResult, context: InferenceContext
+    ) -> bool:
         """Return True if this constraint is satisfied by the given inferred value."""
 
 
@@ -76,7 +79,9 @@ class NoneConstraint(Constraint):
 
         return None
 
-    def satisfied_by(self, inferred: InferenceResult) -> bool:
+    def satisfied_by(
+        self, inferred: InferenceResult, context: InferenceContext
+    ) -> bool:
         """Return True if this constraint is satisfied by the given inferred value."""
         # Assume true if uninferable
         if inferred is util.Uninferable:
@@ -112,7 +117,9 @@ class BooleanConstraint(Constraint):
 
         return None
 
-    def satisfied_by(self, inferred: InferenceResult) -> bool:
+    def satisfied_by(
+        self, inferred: InferenceResult, context: InferenceContext
+    ) -> bool:
         """Return True for uninferable results, or depending on negate flag:
 
         - negate=False: satisfied if boolean value is True
@@ -153,7 +160,9 @@ class TypeConstraint(Constraint):
 
         return None
 
-    def satisfied_by(self, inferred: InferenceResult) -> bool:
+    def satisfied_by(
+        self, inferred: InferenceResult, context: InferenceContext
+    ) -> bool:
         """Return True for uninferable results, or depending on negate flag:
 
         - negate=False: satisfied when inferred is an instance of the checked types.
@@ -163,8 +172,8 @@ class TypeConstraint(Constraint):
             return True
 
         try:
-            types = helpers.class_or_tuple_to_container(self.classinfo)
-            matches_checked_types = helpers.object_isinstance(inferred, types)
+            types = helpers.class_or_tuple_to_container(self.classinfo, context)
+            matches_checked_types = helpers.object_isinstance(inferred, types, context)
 
             if matches_checked_types is util.Uninferable:
                 return True
@@ -204,7 +213,9 @@ class EqualityConstraint(Constraint):
 
         return None
 
-    def satisfied_by(self, inferred: InferenceResult) -> bool:
+    def satisfied_by(
+        self, inferred: InferenceResult, context: InferenceContext
+    ) -> bool:
         """Return True for uninferable/ambiguous results, or depending on negate flag:
 
         - negate=False: satisfied when both operands are equal.
@@ -215,7 +226,7 @@ class EqualityConstraint(Constraint):
         if inferred is util.Uninferable:
             return True
 
-        operand_inferred = util.safe_infer(self.operand)
+        operand_inferred = util.safe_infer(self.operand, context)
         if operand_inferred is util.Uninferable or operand_inferred is None:
             return True
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

Originally reported at https://github.com/pylint-dev/astroid/pull/2927#issuecomment-3954537903

When pylint is ran on Home Assistant - `homeassistant/components/hvv_departures/sensor.py`, it goes into infinite recursion when computing constraints during inference.

Since the constraints module is now inferring values in `TypeConstraint` and `EqualityConstraint`, we should invoke `.infer()` with upstream inference context.

Verified these changes with: https://github.com/zenlyj/core/actions/runs/22542958850

<!-- If this PR references an issue without fixing it: -->

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->
