### PR TITLE
Fix TypeError when inferring random.sample with Module elements (#3043)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,13 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Fix ``TypeError`` in ``brain_random`` when ``random.sample`` is called with a
+  sequence containing nodes whose ``__init__`` does not accept ``lineno``
+  (e.g. ``Module``). The clone helper now filters init params to those the
+  class actually accepts.
+
+  Closes #3043
+
 * Fix ``RecursionError`` in ``_compute_mro()`` when circular class hierarchies
   are created through runtime name rebinding. Circular bases are now resolved
   to the original class instead of recursing.

--- a/astroid/brain/brain_random.py
+++ b/astroid/brain/brain_random.py
@@ -23,7 +23,7 @@ def _clone_node_with_lineno(node, parent, lineno):
     cls = node.__class__
     other_fields = node._other_fields
     _astroid_fields = node._astroid_fields
-    init_params = {
+    candidate_init_params = {
         "lineno": lineno,
         "col_offset": node.col_offset,
         "parent": parent,
@@ -33,6 +33,11 @@ def _clone_node_with_lineno(node, parent, lineno):
     postinit_params = {param: getattr(node, param) for param in _astroid_fields}
 
     valid_init_params = set(inspect.signature(cls.__init__).parameters)
+    init_params = {
+        name: value
+        for name, value in candidate_init_params.items()
+        if name in valid_init_params
+    }
     for param in other_fields:
         if param in valid_init_params:
             init_params[param] = getattr(node, param)

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1002,6 +1002,25 @@ class RandomSampleTest(unittest.TestCase):
         assert isinstance(inferred.elts[0], nodes.FunctionDef)
         assert inferred.elts[0].name == "len"
 
+    def test_no_crash_on_module_clone(self) -> None:
+        """Test that random.sample does not crash when cloning Module nodes.
+
+        Module.__init__ does not accept ``lineno``/``col_offset`` kwargs, so
+        cloning must filter init params to those the class actually accepts.
+
+        Regression test for https://github.com/pylint-dev/astroid/issues/3043
+        """
+        node = astroid.extract_node("""
+        from random import sample
+        import gc
+        sample(list({gc}) * 2, 1)  #@
+        """)
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.List)
+        assert len(inferred.elts) == 1
+        assert isinstance(inferred.elts[0], nodes.Module)
+        assert inferred.elts[0].name == "gc"
+
 
 class SubprocessTest(unittest.TestCase):
     """Test subprocess brain"""


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Write a good description on what the PR does.
- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #3043

`brain_random._clone_node_with_lineno` passes `lineno`, `col_offset`, `end_lineno`, `end_col_offset` to `cls(**init_params)` for every cloned element, but some node classes (e.g. `Module`) don't accept those kwargs in their `__init__`, raising `TypeError: Module.__init__() got an unexpected keyword argument 'lineno'`.

Reproducer from the issue:

```python
import gc
sample(list({gc})*2, 1)
```

Fix: filter the candidate init params to only those present in `inspect.signature(cls.__init__).parameters`, mirroring how the existing `other_fields` loop already does.

Added a regression test `test_no_crash_on_module_clone` alongside the existing `ClassDef`/`FunctionDef` clone tests.