### PR TITLE
Fix inference of annotated Ellipsis assignments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,9 @@ Release date: TBA
 
   References pylint-dev/pylint#872
 
+* Infer annotated ``...`` placeholders (``attr: X = ...`` and
+  ``attr = ...  # type: X``) as ``Uninferable`` instead of ``Const(Ellipsis)``.
+
 
 What's New in astroid 4.1.2?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,8 @@ Release date: TBA
 * Infer annotated ``...`` placeholders (``attr: X = ...`` and
   ``attr = ...  # type: X``) as ``Uninferable`` instead of ``Const(Ellipsis)``.
 
+  Closes #3054
+
 
 What's New in astroid 4.1.2?
 ============================

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -444,15 +444,12 @@ def arguments_assigned_stmts(
     return _arguments_infer_argname(self, node_name, context)
 
 
-def _is_ellipsis_placeholder(value: nodes.NodeNG) -> bool:
-    """True if ``value`` is the stub placeholder ``...`` (bare ``Ellipsis``)."""
-    return isinstance(value, nodes.Const) and value.value is Ellipsis
-
-
-def _has_annotation(
+def _is_ellipsis_placeholder_assignment(
     assign: nodes.AugAssign | nodes.Assign | nodes.AnnAssign | nodes.TypeAlias,
 ) -> bool:
-    """True if ``assign`` carries a PEP 526 annotation or a PEP 484 ``# type:`` comment."""
+    """True when ``assign`` uses ``...`` as a stub placeholder for an annotated name."""
+    if not (isinstance(assign.value, nodes.Const) and assign.value.value is Ellipsis):
+        return False
     if isinstance(assign, nodes.AnnAssign):
         return assign.annotation is not None
     return isinstance(assign, nodes.Assign) and assign.type_annotation is not None
@@ -466,7 +463,7 @@ def assign_assigned_stmts(
     assign_path: list[int] | None = None,
 ) -> Any:
     if not assign_path:
-        if _is_ellipsis_placeholder(self.value) and _has_annotation(self):
+        if _is_ellipsis_placeholder_assignment(self):
             yield util.Uninferable
             return None
         yield self.value

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -455,9 +455,7 @@ def _has_annotation(
     """True if ``assign`` carries a PEP 526 annotation or a PEP 484 ``# type:`` comment."""
     if isinstance(assign, nodes.AnnAssign):
         return assign.annotation is not None
-    if isinstance(assign, nodes.Assign):
-        return assign.type_annotation is not None
-    return False
+    return isinstance(assign, nodes.Assign) and assign.type_annotation is not None
 
 
 @decorators.raise_if_nothing_inferred

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -444,6 +444,22 @@ def arguments_assigned_stmts(
     return _arguments_infer_argname(self, node_name, context)
 
 
+def _is_ellipsis_placeholder(value: nodes.NodeNG) -> bool:
+    """True if ``value`` is the stub placeholder ``...`` (bare ``Ellipsis``)."""
+    return isinstance(value, nodes.Const) and value.value is Ellipsis
+
+
+def _has_annotation(
+    assign: nodes.AugAssign | nodes.Assign | nodes.AnnAssign | nodes.TypeAlias,
+) -> bool:
+    """True if ``assign`` carries a PEP 526 annotation or a PEP 484 ``# type:`` comment."""
+    if isinstance(assign, nodes.AnnAssign):
+        return assign.annotation is not None
+    if isinstance(assign, nodes.Assign):
+        return assign.type_annotation is not None
+    return False
+
+
 @decorators.raise_if_nothing_inferred
 def assign_assigned_stmts(
     self: nodes.AugAssign | nodes.Assign | nodes.AnnAssign | nodes.TypeAlias,
@@ -452,6 +468,9 @@ def assign_assigned_stmts(
     assign_path: list[int] | None = None,
 ) -> Any:
     if not assign_path:
+        if _is_ellipsis_placeholder(self.value) and _has_annotation(self):
+            yield util.Uninferable
+            return None
         yield self.value
         return None
     yield from _resolve_assignment_parts(

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -348,6 +348,60 @@ def test_named_expr_inference() -> None:
     assert node.value == 1
 
 
+def test_annassign_ellipsis_placeholder_yields_uninferable() -> None:
+    attr = extract_node(
+        """
+    class Cls:
+        x: int = ...
+    Cls().x  #@
+    """
+    )
+    assert isinstance(attr, nodes.Attribute)
+    assert list(attr.infer()) == [Uninferable]
+
+
+def test_type_comment_ellipsis_placeholder_yields_uninferable() -> None:
+    attr = extract_node(
+        """
+    class Cls:
+        x = ...  # type: int
+    Cls().x  #@
+    """
+    )
+    assert isinstance(attr, nodes.Attribute)
+    assert list(attr.infer()) == [Uninferable]
+
+
+def test_annassign_concrete_value_still_inferred() -> None:
+    attr = extract_node(
+        """
+    class Cls:
+        x: int = 5
+    Cls().x  #@
+    """
+    )
+    assert isinstance(attr, nodes.Attribute)
+    inferred = list(attr.infer())
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 5
+
+
+def test_bare_ellipsis_without_annotation_still_inferred() -> None:
+    attr = extract_node(
+        """
+    class Cls:
+        x = ...
+    Cls().x  #@
+    """
+    )
+    assert isinstance(attr, nodes.Attribute)
+    inferred = list(attr.infer())
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value is Ellipsis
+
+
 class TestPatternMatching:
     @staticmethod
     def test_assigned_stmts_match_mapping():

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -349,37 +349,31 @@ def test_named_expr_inference() -> None:
 
 
 def test_annassign_ellipsis_placeholder_yields_uninferable() -> None:
-    attr = extract_node(
-        """
+    attr = extract_node("""
     class Cls:
         x: int = ...
     Cls().x  #@
-    """
-    )
+    """)
     assert isinstance(attr, nodes.Attribute)
     assert list(attr.infer()) == [Uninferable]
 
 
 def test_type_comment_ellipsis_placeholder_yields_uninferable() -> None:
-    attr = extract_node(
-        """
+    attr = extract_node("""
     class Cls:
         x = ...  # type: int
     Cls().x  #@
-    """
-    )
+    """)
     assert isinstance(attr, nodes.Attribute)
     assert list(attr.infer()) == [Uninferable]
 
 
 def test_annassign_concrete_value_still_inferred() -> None:
-    attr = extract_node(
-        """
+    attr = extract_node("""
     class Cls:
         x: int = 5
     Cls().x  #@
-    """
-    )
+    """)
     assert isinstance(attr, nodes.Attribute)
     inferred = list(attr.infer())
     assert len(inferred) == 1
@@ -388,13 +382,11 @@ def test_annassign_concrete_value_still_inferred() -> None:
 
 
 def test_bare_ellipsis_without_annotation_still_inferred() -> None:
-    attr = extract_node(
-        """
+    attr = extract_node("""
     class Cls:
         x = ...
     Cls().x  #@
-    """
-    )
+    """)
     assert isinstance(attr, nodes.Attribute)
     inferred = list(attr.infer())
     assert len(inferred) == 1


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This PR fixes astroid treating `x: int = ...` as if `x` were `Ellipsis` at runtime. The `...` in stubs is a placeholder - the annotation carries the real type - but astroid was returning `Const(Ellipsis)`, making pylint flag every method call through the attribute as `no-member`. Annotated `...` assignments now yield `Uninferable`, so attribute checks are skipped instead of asserted against `Ellipsis`. We yield `Uninferable` rather than resolving the annotation, since that would require handling wrappers/unions/forward-refs that astroid doesn't do here today. Concrete values (`x: int = 5`) and bare `x = ..`. without annotation are unchanged.

Example: 
```python
class Foo:
    x: int = ... 
print(Foo().x.bit_length())  # no more E1101
```

Closes #3054
