### PR TITLE
Use exact signatures for GObject introspection bindings

### DIFF
--- a/astroid/brain/brain_gi.py
+++ b/astroid/brain/brain_gi.py
@@ -83,6 +83,35 @@ def _gi_is_method_call(obj):
     return inspect.ismethod(obj) or inspect.ismethoddescriptor(obj)
 
 
+def _gi_replace_nonbuiltin_defaults(sig: inspect.Signature) -> inspect.Signature:
+    """
+    Replace non-builtin default parameter values from signature. This is needed
+    to obtain valid Python syntax when serializing the signature to string.
+    Non-builtin default values will produce signatures like this:
+
+        - (argname : IntEnum = <IntEnum.CONST: 0>, ...)
+        - (argname : ObjectType = <ObjectType object at 0xdeadbeefcafe>, ...)
+
+    In that case, replace the default value by 'None' and strip the type
+    annotation to produce a valid signature: (argname=None, ...)
+    """
+
+    def is_empty_or_primitive_builtin(obj) -> bool:
+        return obj == inspect.Parameter.empty or (
+            obj.__class__.__module__ == "builtins"
+            and isinstance(obj, (bool, str, int, float, type(None)))
+        )
+
+    params: list[inspect.Parameter] = []
+    for val in sig.parameters.values():
+        if is_empty_or_primitive_builtin(val.default):
+            params.append(val)
+        else:
+            params.append(val.replace(default=None, annotation=inspect.Parameter.empty))
+
+    return sig.replace(parameters=params)
+
+
 def _gi_build_stub(parent):  # noqa: C901
     """
     Inspect the passed module recursively and build stubs for functions,
@@ -132,6 +161,7 @@ def _gi_build_stub(parent):  # noqa: C901
             constants[name] = 0
 
     ret = ""
+    supports_inspect = _gi_supports_inspect_signature()
 
     if constants:
         ret += f"# {parent.__name__} constants\n\n"
@@ -155,7 +185,14 @@ def _gi_build_stub(parent):  # noqa: C901
     if functions:
         ret += f"# {parent.__name__} functions\n\n"
     for name in sorted(functions):
-        ret += f"def {name}(*args, **kwargs):\n"
+        sig_str = "(*args, **kwargs)"
+        if supports_inspect:
+            try:
+                sig = inspect.signature(functions[name])
+                sig_str = str(_gi_replace_nonbuiltin_defaults(sig))
+            except ValueError:
+                pass  # best effort: expect some 'no signature found' errors
+        ret += f"def {name}{sig_str}:\n"
         ret += "    pass\n"
 
     if ret:
@@ -163,7 +200,14 @@ def _gi_build_stub(parent):  # noqa: C901
     if methods:
         ret += f"# {parent.__name__} methods\n\n"
     for name in sorted(methods):
-        ret += f"def {name}(self, *args, **kwargs):\n"
+        sig_str = "(self, *args, **kwargs)"
+        if supports_inspect:
+            try:
+                sig = inspect.signature(methods[name])
+                sig_str = str(_gi_replace_nonbuiltin_defaults(sig))
+            except ValueError:
+                pass  # best effort: expect some 'no signature found' errors
+        ret += f"def {name}{sig_str}:\n"
         ret += "    pass\n"
 
     if ret:

--- a/tests/brain/test_gi.py
+++ b/tests/brain/test_gi.py
@@ -11,7 +11,20 @@ try:
 except ImportError:
     HAS_GI = False
 
-from astroid import builder, nodes
+from astroid import builder, nodes, typing
+
+
+class _Param:
+    def __init__(
+        self,
+        name: str,
+        *,
+        argtype: str | None = None,
+        default: str | None = None,
+    ):
+        self.name = name
+        self.type = argtype
+        self.default = default
 
 
 @unittest.skipUnless(HAS_GI, "This test requires the gobject introspection library.")
@@ -28,30 +41,128 @@ class GiBrainClassificationTest(unittest.TestCase):
         """)
         return node.inferred()
 
+    def _check_class_and_signature(
+        self,
+        inferred: typing.InferenceResult,
+        args: list[_Param],
+        ret: None | str = None,
+        is_method: bool = False,
+    ):
+        funcdef = inferred.frame()
+        self.assertIsInstance(funcdef, nodes.FunctionDef)
+
+        def_name = "Method" if is_method else "Function"
+        class_type = "builtins.instancemethod" if is_method else "builtins.function"
+
+        # check classifcation
+        self.assertEqual(
+            inferred.pytype(),
+            class_type,
+            f"{def_name} is not classified as '{class_type}'",
+        )
+
+        # check number of arguments
+        self.assertEqual(
+            len(args),
+            len(funcdef.argnames()),
+            f"{def_name} has unexpected number of arguments",
+        )
+
+        # check argument names, types, and default values
+        default_pos = -1
+        for arg_pos, arg in enumerate(args):
+            self.assertEqual(
+                funcdef.argnames()[arg_pos],
+                arg.name,
+                f"{def_name} does not accept '{arg.name}' as argument{arg_pos}",
+            )
+
+            if arg.type is None:
+                self.assertIsNone(funcdef.args.annotations[arg_pos])
+            else:
+                self.assertGreaterEqual(len(funcdef.args.annotations), arg_pos + 1)
+                self.assertIsNotNone(funcdef.args.annotations[arg_pos])
+                self.assertEqual(
+                    funcdef.args.annotations[arg_pos].as_string(),
+                    arg.type,
+                    f"{def_name}'s argument{arg_pos} is not of type '{arg.type}'",
+                )
+
+            if arg.default is not None:
+                default_pos += 1
+                self.assertGreaterEqual(len(funcdef.args.defaults), default_pos + 1)
+                self.assertIsNotNone(funcdef.args.defaults[default_pos])
+                self.assertEqual(
+                    funcdef.args.defaults[default_pos].as_string(),
+                    arg.default,
+                    f"{def_name} argument{arg_pos}'s default value is not '{arg.default}'",
+                )
+
+        # check return type
+        if ret is None:
+            self.assertIsNone(funcdef.returns)
+        else:
+            self.assertIsNotNone(funcdef.returns)
+            self.assertEqual(
+                funcdef.returns.as_string(),
+                ret,
+                f"{def_name}'s return type is not of type '{ret}'",
+            )
+
     def test_gi_function_classification(self):
         """Test that global functions are correctly classified without the 'self' argument."""
         inferred = self._inferred_gi_symbol("GLib", "2.0", "get_tmp_dir")
         self.assertEqual(len(inferred), 1)
-        self.assertEqual(inferred[0].pytype(), "builtins.function")
+        self._check_class_and_signature(inferred[0], args=[], ret="str")
 
-        funcdef = inferred[0].frame()
-        self.assertIsInstance(funcdef, nodes.FunctionDef)
-
-        args = funcdef.argnames()
-        if len(args) > 0:
-            self.assertNotEqual(args[0], "self")
+    def test_gi_function_classification_with_arguments(self):
+        """Test that global functions are correctly classified with function arguments."""
+        inferred = self._inferred_gi_symbol("GLib", "2.0", "ascii_strdown")
+        self.assertEqual(len(inferred), 1)
+        self._check_class_and_signature(
+            inferred[0],
+            args=[
+                _Param("str", argtype="str"),
+                _Param("len", argtype="int"),
+            ],
+            ret="str",
+        )
 
     def test_gi_method_classification(self):
-        """Test that methods are correctly classified and accept the 'self' argument."""
+        """Test that methods are correctly classified and accept 'self' as first argument."""
         inferred = self._inferred_gi_symbol("GLib", "2.0", "String.append")
         self.assertEqual(len(inferred), 1)
-        self.assertEqual(inferred[0].pytype(), "builtins.instancemethod")
+        self._check_class_and_signature(
+            inferred[0],
+            args=[
+                _Param("self"),
+                _Param("val", argtype="str"),
+            ],
+            ret="gi.repository.GLib.String",
+            is_method=True,
+        )
 
-        funcdef = inferred[0].frame()
-        self.assertIsInstance(funcdef, nodes.FunctionDef)
-
-        self.assertIn(
-            funcdef.argnames()[0],
-            {"self", funcdef.args.vararg},
-            "Method does not accept 'self' as first argument",
+    def test_gi_method_classification_with_default_values(self):
+        """Test that methods are correctly classified and accept arguments with default values."""
+        inferred = self._inferred_gi_symbol("Gtk", "3.0", "Table.attach")
+        self.assertEqual(len(inferred), 1)
+        self._check_class_and_signature(
+            inferred[0],
+            args=[
+                _Param("self"),
+                _Param("child"),
+                _Param("left_attach"),
+                _Param("right_attach"),
+                _Param("top_attach"),
+                _Param("bottom_attach"),
+                _Param(  # expect replacement of <AttachOptions.EXPAND|FILL: 5> by None
+                    "xoptions", default="None"
+                ),
+                _Param(  # expect replacement of <AttachOptions.EXPAND|FILL: 5> by None
+                    "yoptions", default="None"
+                ),
+                _Param("xpadding", default="0"),
+                _Param("ypadding", default="0"),
+            ],
+            is_method=True,
         )


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

With the recent change to use `inspect.signature()` (#2930), instead of generating signatures for all functions and methods with "wildcards" (`*args, **kwargs`), the exact signature could be provided for better linting.

Given the following `example.py`

``` python
"""Simple Example from https://python-gtk-3-tutorial.readthedocs.io/en/latest/introduction.html"""

import gi

gi.require_version("Gtk", "3.0")
from gi.repository import Gtk  # pylint: disable=wrong-import-position

win = Gtk.Window()
win.connect("destroy", Gtk.main_quit)
win.set_default_size(200)  # BUG: deliberately missing second argument
win.show_all()
Gtk.main()
```

... the missing second argument to `set_default_size` could be reported with a meaningful error message when using exact signatures:

``` sh
$ pylint example.py 
************* Module example
example.py:10:0: E1120: No value for argument 'height' in method call (no-value-for-parameter)

------------------------------------------------------------------
Your code has been rated at 3.75/10 (previous run: 3.75/10, +0.00)
```

## Risks

While this feature would substantially improve linting analysis, it would come at a noticeably higher computational cost during module loading time to generate the signatures.

### Linting time for the `example.py` above
- 5.63 sec
- 8.87 sec (+58%)

### Linting time for [Apport's `tests/system/test_ui_gtk.py`](https://github.com/canonical/apport/blob/main/tests/system/test_ui_gtk.py)
- 8.71 sec
- 11.45 sec (+31%)

Refs #2930
