### PR TITLE
helpers: simplify Uninferable type error message

### DIFF
--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -130,7 +130,7 @@ def _object_type_is_subclass(
     for klass in class_seq:
         if isinstance(klass, util.UninferableBase):
             raise AstroidTypeError(
-                f"arg 2 must be a type or tuple of types, not {type(klass)!r}"
+                "arg 2 must be a type or tuple of types, not <class 'astroid.util.UninferableBase'>"
             )
 
         for obj_subclass in obj_type.mro():


### PR DESCRIPTION
﻿## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Closes #2760

This simplifies the `AstroidTypeError` branch in `_object_type_is_subclass`.

When `klass` is `Uninferable`, we already know its exact type from the guard:

```python
if isinstance(klass, util.UninferableBase):
```

So the error message no longer needs runtime interpolation via `type(klass)`.
The message is now emitted as a static literal while preserving the same text output.

### Validation

- `python -m pytest tests/brain/test_brain.py -k "isinstance or issubclass"`
  - `35 passed, 105 deselected`
