### PR TITLE
objectmodel: fix crash analyzing property fset in generic classes with type annotations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,8 +12,7 @@ What's New in astroid 4.1.2?
 ============================
 Release date: TBA
 
-* Fix `AttributeError: 'AnnAssign' object has no attribute 'name'.`
-	Fix crash accessing property `fset` in generic classes with type annotations.
+* Fix crash accessing property `fset` in generic classes with type annotations.
   Closes #2996
 
 * Fix infinite recursion caused by cyclic inference in ``Constraint``.

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,10 @@ What's New in astroid 4.1.2?
 ============================
 Release date: TBA
 
+* Fix `AttributeError: 'AnnAssign' object has no attribute 'name'.`
+	Fix crash accessing property `fset` in generic classes with type annotations.
+  Closes #2996
+
 * Fix ``RecursionError`` in ``_compute_mro()`` when circular class hierarchies
   are created through runtime name rebinding. Circular bases are now resolved
   to the original class instead of recursing.

--- a/ChangeLog
+++ b/ChangeLog
@@ -15,7 +15,7 @@ Release date: TBA
 * Fix `AttributeError: 'AnnAssign' object has no attribute 'name'.`
 	Fix crash accessing property `fset` in generic classes with type annotations.
   Closes #2996
-  
+
 * Fix infinite recursion caused by cyclic inference in ``Constraint``.
 
 * Fix ``RecursionError`` in ``_compute_mro()`` when circular class hierarchies

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -1011,12 +1011,11 @@ class PropertyModel(ObjectModel):
             :param func: property for which the setter has to be found
             :return: the setter function or None
             """
-            for target in [
-                t for t in func.parent.get_children() if t.name == func.function.name
-            ]:
-                for dec_name in target.decoratornames():
-                    if dec_name.endswith(func.function.name + ".setter"):
-                        return target
+            for node in func.parent.body:
+                if isinstance(node, (nodes.FunctionDef, nodes.AsyncFunctionDef)):
+                    for dec_name in node.decoratornames():
+                        if dec_name.endswith(func.function.name + ".setter"):
+                            return node
             return None
 
         func_setter = find_setter(func)

--- a/script/.contributors_aliases.json
+++ b/script/.contributors_aliases.json
@@ -37,6 +37,10 @@
     "mails": ["55152140+jayaddison@users.noreply.github.com", "jay@jp-hosting.net"],
     "name": "James Addison"
   },
+  "731937+doctorcolossus@users.noreply.github.com": {
+    "mails": ["731937+doctorcolossus@users.noreply.github.com"],
+    "name": "Casey Jones"
+  },
   "Hnasar@users.noreply.github.com": {
     "mails": ["Hnasar@users.noreply.github.com", "hashem@hudson-trading.com"],
     "name": "Hashem Nasarat"

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -1016,3 +1016,30 @@ def test_builtin_func_no_descriptor_attrs(attr: str) -> None:
     node = builder.extract_node(f"eval.{attr}")
     with pytest.raises(InferenceError):
         next(node.infer())
+
+def test_getattr_on_property_fset_with_annassign_does_not_crash() -> None:
+    """Test that getattr on property fset doesn't crash with AnnAssign."""
+    node = builder.extract_node("""
+    from typing import TypeVar, Generic
+
+    T = TypeVar('T')
+
+    class Base:
+        _x: object
+        @property
+        def x(self):
+            return self._x
+        @x.setter
+        def x(self, val):
+            self._x = val
+
+    class Child(Base, Generic[T]):
+        _x: T
+        @property
+        def x(self) -> T:
+            return self._x
+        @x.setter
+        def x(self, val):
+            getattr(Base.x, "fset", None)  #@
+    """)
+    next(node.infer())

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -1017,6 +1017,7 @@ def test_builtin_func_no_descriptor_attrs(attr: str) -> None:
     with pytest.raises(InferenceError):
         next(node.infer())
 
+
 def test_getattr_on_property_fset_with_annassign_does_not_crash() -> None:
     """Test that getattr on property fset doesn't crash with AnnAssign."""
     node = builder.extract_node("""


### PR DESCRIPTION
The `find_setter` function previously searched through all child nodes looking for nodes with a name matching the property function, then checked for `.setter` decorators. This caused a crash when encountering `AnnAssign` nodes (like type hints) which don't have a 'name' attribute.

Instead, search only through `FunctionDef` and `AsyncFunctionDef` nodes in the class body, checking their decorators directly. This is more semantically correct (setters are always functions/methods) and avoids the crash on non-function nodes.

Fixes #2996.

## Type of Changes


|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #2996