### PR TITLE
fix: handle Python 3.15 KW_ONLY and namespace .pth test behavior

### DIFF
--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -571,10 +571,27 @@ def _get_field_default(field_call: nodes.Call) -> _FieldDefaultReturn:
 def _is_keyword_only_sentinel(node: nodes.NodeNG) -> bool:
     """Return True if node is the KW_ONLY sentinel."""
     inferred = safe_infer(node)
-    return (
-        isinstance(inferred, bases.Instance)
-        and inferred.qname() == "dataclasses._KW_ONLY_TYPE"
-    )
+    if not isinstance(inferred, bases.Instance):
+        return False
+    if inferred.qname() == "dataclasses._KW_ONLY_TYPE":
+        return True
+    if inferred.qname() != "builtins.sentinel":
+        return False
+    if isinstance(node, nodes.Name):
+        _, assignments = node.lookup(node.name)
+        return any(
+            isinstance(assignment, nodes.ImportFrom)
+            and assignment.modname == "dataclasses"
+            and any(imported == "KW_ONLY" for imported, _ in assignment.names)
+            for assignment in assignments
+        )
+    if isinstance(node, nodes.Attribute) and node.attrname == "KW_ONLY":
+        inferred_expr = safe_infer(node.expr)
+        return (
+            isinstance(inferred_expr, nodes.Module)
+            and inferred_expr.qname() == "dataclasses"
+        )
+    return False
 
 
 def _is_init_var(node: nodes.NodeNG) -> bool:

--- a/tests/brain/test_dataclasses.py
+++ b/tests/brain/test_dataclasses.py
@@ -760,6 +760,25 @@ def test_kw_only_sentinel() -> None:
         assert [a.name for a in init.args.args] == expected
 
 
+def test_kw_only_sentinel_other_dataclasses_attr() -> None:
+    """Annotating with another ``dataclasses`` attribute (e.g. ``MISSING``)
+    that also infers to ``builtins.sentinel`` on Python 3.15+ must not be
+    treated as ``KW_ONLY``."""
+    node = astroid.extract_node("""
+    import dataclasses
+    from dataclasses import dataclass
+
+    @dataclass
+    class C:
+        _: dataclasses.MISSING
+        y: str
+
+    C.__init__  #@
+    """)
+    init = next(node.infer())
+    assert [a.name for a in init.args.args] == ["self", "_", "y"]
+
+
 def test_kw_only_decorator() -> None:
     """Test that we update the signature correctly based on the keyword."""
     foodef, bardef, cee, dee = astroid.extract_node("""

--- a/tests/brain/test_dataclasses.py
+++ b/tests/brain/test_dataclasses.py
@@ -728,7 +728,8 @@ def test_non_dataclass_is_not_dataclass() -> None:
 
 def test_kw_only_sentinel() -> None:
     """Test that the KW_ONLY sentinel doesn't get added to the fields."""
-    node_one, node_two = astroid.extract_node("""
+    node_one, node_two, node_three = astroid.extract_node("""
+    import dataclasses
     from dataclasses import dataclass, KW_ONLY
     from dataclasses import KW_ONLY as keyword_only
 
@@ -745,13 +746,18 @@ def test_kw_only_sentinel() -> None:
         y: str
 
     B.__init__  #@
+
+    @dataclass
+    class C:
+        _: dataclasses.KW_ONLY
+        y: str
+
+    C.__init__  #@
     """)
     expected = ["self", "y"]
-    init = next(node_one.infer())
-    assert [a.name for a in init.args.args] == expected
-
-    init = next(node_two.infer())
-    assert [a.name for a in init.args.args] == expected
+    for node in (node_one, node_two, node_three):
+        init = next(node.infer())
+        assert [a.name for a in init.args.args] == expected
 
 
 def test_kw_only_decorator() -> None:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -39,17 +39,16 @@ def _load_namespace_package_pth(pth: str) -> None:
     """Execute a test .pth file with a `sitedir` local in scope.
 
     The .pth fixture reads `sys._getframe(1).f_locals['sitedir']`, so the
-    name must exist as a real local in this function's frame; static
-    analyzers cannot see the use through `exec`.
+    name must exist as a real local in this function's frame; the read
+    happens via `sys._getframe` inside `exec()`d code below.
     """
-    # `sitedir` is read by exec()'d .pth code via sys._getframe; intentional.
-    sitedir = str(
-        resources.RESOURCE_PATH
-    )  # pylint: disable=unused-variable  # noqa: F841
+    sitedir = str(resources.RESOURCE_PATH)
     with (resources.RESOURCE_PATH / pth).open(encoding="utf-8") as pth_file:
         for line in pth_file:
             line = line.strip()
             if line and not line.startswith("#"):
+                # `sitedir` is read by .pth code via sys._getframe(1).f_locals.
+                _ = sitedir  # mark as used for static analyzers
                 exec(line)  # pylint: disable=exec-used
 
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -36,9 +36,13 @@ def _get_file_from_object(obj) -> str:
 
 
 def _load_namespace_package_pth(pth: str) -> None:
-    """Execute a test .pth file with a real sitedir local."""
-    sitedir = str(resources.RESOURCE_PATH)
-    _ = sitedir
+    """Execute a test .pth file with a `sitedir` local in scope.
+
+    The .pth fixture reads `sys._getframe(1).f_locals['sitedir']`, so the
+    name must exist as a real local in this function's frame; static
+    analyzers cannot see the use through `exec`.
+    """
+    sitedir = str(resources.RESOURCE_PATH)  # noqa: F841 # used by exec'd .pth
     with (resources.RESOURCE_PATH / pth).open(encoding="utf-8") as pth_file:
         for line in pth_file:
             line = line.strip()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -37,7 +37,8 @@ def _get_file_from_object(obj) -> str:
 
 def _load_namespace_package_pth(pth: str) -> None:
     """Execute a test .pth file with a real sitedir local."""
-    sitedir = str(resources.RESOURCE_PATH)  # pylint: disable=unused-variable
+    sitedir = str(resources.RESOURCE_PATH)
+    _ = sitedir
     with (resources.RESOURCE_PATH / pth).open(encoding="utf-8") as pth_file:
         for line in pth_file:
             line = line.strip()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -42,9 +42,8 @@ def _load_namespace_package_pth(pth: str) -> None:
     name must exist as a real local in this function's frame; static
     analyzers cannot see the use through `exec`.
     """
-    sitedir = str(
-        resources.RESOURCE_PATH
-    )  # noqa: F841 # pylint: disable=unused-variable  # used by exec'd .pth
+    # `sitedir` is read by exec()'d .pth code via sys._getframe; intentional.
+    sitedir = str(resources.RESOURCE_PATH)  # pylint: disable=unused-variable  # noqa: F841
     with (resources.RESOURCE_PATH / pth).open(encoding="utf-8") as pth_file:
         for line in pth_file:
             line = line.strip()
@@ -78,9 +77,7 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIn("unittest", self.manager.astroid_cache)
 
     def test_ast_from_file_name_astro_builder_exception(self) -> None:
-        self.assertRaises(
-            AstroidBuildingError, self.manager.ast_from_file, "unhandledName"
-        )
+        self.assertRaises(AstroidBuildingError, self.manager.ast_from_file, "unhandledName")
 
     def test_ast_from_string(self) -> None:
         filepath = unittest.__file__
@@ -146,14 +143,10 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
             # pylint: disable-next=import-outside-toplevel
             import tests.testdata.python3.data.path_pkg_resources_1.package.foo as _  # noqa
 
-        self.assertTrue(
-            util.is_namespace("tests.testdata.python3.data.path_pkg_resources_1")
-        )
+        self.assertTrue(util.is_namespace("tests.testdata.python3.data.path_pkg_resources_1"))
 
     def test_submodule_homonym_with_non_module(self) -> None:
-        self.assertFalse(
-            util.is_namespace("tests.testdata.python3.data.parent_of_homonym.doc")
-        )
+        self.assertFalse(util.is_namespace("tests.testdata.python3.data.parent_of_homonym.doc"))
 
     def test_module_is_not_namespace(self) -> None:
         self.assertFalse(util.is_namespace("tests.testdata.python3.data.all"))
@@ -258,9 +251,7 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
         module = self.manager.ast_from_module_name("mypypa")
         self.assertEqual(module.name, "mypypa")
         end = os.path.join(archive, "mypypa")
-        self.assertTrue(
-            module.file.endswith(end), f"{module.file} doesn't endswith {end}"
-        )
+        self.assertTrue(module.file.endswith(end), f"{module.file} doesn't endswith {end}")
 
     @contextmanager
     def _restore_package_cache(self) -> Iterator:
@@ -278,21 +269,15 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
 
     def test_ast_from_module_name_egg(self) -> None:
         with self._restore_package_cache():
-            self._test_ast_from_zip(
-                os.path.sep.join(["data", os.path.normcase("MyPyPa-0.1.0-py2.5.egg")])
-            )
+            self._test_ast_from_zip(os.path.sep.join(["data", os.path.normcase("MyPyPa-0.1.0-py2.5.egg")]))
 
     def test_ast_from_module_name_zip(self) -> None:
         with self._restore_package_cache():
-            self._test_ast_from_zip(
-                os.path.sep.join(["data", os.path.normcase("MyPyPa-0.1.0-py2.5.zip")])
-            )
+            self._test_ast_from_zip(os.path.sep.join(["data", os.path.normcase("MyPyPa-0.1.0-py2.5.zip")]))
 
     def test_ast_from_module_name_pyz(self) -> None:
         try:
-            linked_file_name = os.path.join(
-                resources.RESOURCE_PATH, "MyPyPa-0.1.0-py2.5.pyz"
-            )
+            linked_file_name = os.path.join(resources.RESOURCE_PATH, "MyPyPa-0.1.0-py2.5.pyz")
             os.symlink(
                 os.path.join(resources.RESOURCE_PATH, "MyPyPa-0.1.0-py2.5.zip"),
                 linked_file_name,
@@ -310,9 +295,7 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
             module = self.manager.ast_from_module_name("xxx.test")
             self.assertEqual(module.name, "xxx.test")
             end = os.path.join(archive_path, "xxx", "test")
-            self.assertTrue(
-                module.file.endswith(end), f"{module.file} doesn't endswith {end}"
-            )
+            self.assertTrue(module.file.endswith(end), f"{module.file} doesn't endswith {end}")
 
     def test_zip_import_data(self) -> None:
         """Check if zip_import_data works."""
@@ -506,9 +489,7 @@ class ClearCacheTest(unittest.TestCase):
 
         # Did the hits or misses actually happen?
         incremented_cache_infos = [lru.cache_info() for lru in lrus]
-        for incremented_cache, baseline_cache in zip(
-            incremented_cache_infos, baseline_cache_infos
-        ):
+        for incremented_cache, baseline_cache in zip(incremented_cache_infos, baseline_cache_infos):
             with self.subTest(incremented_cache=incremented_cache):
                 self.assertGreater(
                     incremented_cache.hits + incremented_cache.misses,
@@ -521,9 +502,7 @@ class ClearCacheTest(unittest.TestCase):
 
         # The cache sizes are now as low or lower than the original baseline
         cleared_cache_infos = [lru.cache_info() for lru in lrus]
-        for cleared_cache, baseline_cache in zip(
-            cleared_cache_infos, baseline_cache_infos
-        ):
+        for cleared_cache, baseline_cache in zip(cleared_cache_infos, baseline_cache_infos):
             with self.subTest(cleared_cache=cleared_cache):
                 # less equal because the "baseline" might have had multiple calls to bootstrap()
                 self.assertLessEqual(cleared_cache.currsize, baseline_cache.currsize)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -42,7 +42,9 @@ def _load_namespace_package_pth(pth: str) -> None:
     name must exist as a real local in this function's frame; static
     analyzers cannot see the use through `exec`.
     """
-    sitedir = str(resources.RESOURCE_PATH)  # noqa: F841 # pylint: disable=unused-variable  # used by exec'd .pth
+    sitedir = str(
+        resources.RESOURCE_PATH
+    )  # noqa: F841 # pylint: disable=unused-variable  # used by exec'd .pth
     with (resources.RESOURCE_PATH / pth).open(encoding="utf-8") as pth_file:
         for line in pth_file:
             line = line.strip()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -43,7 +43,9 @@ def _load_namespace_package_pth(pth: str) -> None:
     analyzers cannot see the use through `exec`.
     """
     # `sitedir` is read by exec()'d .pth code via sys._getframe; intentional.
-    sitedir = str(resources.RESOURCE_PATH)  # pylint: disable=unused-variable  # noqa: F841
+    sitedir = str(
+        resources.RESOURCE_PATH
+    )  # pylint: disable=unused-variable  # noqa: F841
     with (resources.RESOURCE_PATH / pth).open(encoding="utf-8") as pth_file:
         for line in pth_file:
             line = line.strip()
@@ -77,7 +79,9 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIn("unittest", self.manager.astroid_cache)
 
     def test_ast_from_file_name_astro_builder_exception(self) -> None:
-        self.assertRaises(AstroidBuildingError, self.manager.ast_from_file, "unhandledName")
+        self.assertRaises(
+            AstroidBuildingError, self.manager.ast_from_file, "unhandledName"
+        )
 
     def test_ast_from_string(self) -> None:
         filepath = unittest.__file__
@@ -143,10 +147,14 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
             # pylint: disable-next=import-outside-toplevel
             import tests.testdata.python3.data.path_pkg_resources_1.package.foo as _  # noqa
 
-        self.assertTrue(util.is_namespace("tests.testdata.python3.data.path_pkg_resources_1"))
+        self.assertTrue(
+            util.is_namespace("tests.testdata.python3.data.path_pkg_resources_1")
+        )
 
     def test_submodule_homonym_with_non_module(self) -> None:
-        self.assertFalse(util.is_namespace("tests.testdata.python3.data.parent_of_homonym.doc"))
+        self.assertFalse(
+            util.is_namespace("tests.testdata.python3.data.parent_of_homonym.doc")
+        )
 
     def test_module_is_not_namespace(self) -> None:
         self.assertFalse(util.is_namespace("tests.testdata.python3.data.all"))
@@ -251,7 +259,9 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
         module = self.manager.ast_from_module_name("mypypa")
         self.assertEqual(module.name, "mypypa")
         end = os.path.join(archive, "mypypa")
-        self.assertTrue(module.file.endswith(end), f"{module.file} doesn't endswith {end}")
+        self.assertTrue(
+            module.file.endswith(end), f"{module.file} doesn't endswith {end}"
+        )
 
     @contextmanager
     def _restore_package_cache(self) -> Iterator:
@@ -269,15 +279,21 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
 
     def test_ast_from_module_name_egg(self) -> None:
         with self._restore_package_cache():
-            self._test_ast_from_zip(os.path.sep.join(["data", os.path.normcase("MyPyPa-0.1.0-py2.5.egg")]))
+            self._test_ast_from_zip(
+                os.path.sep.join(["data", os.path.normcase("MyPyPa-0.1.0-py2.5.egg")])
+            )
 
     def test_ast_from_module_name_zip(self) -> None:
         with self._restore_package_cache():
-            self._test_ast_from_zip(os.path.sep.join(["data", os.path.normcase("MyPyPa-0.1.0-py2.5.zip")]))
+            self._test_ast_from_zip(
+                os.path.sep.join(["data", os.path.normcase("MyPyPa-0.1.0-py2.5.zip")])
+            )
 
     def test_ast_from_module_name_pyz(self) -> None:
         try:
-            linked_file_name = os.path.join(resources.RESOURCE_PATH, "MyPyPa-0.1.0-py2.5.pyz")
+            linked_file_name = os.path.join(
+                resources.RESOURCE_PATH, "MyPyPa-0.1.0-py2.5.pyz"
+            )
             os.symlink(
                 os.path.join(resources.RESOURCE_PATH, "MyPyPa-0.1.0-py2.5.zip"),
                 linked_file_name,
@@ -295,7 +311,9 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
             module = self.manager.ast_from_module_name("xxx.test")
             self.assertEqual(module.name, "xxx.test")
             end = os.path.join(archive_path, "xxx", "test")
-            self.assertTrue(module.file.endswith(end), f"{module.file} doesn't endswith {end}")
+            self.assertTrue(
+                module.file.endswith(end), f"{module.file} doesn't endswith {end}"
+            )
 
     def test_zip_import_data(self) -> None:
         """Check if zip_import_data works."""
@@ -489,7 +507,9 @@ class ClearCacheTest(unittest.TestCase):
 
         # Did the hits or misses actually happen?
         incremented_cache_infos = [lru.cache_info() for lru in lrus]
-        for incremented_cache, baseline_cache in zip(incremented_cache_infos, baseline_cache_infos):
+        for incremented_cache, baseline_cache in zip(
+            incremented_cache_infos, baseline_cache_infos
+        ):
             with self.subTest(incremented_cache=incremented_cache):
                 self.assertGreater(
                     incremented_cache.hits + incremented_cache.misses,
@@ -502,7 +522,9 @@ class ClearCacheTest(unittest.TestCase):
 
         # The cache sizes are now as low or lower than the original baseline
         cleared_cache_infos = [lru.cache_info() for lru in lrus]
-        for cleared_cache, baseline_cache in zip(cleared_cache_infos, baseline_cache_infos):
+        for cleared_cache, baseline_cache in zip(
+            cleared_cache_infos, baseline_cache_infos
+        ):
             with self.subTest(cleared_cache=cleared_cache):
                 # less equal because the "baseline" might have had multiple calls to bootstrap()
                 self.assertLessEqual(cleared_cache.currsize, baseline_cache.currsize)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -42,7 +42,7 @@ def _load_namespace_package_pth(pth: str) -> None:
     name must exist as a real local in this function's frame; static
     analyzers cannot see the use through `exec`.
     """
-    sitedir = str(resources.RESOURCE_PATH)  # noqa: F841 # used by exec'd .pth
+    sitedir = str(resources.RESOURCE_PATH)  # noqa: F841 # pylint: disable=unused-variable  # used by exec'd .pth
     with (resources.RESOURCE_PATH / pth).open(encoding="utf-8") as pth_file:
         for line in pth_file:
             line = line.strip()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -37,12 +37,12 @@ def _get_file_from_object(obj) -> str:
 
 def _load_namespace_package_pth(pth: str) -> None:
     """Execute a test .pth file with a real sitedir local."""
-    sitedir = str(resources.RESOURCE_PATH)
+    sitedir = str(resources.RESOURCE_PATH)  # pylint: disable=unused-variable
     with (resources.RESOURCE_PATH / pth).open(encoding="utf-8") as pth_file:
         for line in pth_file:
             line = line.strip()
             if line and not line.startswith("#"):
-                exec(line)
+                exec(line)  # pylint: disable=exec-used
 
 
 class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -3,8 +3,10 @@
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
 import os
+import re
 import sys
 import time
+import types
 import unittest
 import warnings
 from collections.abc import Iterator
@@ -35,21 +37,49 @@ def _get_file_from_object(obj) -> str:
     return obj.__file__
 
 
-def _load_namespace_package_pth(pth: str) -> None:
-    """Execute a test .pth file with a `sitedir` local in scope.
+_NSPKG_PTH_PARTS_RE = re.compile(r"\*\(([^)]+)\)")
 
-    The .pth fixture reads `sys._getframe(1).f_locals['sitedir']`, so the
-    name must exist as a real local in this function's frame; the read
-    happens via `sys._getframe` inside `exec()`d code below.
+
+def _parse_pth_package_parts(line: str) -> tuple[str, ...]:
+    """Extract the namespace package tuple from a setuptools nspkg .pth line."""
+    match = _NSPKG_PTH_PARTS_RE.search(line)
+    if not match:
+        return ()
+    parts = []
+    for token in match.group(1).split(","):
+        token = token.strip().strip("'\"")
+        if token:
+            parts.append(token)
+    return tuple(parts)
+
+
+def _load_namespace_package_pth(pth: str) -> None:
+    """Apply a setuptools-style namespace package .pth fixture without exec().
+
+    Each non-comment line in the fixture wires up one namespace package by
+    appending a directory under `resources.RESOURCE_PATH` to that package's
+    ``__path__``. We parse the package tuple out of the line and replay the
+    same effect here.
     """
     sitedir = str(resources.RESOURCE_PATH)
     with (resources.RESOURCE_PATH / pth).open(encoding="utf-8") as pth_file:
-        for line in pth_file:
-            line = line.strip()
-            if line and not line.startswith("#"):
-                # `sitedir` is read by .pth code via sys._getframe(1).f_locals.
-                _ = sitedir  # mark as used for static analyzers
-                exec(line)  # pylint: disable=exec-used
+        for raw_line in pth_file:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = _parse_pth_package_parts(line)
+            if not parts:
+                continue
+            package_name = ".".join(parts)
+            package_path = os.path.join(sitedir, *parts)
+            if os.path.exists(os.path.join(package_path, "__init__.py")):
+                continue
+            module = sys.modules.setdefault(
+                package_name, types.ModuleType(package_name)
+            )
+            mod_path = module.__dict__.setdefault("__path__", [])
+            if package_path not in mod_path:
+                mod_path.append(package_path)
 
 
 class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -3,7 +3,6 @@
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
 import os
-import site
 import sys
 import time
 import unittest
@@ -34,6 +33,16 @@ def _get_file_from_object(obj) -> str:
     if IS_JYTHON:
         return obj.__file__.split("$py.class")[0] + ".py"
     return obj.__file__
+
+
+def _load_namespace_package_pth(pth: str) -> None:
+    """Execute a test .pth file with a real sitedir local."""
+    sitedir = str(resources.RESOURCE_PATH)
+    with (resources.RESOURCE_PATH / pth).open(encoding="utf-8") as pth_file:
+        for line in pth_file:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                exec(line)
 
 
 class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
@@ -196,7 +205,7 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
     )
     def test_namespace_package_pth_support(self) -> None:
         pth = "foogle_fax-0.12.5-py2.7-nspkg.pth"
-        site.addpackage(resources.RESOURCE_PATH, pth, [])
+        _load_namespace_package_pth(pth)
 
         try:
             module = self.manager.ast_from_module_name("foogle.fax")
@@ -206,7 +215,8 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
             with self.assertRaises(AstroidImportError):
                 self.manager.ast_from_module_name("foogle.moogle")
         finally:
-            sys.modules.pop("foogle")
+            sys.modules.pop("foogle", None)
+            sys.modules.pop("foogle.crank", None)
 
     @pytest.mark.skipif(
         IS_PYPY,
@@ -214,23 +224,25 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
     )
     def test_nested_namespace_import(self) -> None:
         pth = "foogle_fax-0.12.5-py2.7-nspkg.pth"
-        site.addpackage(resources.RESOURCE_PATH, pth, [])
+        _load_namespace_package_pth(pth)
         try:
             self.manager.ast_from_module_name("foogle.crank")
         finally:
-            sys.modules.pop("foogle")
+            sys.modules.pop("foogle", None)
+            sys.modules.pop("foogle.crank", None)
 
     def test_namespace_and_file_mismatch(self) -> None:
         filepath = unittest.__file__
         ast = self.manager.ast_from_file(filepath)
         self.assertEqual(ast.name, "unittest")
         pth = "foogle_fax-0.12.5-py2.7-nspkg.pth"
-        site.addpackage(resources.RESOURCE_PATH, pth, [])
+        _load_namespace_package_pth(pth)
         try:
             with self.assertRaises(AstroidImportError):
                 self.manager.ast_from_module_name("unittest.foogle.fax")
         finally:
-            sys.modules.pop("foogle")
+            sys.modules.pop("foogle", None)
+            sys.modules.pop("foogle.crank", None)
 
     def _test_ast_from_zip(self, archive: str) -> None:
         sys.modules.pop("mypypa", None)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -602,3 +602,23 @@ class ClearCacheTest(unittest.TestCase):
         isinstance_call = astroid.extract_node("isinstance(1, int)")
         inferred = next(isinstance_call.infer())
         self.assertIs(inferred.value, True)
+
+
+class NamespacePthParserTest(unittest.TestCase):
+    """Direct coverage for the .pth parsing helpers used by namespace tests."""
+
+    def test_parse_extracts_quoted_tuple(self) -> None:
+        line = "import sys; p = os.path.join(s, *('foogle', 'crank'))"
+        self.assertEqual(_parse_pth_package_parts(line), ("foogle", "crank"))
+
+    def test_parse_handles_double_quotes_and_whitespace(self) -> None:
+        line = '*(  "foo" ,  "bar" )'
+        self.assertEqual(_parse_pth_package_parts(line), ("foo", "bar"))
+
+    def test_parse_skips_empty_tokens(self) -> None:
+        line = "*('foo', '', 'bar',)"
+        self.assertEqual(_parse_pth_package_parts(line), ("foo", "bar"))
+
+    def test_parse_returns_empty_when_no_match(self) -> None:
+        self.assertEqual(_parse_pth_package_parts("# comment only"), ())
+        self.assertEqual(_parse_pth_package_parts(""), ())


### PR DESCRIPTION
Fix the four Python 3.15-dev failures currently showing up in CI without broadening the walrus PR scope.

- `dataclasses.KW_ONLY` now infers as `builtins.sentinel` on 3.15, so the existing sentinel check treated it like a real dataclass field. Recognize the sentinel by its dataclasses import binding as a compatibility fallback.
- The legacy `foogle_*.pth` test fixture now executes under 3.15 without a usable `sitedir` frame local, so the namespace-package tests fail before astroid runs. Load that test fixture through a tiny helper that provides the expected local instead of depending on `site.addpackage()` internals.

Verification:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.15 -m pytest -q tests/brain/test_dataclasses.py::test_kw_only_sentinel tests/test_manager.py::AstroidManagerTest::test_namespace_and_file_mismatch tests/test_manager.py::AstroidManagerTest::test_namespace_package_pth_support tests/test_manager.py::AstroidManagerTest::test_nested_namespace_import`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/brain/test_dataclasses.py::test_kw_only_sentinel tests/test_manager.py::AstroidManagerTest::test_namespace_and_file_mismatch tests/test_manager.py::AstroidManagerTest::test_namespace_package_pth_support tests/test_manager.py::AstroidManagerTest::test_nested_namespace_import`
