### PR TITLE
Include inference kwargs in cache key via InferKwargs TypedDict

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -42,6 +42,12 @@ Release date: TBA
 
   Closes #2764
 
+* Include inference kwargs (e.g. ``asname``) in the inference cache key so that
+  different invocations of ``Import._infer()`` with different kwargs produce
+  separate cache entries.
+
+  Closes pylint-dev/pylint#10193
+
 
 What's New in astroid 4.1.1?
 ============================

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -48,14 +48,15 @@ from astroid.typing import (
 )
 
 if sys.version_info >= (3, 11):
-    from typing import Self
+    from typing import Self, Unpack
 else:
-    from typing_extensions import Self
+    from typing_extensions import Self, Unpack
 
 if TYPE_CHECKING:
     from astroid import nodes
     from astroid.nodes import LocalsDictNodeNG
     from astroid.nodes.node_ng import FrameType
+    from astroid.typing import InferKwargs
 
 
 def _is_const(value) -> bool:
@@ -342,7 +343,7 @@ class BaseContainer(_base_nodes.ParentAssignNode, Instance, metaclass=abc.ABCMet
     def _infer(
         self,
         context: InferenceContext | None = None,
-        **kwargs: Any,
+        **kwargs: Unpack[InferKwargs],
     ) -> Iterator[Self]:
         has_starred_named_expr = any(
             isinstance(e, (Starred, NamedExpr)) for e in self.elts
@@ -441,7 +442,7 @@ class AssignName(
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         """Infer an AssignName: need to inspect the RHS part of the
         assign node.
@@ -454,7 +455,7 @@ class AssignName(
 
     @decorators.raise_if_nothing_inferred
     def infer_lhs(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         """Infer a Name: use name lookup rules.
 
@@ -569,7 +570,7 @@ class Name(_base_nodes.LookupMixIn, _base_nodes.NoChildrenNode):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         """Infer a Name: use name lookup rules
 
@@ -1040,7 +1041,7 @@ class Arguments(
 
     @decorators.raise_if_nothing_inferred
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult]:
         # pylint: disable-next=import-outside-toplevel
         from astroid.protocols import _arguments_infer_argname
@@ -1094,7 +1095,7 @@ def _format_args(
 def _infer_attribute(
     node: nodes.AssignAttr | nodes.Attribute,
     context: InferenceContext | None = None,
-    **kwargs: Any,
+    **kwargs: Unpack[InferKwargs],
 ) -> Generator[InferenceResult, None, InferenceErrorInfo]:
     """Infer an AssignAttr/Attribute node by using getattr on the associated object."""
     # pylint: disable=import-outside-toplevel
@@ -1183,7 +1184,7 @@ class AssignAttr(_base_nodes.LookupMixIn, _base_nodes.ParentAssignNode):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         """Infer an AssignAttr: need to inspect the RHS part of the
         assign node.
@@ -1197,7 +1198,7 @@ class AssignAttr(_base_nodes.LookupMixIn, _base_nodes.ParentAssignNode):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def infer_lhs(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         return _infer_attribute(self, context, **kwargs)
 
@@ -1459,7 +1460,7 @@ class AugAssign(
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult]:
         return self._filter_operation_errors(
             self._infer_augassign, context, util.BadBinaryOperationMessage
@@ -1544,7 +1545,7 @@ class BinOp(_base_nodes.OperatorNode):
         return self.op != "**"
 
     def _infer_binop(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult]:
         """Binary operation inference logic."""
         left = self.left
@@ -1574,7 +1575,7 @@ class BinOp(_base_nodes.OperatorNode):
     @decorators.yes_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult]:
         return self._filter_operation_errors(
             self._infer_binop, context, util.BadBinaryOperationMessage
@@ -1651,7 +1652,7 @@ class BoolOp(NodeNG):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         """Infer a boolean operation (and / or / not).
 
@@ -1762,7 +1763,7 @@ class Call(NodeNG):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo]:
         """Infer a Call node by trying to guess what the function returns."""
         callcontext = copy_context(context)
@@ -1923,7 +1924,7 @@ class Compare(NodeNG):
         return retval  # it was all the same value
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[nodes.Const | util.UninferableBase]:
         """Chained comparison inference logic."""
         retval: bool | util.UninferableBase = True
@@ -2197,7 +2198,7 @@ class Const(_base_nodes.NoChildrenNode, Instance):
         return bool(self.value)
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Iterator[Const]:
         yield self
 
@@ -2471,7 +2472,7 @@ class Dict(NodeNG, Instance):
         return bool(self.items)
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Iterator[nodes.Dict]:
         if not any(isinstance(k, DictUnpack) for k, _ in self.items):
             yield self
@@ -2599,7 +2600,7 @@ class EmptyNode(_base_nodes.NoChildrenNode):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult]:
         if not self.has_underlying_object():
             yield util.Uninferable
@@ -2889,7 +2890,7 @@ class ImportFrom(_base_nodes.ImportNode):
         self,
         context: InferenceContext | None = None,
         asname: bool = True,
-        **kwargs: Any,
+        **kwargs: Unpack[InferKwargs],
     ) -> Generator[InferenceResult]:
         """Infer a ImportFrom node: return the imported module/object."""
         context = context or InferenceContext()
@@ -2956,7 +2957,7 @@ class Attribute(NodeNG):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo]:
         return _infer_attribute(self, context, **kwargs)
 
@@ -3014,7 +3015,7 @@ class Global(_base_nodes.NoChildrenNode, _base_nodes.Statement):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult]:
         if context is None or context.lookupname is None:
             raise InferenceError(node=self, context=context)
@@ -3131,7 +3132,7 @@ class IfExp(NodeNG):
 
     @decorators.raise_if_nothing_inferred
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult]:
         """Support IfExp inference.
 
@@ -3229,7 +3230,7 @@ class Import(_base_nodes.ImportNode):
         self,
         context: InferenceContext | None = None,
         asname: bool = True,
-        **kwargs: Any,
+        **kwargs: Unpack[InferKwargs],
     ) -> Generator[nodes.Module]:
         """Infer an Import node: return the imported module/object."""
         context = context or InferenceContext()
@@ -3453,7 +3454,7 @@ class ParamSpec(_base_nodes.AssignTypeNode):
         self.default_value = default_value
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Iterator[ParamSpec]:
         yield self
 
@@ -3655,7 +3656,7 @@ class Slice(NodeNG):
             yield self.step
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Iterator[Slice]:
         yield self
 
@@ -3758,7 +3759,7 @@ class Subscript(NodeNG):
         yield self.slice
 
     def _infer_subscript(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         """Inference for subscripts.
 
@@ -3818,11 +3819,11 @@ class Subscript(NodeNG):
 
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
-    def _infer(self, context: InferenceContext | None = None, **kwargs: Any):
+    def _infer(self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]):
         return self._infer_subscript(context, **kwargs)
 
     @decorators.raise_if_nothing_inferred
-    def infer_lhs(self, context: InferenceContext | None = None, **kwargs: Any):
+    def infer_lhs(self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]):
         return self._infer_subscript(context, **kwargs)
 
 
@@ -4160,7 +4161,7 @@ class TypeAlias(_base_nodes.AssignTypeNode, _base_nodes.Statement):
         self.value = value
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Iterator[TypeAlias]:
         yield self
 
@@ -4220,7 +4221,7 @@ class TypeVar(_base_nodes.AssignTypeNode):
         self.default_value = default_value
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Iterator[TypeVar]:
         yield self
 
@@ -4267,7 +4268,7 @@ class TypeVarTuple(_base_nodes.AssignTypeNode):
         self.default_value = default_value
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Iterator[TypeVarTuple]:
         yield self
 
@@ -4355,7 +4356,7 @@ class UnaryOp(_base_nodes.OperatorNode):
         return super().op_precedence()
 
     def _infer_unaryop(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[
         InferenceResult | util.BadUnaryOperationMessage, None, InferenceErrorInfo
     ]:
@@ -4421,7 +4422,7 @@ class UnaryOp(_base_nodes.OperatorNode):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo]:
         """Infer what an UnaryOp should return when evaluated."""
         yield from self._filter_operation_errors(
@@ -4733,7 +4734,7 @@ class FormattedValue(NodeNG):
             yield self.format_spec
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         format_specs = Const("") if self.format_spec is None else self.format_spec
         uninferable_already_generated = False
@@ -4832,7 +4833,7 @@ class JoinedStr(NodeNG):
         yield from self.values
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         if self.values:
             yield from self._infer_with_values(context)
@@ -4840,7 +4841,7 @@ class JoinedStr(NodeNG):
             yield Const("")
 
     def _infer_with_values(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         uninferable_already_generated = False
         for inferred in self._infer_from_values(self.values, context):
@@ -4856,7 +4857,7 @@ class JoinedStr(NodeNG):
 
     @classmethod
     def _infer_from_values(
-        cls, nodes: list[NodeNG], context: InferenceContext | None = None, **kwargs: Any
+        cls, nodes: list[NodeNG], context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         if not nodes:
             return
@@ -4879,7 +4880,7 @@ class JoinedStr(NodeNG):
 
     @classmethod
     def _safe_infer_from_node(
-        cls, node: NodeNG, context: InferenceContext | None = None, **kwargs: Any
+        cls, node: NodeNG, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         try:
             yield from node._infer(context, **kwargs)
@@ -5035,7 +5036,11 @@ class Unknown(_base_nodes.AssignTypeNode):
     def qname(self) -> Literal["Unknown"]:
         return "Unknown"
 
-    def _infer(self, context: InferenceContext | None = None, **kwargs):
+    def _infer(
+        self,
+        context: InferenceContext | None = None,
+        **kwargs: Unpack[InferKwargs],
+    ):
         """Inference on an Unknown node immediately terminates."""
         yield util.Uninferable
 
@@ -5072,7 +5077,7 @@ class EvaluatedObject(NodeNG):
         )
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[NodeNG | util.UninferableBase]:
         yield self.value
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3819,11 +3819,15 @@ class Subscript(NodeNG):
 
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
-    def _infer(self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]):
+    def _infer(
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
+    ):
         return self._infer_subscript(context, **kwargs)
 
     @decorators.raise_if_nothing_inferred
-    def infer_lhs(self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]):
+    def infer_lhs(
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
+    ):
         return self._infer_subscript(context, **kwargs)
 
 
@@ -4857,7 +4861,10 @@ class JoinedStr(NodeNG):
 
     @classmethod
     def _infer_from_values(
-        cls, nodes: list[NodeNG], context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
+        cls,
+        nodes: list[NodeNG],
+        context: InferenceContext | None = None,
+        **kwargs: Unpack[InferKwargs],
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         if not nodes:
             return
@@ -4880,7 +4887,10 @@ class JoinedStr(NodeNG):
 
     @classmethod
     def _safe_infer_from_node(
-        cls, node: NodeNG, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
+        cls,
+        node: NodeNG,
+        context: InferenceContext | None = None,
+        **kwargs: Unpack[InferKwargs],
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         try:
             yield from node._infer(context, **kwargs)

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -31,10 +31,10 @@ from astroid.nodes.as_string import AsStringVisitor
 from astroid.nodes.const import OP_PRECEDENCE
 from astroid.nodes.utils import Position
 from astroid.typing import (
-    InferKwargs,
     InferenceErrorInfo,
     InferenceResult,
     InferFn,
+    InferKwargs,
     infer_kwargs_cache_key,
 )
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -11,7 +11,6 @@ from functools import cached_property
 from functools import singledispatch as _singledispatch
 from typing import (
     TYPE_CHECKING,
-    Any,
     ClassVar,
     TypeVar,
     cast,
@@ -31,12 +30,18 @@ from astroid.manager import AstroidManager
 from astroid.nodes.as_string import AsStringVisitor
 from astroid.nodes.const import OP_PRECEDENCE
 from astroid.nodes.utils import Position
-from astroid.typing import InferenceErrorInfo, InferenceResult, InferFn
+from astroid.typing import (
+    InferKwargs,
+    InferenceErrorInfo,
+    InferenceResult,
+    InferFn,
+    infer_kwargs_cache_key,
+)
 
 if sys.version_info >= (3, 11):
-    from typing import Self
+    from typing import Self, Unpack
 else:
-    from typing_extensions import Self
+    from typing_extensions import Self, Unpack
 
 
 if TYPE_CHECKING:
@@ -121,7 +126,7 @@ class NodeNG:
         """
 
     def infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult]:
         """Get a generator of the inferred values.
 
@@ -153,7 +158,13 @@ class NodeNG:
             except UseInferenceDefault:
                 pass
 
-        key = (self, context.lookupname, context.callcontext, context.boundnode)
+        key = (
+            self,
+            context.lookupname,
+            context.callcontext,
+            context.boundnode,
+            infer_kwargs_cache_key(kwargs),
+        )
         if key in context.inferred:
             yield from context.inferred[key]
             return
@@ -554,7 +565,7 @@ class NodeNG:
         pass
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         """We don't know how to resolve a statement by default."""
         # this method is overridden by most concrete classes

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -46,9 +46,9 @@ from astroid.nodes.scoped_nodes.utils import builtin_lookup
 from astroid.nodes.utils import Position
 from astroid.typing import (
     InferBinaryOp,
-    InferKwargs,
     InferenceErrorInfo,
     InferenceResult,
+    InferKwargs,
     SuccessfulInferenceResult,
 )
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -16,7 +16,7 @@ import os
 import sys
 from collections.abc import Generator, Iterable, Iterator, Sequence
 from functools import cached_property, lru_cache
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, NoReturn
+from typing import TYPE_CHECKING, ClassVar, Literal, NoReturn
 
 from astroid import bases, protocols, util
 from astroid.context import (
@@ -46,15 +46,16 @@ from astroid.nodes.scoped_nodes.utils import builtin_lookup
 from astroid.nodes.utils import Position
 from astroid.typing import (
     InferBinaryOp,
+    InferKwargs,
     InferenceErrorInfo,
     InferenceResult,
     SuccessfulInferenceResult,
 )
 
 if sys.version_info >= (3, 11):
-    from typing import Self
+    from typing import Self, Unpack
 else:
-    from typing_extensions import Self
+    from typing_extensions import Self, Unpack
 
 if TYPE_CHECKING:
     from astroid import nodes, objects
@@ -602,7 +603,7 @@ class Module(LocalsDictNodeNG):
         return self
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[Module]:
         yield self
 
@@ -1060,7 +1061,7 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
         raise AttributeInferenceError(target=self, attribute=name)
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[Lambda]:
         yield self
 
@@ -1519,7 +1520,7 @@ class FunctionDef(
         return bool(yields_without_lambdas & yields_without_functions)
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[objects.Property | FunctionDef, None, InferenceErrorInfo]:
         from astroid import objects  # pylint: disable=import-outside-toplevel
 
@@ -2941,6 +2942,6 @@ class ClassDef(
         return self
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[ClassDef]:
         yield self

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -29,7 +29,7 @@ from astroid.exceptions import (
 from astroid.interpreter import objectmodel
 from astroid.manager import AstroidManager
 from astroid.nodes import node_classes, scoped_nodes
-from astroid.typing import InferKwargs, InferenceResult, SuccessfulInferenceResult
+from astroid.typing import InferenceResult, InferKwargs, SuccessfulInferenceResult
 
 if sys.version_info >= (3, 11):
     from typing import Self, Unpack
@@ -43,7 +43,9 @@ class FrozenSet(node_classes.BaseContainer):
     def pytype(self) -> Literal["builtins.frozenset"]:
         return "builtins.frozenset"
 
-    def _infer(self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]):
+    def _infer(
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
+    ):
         yield self
 
     @cached_property
@@ -88,7 +90,9 @@ class Super(node_classes.NodeNG):
             end_col_offset=scope.end_col_offset,
         )
 
-    def _infer(self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]):
+    def _infer(
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
+    ):
         yield self
 
     def super_mro(self):

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import sys
 from collections.abc import Generator, Iterator
 from functools import cached_property
-from typing import Any, Literal, NoReturn
+from typing import Literal, NoReturn
 
 from astroid import bases, util
 from astroid.context import InferenceContext
@@ -29,12 +29,12 @@ from astroid.exceptions import (
 from astroid.interpreter import objectmodel
 from astroid.manager import AstroidManager
 from astroid.nodes import node_classes, scoped_nodes
-from astroid.typing import InferenceResult, SuccessfulInferenceResult
+from astroid.typing import InferKwargs, InferenceResult, SuccessfulInferenceResult
 
 if sys.version_info >= (3, 11):
-    from typing import Self
+    from typing import Self, Unpack
 else:
-    from typing_extensions import Self
+    from typing_extensions import Self, Unpack
 
 
 class FrozenSet(node_classes.BaseContainer):
@@ -43,7 +43,7 @@ class FrozenSet(node_classes.BaseContainer):
     def pytype(self) -> Literal["builtins.frozenset"]:
         return "builtins.frozenset"
 
-    def _infer(self, context: InferenceContext | None = None, **kwargs: Any):
+    def _infer(self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]):
         yield self
 
     @cached_property
@@ -88,7 +88,7 @@ class Super(node_classes.NodeNG):
             end_col_offset=scope.end_col_offset,
         )
 
-    def _infer(self, context: InferenceContext | None = None, **kwargs: Any):
+    def _infer(self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]):
         yield self
 
     def super_mro(self):
@@ -364,6 +364,6 @@ class Property(scoped_nodes.FunctionDef):
         raise InferenceError("Properties are not callable")
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None, **kwargs: Unpack[InferKwargs]
     ) -> Generator[Self]:
         yield self

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable, Generator
 from typing import (
     TYPE_CHECKING,
@@ -15,12 +16,39 @@ from typing import (
     Union,
 )
 
+if sys.version_info >= (3, 11):
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from astroid import bases, exceptions, nodes, transforms, util
     from astroid.context import InferenceContext
     from astroid.interpreter._import import spec
+
+
+class InferKwargs(TypedDict, total=False):
+    """Keyword arguments for inference methods.
+
+    These are included in the inference cache key to ensure that different
+    invocations with different kwargs produce separate cache entries.
+
+    When adding a new field, also update :func:`infer_kwargs_cache_key` below
+    so that the new argument is reflected in the cache key.
+    """
+
+    asname: bool
+
+
+def infer_kwargs_cache_key(kwargs: InferKwargs) -> tuple[tuple[str, Any], ...]:
+    """Generate a deterministic cache key from inference kwargs.
+
+    This is kept next to :class:`InferKwargs` so that anyone adding a new
+    field is reminded to consider its impact on the cache key.
+    """
+    return tuple(sorted(kwargs.items())) if kwargs else ()
 
 
 class InferenceErrorInfo(TypedDict):
@@ -86,7 +114,7 @@ class InferFn(Protocol, Generic[_SuccessfulInferenceResultT_contra]):
         self,
         node: _SuccessfulInferenceResultT_contra,
         context: InferenceContext | None = None,
-        **kwargs: Any,
+        **kwargs: Unpack[InferKwargs],
     ) -> Iterator[InferenceResult]: ...  # pragma: no cover
 
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -6953,6 +6953,36 @@ def test_imported_module_var_inferable3() -> None:
     assert i_w_val.as_string() == "['w', 'v']"
 
 
+def test_import_inference_cache_includes_asname() -> None:
+    """Inference cache should distinguish calls with different asname values.
+
+    When an Import node is inferred with asname=True and then asname=False,
+    the second call should not return the cached result from the first.
+
+    Regression test for https://github.com/pylint-dev/pylint/issues/10193.
+    """
+    code = textwrap.dedent("""
+    import os.path as mypath  #@
+    """)
+    import_node = _extract_single_node(code)
+    assert isinstance(import_node, nodes.Import)
+
+    ctx1 = InferenceContext()
+    ctx1.lookupname = "mypath"
+    # With asname=True (default): resolves 'mypath' -> 'os.path' -> os.path module
+    result1 = list(import_node.infer(ctx1, asname=True))
+    assert len(result1) == 1
+    assert isinstance(result1[0], nodes.Module)
+    assert result1[0].name == "os.path"
+
+    ctx2 = InferenceContext()
+    ctx2.lookupname = "mypath"
+    # With asname=False: should try to import 'mypath' literally, which fails
+    # The key test: this should NOT return the cached os.path result
+    with pytest.raises(InferenceError):
+        list(import_node.infer(ctx2, asname=False))
+
+
 @pytest.mark.skipif(
     IS_PYPY, reason="Test run with coverage on PyPy sometimes raises a RecursionError"
 )


### PR DESCRIPTION
## Summary
- Inference cache key in `NodeNG.infer()` now includes kwargs so that different invocations (e.g. `asname=True` vs `asname=False`) produce separate cache entries
- Added `InferKwargs` TypedDict to `astroid/typing.py` documenting valid inference kwargs
- Added regression test demonstrating the cache collision bug

## Context
Follow-up to #2969 per @DanielNoord's [suggestion](https://github.com/pylint-dev/astroid/pull/2969#issuecomment-2681843137) to make inference kwargs explicit using a TypedDict.

The root cause of pylint-dev/pylint#10193: when `import my_module.utils as my_module` is used, pylint calls `node.infer(ctx, asname=False)` to get the unaliased module. But if the node was previously inferred with `asname=True` (the default), the cached result was returned because `asname` wasn't part of the cache key.

## Changes
- `astroid/typing.py`: Add `InferKwargs(TypedDict)` with `asname: bool`
- `astroid/nodes/node_ng.py`: Include `kwargs` in inference cache key
- `tests/test_inference.py`: Add `test_import_inference_cache_includes_asname`
- `ChangeLog`: Entry for 4.1.1

## Test plan
- [x] New test fails without the fix (verified by temporarily reverting)
- [x] New test passes with the fix
- [x] All 438 inference tests pass
- [x] 868 tests pass across test_inference, test_scoped_nodes, test_builder, test_nodes
- [x] ruff, black, mypy clean on changed files

Closes pylint-dev/pylint#10193
Supersedes #2969