### PR TITLE
perf: hoist obj_type.mro() out of subclass-check loop

### DIFF
--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -113,13 +113,14 @@ def _object_type_is_subclass(
     # strict compatibility with issubclass
     # issubclass(type, (object, 1)) evaluates to true
     # issubclass(object, (1, type)) raises TypeError
+    obj_mro = obj_type.mro()
     for klass in class_seq:
         if isinstance(klass, util.UninferableBase):
             raise AstroidTypeError(
                 "arg 2 must be a type or tuple of types, not <class 'astroid.util.UninferableBase'>"
             )
 
-        for obj_subclass in obj_type.mro():
+        for obj_subclass in obj_mro:
             if obj_subclass == klass:
                 return True
     return False


### PR DESCRIPTION


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Description

`_object_type_is_subclass` was calling `obj_type.mro()` inside the loop over `class_seq`, recomputing C3 linearization for every candidate. The result is path-independent here, so compute it once before the loop. This is on the hot path for `isinstance`/`issubclass` inference.
