### PR TITLE
Wrong inference for the `str(const)`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -68,6 +68,13 @@ Release date: TBA
 
   Closes #3067
 
+* ``str()`` of a constant argument now infers the actual string value instead
+  of always inferring ``""``. When every inference path of the argument
+  resolves to ``Const`` values that stringify to the same string, ``infer_str``
+  returns that string; otherwise it keeps falling back to ``Const("")``.
+
+  Closes #2994
+
 What's New in astroid 4.1.2?
 ============================
 Release date: 2026-03-22

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -852,7 +852,7 @@ def infer_str(node, context: InferenceContext | None = None) -> nodes.Const:
     if call.positional_arguments:
         try:
             first_value = next(call.positional_arguments[0].infer(context=context))
-        except (InferenceError, StopIteration) as exc:
+        except (InferenceError, StopIteration):
             return nodes.Const("")
 
         if isinstance(first_value, nodes.Const):

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -849,20 +849,28 @@ def infer_str(node, context: InferenceContext | None = None) -> nodes.Const:
     if call.keyword_arguments:
         raise UseInferenceDefault("TypeError: str() must take no keyword arguments")
 
-    if call.positional_arguments:
-        try:
-            first_value = next(call.positional_arguments[0].infer(context=context))
-        except (InferenceError, StopIteration):
-            return nodes.Const("")
+    fallback = nodes.Const("")
 
-        if isinstance(first_value, nodes.Const):
+    if not call.positional_arguments:
+        return fallback
+
+    # Accept only if all inferred values resolve to the same string
+    candidates: set[str] = set()
+    try:
+        for inferred in call.positional_arguments[0].infer(context=context):
+            if not isinstance(inferred, nodes.Const):
+                return fallback
+
             try:
-                stringified = str(first_value.value)
+                candidates.add(str(inferred.value))
             except ValueError:
-                return nodes.Const("")
-            return nodes.Const(stringified)
+                return fallback
+    except InferenceError:
+        return fallback
 
-    return nodes.Const("")
+    if len(candidates) == 1:
+        return nodes.Const(candidates.pop())
+    return fallback
 
 
 def infer_int(node, context: InferenceContext | None = None):

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -856,7 +856,11 @@ def infer_str(node, context: InferenceContext | None = None) -> nodes.Const:
             return nodes.Const("")
 
         if isinstance(first_value, nodes.Const):
-            return nodes.Const(str(first_value.value))
+            try:
+                stringified = str(first_value.value)
+            except ValueError:
+                return nodes.Const("")
+            return nodes.Const(stringified)
 
     return nodes.Const("")
 

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -842,15 +842,23 @@ def infer_str(node, context: InferenceContext | None = None) -> nodes.Const:
 
     :param nodes.Call node: str() call to infer
     :param context.InferenceContext: node context
-    :rtype nodes.Const: a Const containing an empty string
+    :rtype nodes.Const:
+        a Const containing a stringified value of str() call if possible, else an empty string
     """
     call = arguments.CallSite.from_call(node, context=context)
     if call.keyword_arguments:
         raise UseInferenceDefault("TypeError: str() must take no keyword arguments")
-    try:
-        return nodes.Const("")
-    except (AstroidTypeError, InferenceError) as exc:
-        raise UseInferenceDefault(str(exc)) from exc
+
+    if call.positional_arguments:
+        try:
+            first_value = next(call.positional_arguments[0].infer(context=context))
+        except (InferenceError, StopIteration) as exc:
+            return nodes.Const("")
+
+        if isinstance(first_value, nodes.Const):
+            return nodes.Const(str(first_value.value))
+
+    return nodes.Const("")
 
 
 def infer_int(node, context: InferenceContext | None = None):

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -869,7 +869,7 @@ def infer_str(node, context: InferenceContext | None = None) -> nodes.Const:
         return fallback
 
     if len(candidates) == 1:
-        return nodes.Const(candidates.pop())
+        return nodes.Const(next(iter(candidates)))
     return fallback
 
 

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1419,6 +1419,7 @@ def test_infer_str() -> None:
     assert isinstance(inferred, astroid.Instance)
     assert inferred.qname() == "builtins.str"
 
+
 def test_infer_str_const() -> None:
     ast_nodes = astroid.extract_node("""
     str('') #@

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1432,6 +1432,9 @@ def test_infer_str_const() -> None:
     str(4.33) #@
     str(...) #@
     str(2 + 2) #@
+    str() #@
+    str(int) #@
+    str(2 if unknown() else 3) #@
     """)
 
     inferred = list(node.inferred()[0].value for node in ast_nodes)
@@ -1444,6 +1447,9 @@ def test_infer_str_const() -> None:
     assert inferred[6] == "4.33"
     assert inferred[7] == "Ellipsis"
     assert inferred[8] == "4"
+    assert inferred[9] == ""
+    assert inferred[10] == ""
+    assert inferred[11] == ""
 
 
 def test_infer_int() -> None:

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1407,6 +1407,7 @@ def test_infer_str() -> None:
     str(s) #@
     str('a') #@
     str(some_object()) #@
+    str(7**10000) #@
     """)
     for node in ast_nodes:
         inferred = next(node.infer())

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1419,6 +1419,30 @@ def test_infer_str() -> None:
     assert isinstance(inferred, astroid.Instance)
     assert inferred.qname() == "builtins.str"
 
+def test_infer_str_const() -> None:
+    ast_nodes = astroid.extract_node("""
+    str('') #@
+    str('a') #@
+    str(1) #@
+    str(True) #@
+    str(False) #@
+    str(None) #@
+    str(4.33) #@
+    str(...) #@
+    str(2 + 2) #@
+    """)
+
+    inferred = list(node.inferred()[0].value for node in ast_nodes)
+    assert inferred[0] == ""
+    assert inferred[1] == "a"
+    assert inferred[2] == "1"
+    assert inferred[3] == "True"
+    assert inferred[4] == "False"
+    assert inferred[5] == "None"
+    assert inferred[6] == "4.33"
+    assert inferred[7] == "..."
+    assert inferred[8] == "4"
+
 
 def test_infer_int() -> None:
     ast_nodes = astroid.extract_node("""

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1440,7 +1440,7 @@ def test_infer_str_const() -> None:
     assert inferred[4] == "False"
     assert inferred[5] == "None"
     assert inferred[6] == "4.33"
-    assert inferred[7] == "..."
+    assert inferred[7] == "Ellipsis"
     assert inferred[8] == "4"
 
 

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1474,6 +1474,23 @@ def test_infer_str_const() -> None:
     assert inferred[11] == ""
 
 
+def test_infer_str_does_not_run_user_str() -> None:
+    """A user-defined __str__ must never be executed during inference."""
+    node = astroid.extract_node("""
+    class StrWillFail:
+        def __str__(self):
+            raise RuntimeError
+
+    str(StrWillFail()) #@
+    """)
+    # The argument infers to an Instance, not a nodes.Const, so infer_str
+    # returns the empty-string fallback without ever calling __str__.
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == ""
+
+
 def test_infer_int() -> None:
     ast_nodes = astroid.extract_node("""
     int(0) #@


### PR DESCRIPTION
This PR fixes the wrong inference for the `str(a)`, then the `a` is inferred to be `Const`.

Closes #2994 

I preserved returning `Const("")` in other cases. Maybe it should raise `UseInferenceDefault` like the `infer_int` does ? 