### PR TITLE
chore: pin setuptools<82 unconditionally, drop pkg_resources importorskip

### DIFF
--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -7,8 +7,10 @@ numpy>=1.17.0,<2; python_version<"3.12"
 python-dateutil
 PyQt6
 regex
-# Pinned as 82.0.0 removes `pkg_resources` which we require for a test.
-setuptools<82; python_version>="3.12"
+# ``tests/testdata/python3/data/path_pkg_resources_1`` declares its
+# namespace via ``pkg_resources``; pin setuptools to versions that still
+# ship it (removed in 82.0.0). Applies on every supported Python.
+setuptools<82
 six
 urllib3>1,<2
 typing_extensions>=4.4.0

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -161,12 +161,9 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
         self._test_ast_from_old_namespace_package_protocol("pkgutil")
 
     def test_ast_from_namespace_pkg_resources(self) -> None:
-        pytest.importorskip("pkg_resources")
         self._test_ast_from_old_namespace_package_protocol("pkg_resources")
 
     def test_identify_old_namespace_package_protocol(self) -> None:
-        pytest.importorskip("pkg_resources")
-
         # Like the above cases, this package follows the old namespace package protocol
         # astroid currently assumes such packages are in sys.modules, so import it
         with warnings.catch_warnings():


### PR DESCRIPTION


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |


## Description

``pkg_resources`` is required by
``tests/testdata/python3/data/path_pkg_resources_1`` to declare its namespace, independent of the Python version. setuptools 82.0.0 removes ``pkg_resources`` entirely, so cap setuptools on every supported Python and drop the ``pytest.importorskip("pkg_resources")`` workaround added in #3049, preserving real test coverage rather than silently skipping.
