### PR TITLE
Fix typing.self resolution when inheriting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,12 +8,8 @@ What's New in astroid 4.2.0?
 Release date: TBA
 
 * ``super()`` with no argument now resolves against the class of the object the
-  method was called on, instead of the class the method is written in. It is
-  short for ``super(__class__, self)``, so the lookup starts after the class the
-  method is written in but walks the mro of the caller. A method inherited by a
-  subclass now reaches what that subclass would reach, and a mixin reaches the
-  classes it is mixed in front of. One consequence is that a ``typing.Self``
-  return value survives a chain of ``super()`` calls.
+  method was called on, instead of the class the method is written in. One consequence
+  is that a ``typing.Self`` return value survives a chain of ``super()`` calls.
 
   Closes #2852
   Closes pylint-dev/pylint#10807

--- a/ChangeLog
+++ b/ChangeLog
@@ -121,7 +121,7 @@ Release date: TBA
   of nodes. They now fall back to the default inference past ``1e8`` characters,
   matching the sequence-repetition guard.
 
-Refs #3127 
+Refs #3127
 
 * Bound string/bytes multiplication (``"x" * n``) and integer left shifts
   (``1 << n``) in ``const_infer_binary_op`` the same way list/tuple

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,17 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* ``super()`` with no argument now resolves against the class of the object the
+  method was called on, instead of the class the method is written in. It is
+  short for ``super(__class__, self)``, so the lookup starts after the class the
+  method is written in but walks the mro of the caller. A method inherited by a
+  subclass now reaches what that subclass would reach, and a mixin reaches the
+  classes it is mixed in front of. One consequence is that a ``typing.Self``
+  return value survives a chain of ``super()`` calls.
+
+  Closes #2852
+  Closes pylint-dev/pylint#10807
+
 * The documentation build now fails on any Sphinx warning, so a cross-reference
   that does not resolve is caught by CI instead of quietly rendering as plain
   text. ``Uninferable``, ``Position`` and the ``BadOperationMessage`` classes

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -518,9 +518,9 @@ def infer_super(
         # propagate through super() calls.
         effective_cls = cls
         if context is not None and context.boundnode is not None:
-            from astroid.bases import (
+            from astroid.bases import (  # pylint: disable=import-outside-toplevel
                 Instance,
-            )  # pylint: disable=import-outside-toplevel
+            )
 
             bound = context.boundnode
             if isinstance(bound, Instance):

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -518,7 +518,9 @@ def infer_super(
         # propagate through super() calls.
         effective_cls = cls
         if context is not None and context.boundnode is not None:
-            from astroid.bases import Instance  # pylint: disable=import-outside-toplevel
+            from astroid.bases import (
+                Instance,
+            )  # pylint: disable=import-outside-toplevel
 
             bound = context.boundnode
             if isinstance(bound, Instance):

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -10,9 +10,10 @@ import itertools
 import re
 from collections.abc import Callable, Iterable, Iterator
 from functools import lru_cache, partial
-from typing import TYPE_CHECKING, NoReturn, cast
+from typing import NoReturn, cast
 
 from astroid import arguments, helpers, nodes, objects, util
+from astroid.bases import Instance
 from astroid.builder import AstroidBuilder
 from astroid.context import InferenceContext
 from astroid.exceptions import (
@@ -30,9 +31,6 @@ from astroid.typing import (
     InferenceResult,
     SuccessfulInferenceResult,
 )
-
-if TYPE_CHECKING:
-    from astroid.bases import Instance
 
 ContainerObjects = (
     objects.FrozenSet | objects.DictItems | objects.DictKeys | objects.DictValues
@@ -480,6 +478,30 @@ def infer_dict(node: nodes.Call, context: InferenceContext | None = None) -> nod
     return value
 
 
+def _mro_owner(cls: nodes.ClassDef, context: InferenceContext | None) -> nodes.ClassDef:
+    """Return the class whose mro a ``super()`` call with no argument walks.
+
+    ``super()`` with no argument is ``super(__class__, self)``. It starts the
+    lookup after the class the method is written in, but it walks the mro of the
+    object the method was called on, which can be a subclass, or a class that
+    only meets the method's own class in the mro of that subclass (a mixin).
+    ``context.boundnode`` is that object when it is known.
+    """
+    bound = context.boundnode if context is not None else None
+    if isinstance(bound, Instance):
+        bound_cls = bound._proxied
+    elif isinstance(bound, nodes.ClassDef):
+        bound_cls = bound
+    else:
+        return cls
+    try:
+        if cls in bound_cls.mro():
+            return bound_cls
+    except MroError:
+        pass
+    return cls
+
+
 def infer_super(
     node: nodes.Call, context: InferenceContext | None = None
 ) -> objects.Super:
@@ -511,36 +533,13 @@ def infer_super(
     assert cls is not None
     if not node.args:
         mro_pointer = cls
-        # When context.boundnode is set (e.g. a subclass called this method),
-        # use it as mro_type so that super() resolves against the actual
-        # calling class rather than the lexical class.  This is critical for
-        # three-level (or deeper) inheritance chains where typing.Self must
-        # propagate through super() calls.
-        effective_cls = cls
-        if context is not None and context.boundnode is not None:
-            from astroid.bases import (  # pylint: disable=import-outside-toplevel
-                Instance,
-            )
-
-            bound = context.boundnode
-            if isinstance(bound, Instance):
-                bound_cls = bound._proxied
-            elif isinstance(bound, nodes.ClassDef):
-                bound_cls = bound
-            else:
-                bound_cls = None
-            if bound_cls is not None:
-                try:
-                    if cls in bound_cls.mro():
-                        effective_cls = bound_cls
-                except (MroError, ValueError):
-                    pass
+        mro_owner = _mro_owner(cls, context)
         # In we are in a classmethod, the interpreter will fill
         # automatically the class as the second argument, not an instance.
         if scope.type == "classmethod":
-            mro_type = effective_cls
+            mro_type = mro_owner
         else:
-            mro_type = effective_cls.instantiate_class()
+            mro_type = mro_owner.instantiate_class()
     else:
         try:
             mro_pointer = next(node.args[0].infer(context=context))

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -511,12 +511,34 @@ def infer_super(
     assert cls is not None
     if not node.args:
         mro_pointer = cls
+        # When context.boundnode is set (e.g. a subclass called this method),
+        # use it as mro_type so that super() resolves against the actual
+        # calling class rather than the lexical class.  This is critical for
+        # three-level (or deeper) inheritance chains where typing.Self must
+        # propagate through super() calls.
+        effective_cls = cls
+        if context is not None and context.boundnode is not None:
+            from astroid.bases import Instance  # pylint: disable=import-outside-toplevel
+
+            bound = context.boundnode
+            if isinstance(bound, Instance):
+                bound_cls = bound._proxied
+            elif isinstance(bound, nodes.ClassDef):
+                bound_cls = bound
+            else:
+                bound_cls = None
+            if bound_cls is not None:
+                try:
+                    if cls in bound_cls.mro():
+                        effective_cls = bound_cls
+                except (MroError, ValueError):
+                    pass
         # In we are in a classmethod, the interpreter will fill
         # automatically the class as the second argument, not an instance.
         if scope.type == "classmethod":
-            mro_type = cls
+            mro_type = effective_cls
         else:
-            mro_type = cls.instantiate_class()
+            mro_type = effective_cls.instantiate_class()
     else:
         try:
             mro_pointer = next(node.args[0].infer(context=context))

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -520,6 +520,62 @@ class SuperTests(unittest.TestCase):
         self.assertIsInstance(inferred, bases.Instance)
         self.assertEqual(inferred._proxied.name, "Child")
 
+    def test_super_method_three_level_chain_return_type(self) -> None:
+        """Test that super().method() infers the leaf type in a 3-level chain.
+
+        Regression test for:
+        https://github.com/pylint-dev/pylint/issues/10807
+        https://github.com/pylint-dev/astroid/issues/2852
+        """
+        node = builder.extract_node("""
+        import typing
+
+        class A:
+            def method(self) -> typing.Self:
+                return self
+
+        class B(A):
+            def method(self) -> typing.Self:
+                return super().method()
+
+        class C(B):
+            clsattr = 1
+
+        C().method() #@
+        """)
+        inferred = next(node.infer())
+        self.assertIsInstance(inferred, bases.Instance)
+        self.assertEqual(inferred._proxied.name, "C")
+
+    def test_super_classmethod_three_level_chain_return_type(self) -> None:
+        """Test that super().classmethod() infers the leaf type in a 3-level chain.
+
+        Regression test for:
+        https://github.com/pylint-dev/pylint/issues/9159
+        https://github.com/pylint-dev/astroid/issues/2852
+        """
+        node = builder.extract_node("""
+        import typing
+
+        class C:
+            @classmethod
+            def from_nothing(cls) -> typing.Self:
+                return cls()
+
+        class D(C):
+            @classmethod
+            def from_nothing(cls) -> typing.Self:
+                return super().from_nothing()
+
+        class E(D):
+            clsattr = 1
+
+        E.from_nothing() #@
+        """)
+        inferred = next(node.infer())
+        self.assertIsInstance(inferred, bases.Instance)
+        self.assertEqual(inferred._proxied.name, "E")
+
     def test_super_invalid_types(self) -> None:
         node = builder.extract_node("""
         import collections

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -576,6 +576,78 @@ class SuperTests(unittest.TestCase):
         self.assertIsInstance(inferred, bases.Instance)
         self.assertEqual(inferred._proxied.name, "E")
 
+    def test_super_in_a_mixin_uses_the_mro_of_the_class_using_it(self) -> None:
+        """A mixin has no base of its own to delegate to.
+
+        ``Mixin.sound`` only has something to call because ``Leaf`` puts
+        ``Base`` after ``Mixin`` in its mro.
+        """
+        node = builder.extract_node("""
+        class Base:
+            def sound(self):
+                return "moo"
+
+        class Mixin:
+            def sound(self):
+                return super().sound()
+
+        class Leaf(Mixin, Base):
+            pass
+
+        Leaf().sound() #@
+        """)
+        inferred = next(node.infer())
+        self.assertIsInstance(inferred, bases.Instance)
+        self.assertEqual(inferred._proxied.name, "str")
+
+    def test_super_follows_the_mro_of_the_calling_class(self) -> None:
+        """``super()`` in ``Left`` reaches ``Right``, which is not an ancestor of it.
+
+        ``Right`` comes after ``Left`` and before ``Base`` in ``Leaf``'s mro, so
+        that is what ``Left.pick`` delegates to when called on a ``Leaf``.
+        """
+        node = builder.extract_node("""
+        class Base:
+            def pick(self):
+                return "apple"
+
+        class Left(Base):
+            def pick(self):
+                return super().pick()
+
+        class Right(Base):
+            def pick(self):
+                return "banana"
+
+        class Leaf(Left, Right):
+            pass
+
+        Leaf().pick() #@
+        """)
+        # ``Base.pick`` is still inferred as a second, stale possibility, but the
+        # value the call really produces comes first.
+        inferred = next(node.infer())
+        self.assertIsInstance(inferred, nodes.Const)
+        self.assertEqual(inferred.value, "banana")
+
+    def test_super_when_the_calling_class_has_no_usable_mro(self) -> None:
+        """A class whose mro cannot be computed falls back, it does not raise."""
+        node = builder.extract_node("""
+        class Base:
+            def eat(self):
+                return "yum"
+
+        class Mixin:
+            def eat(self):
+                return super().eat()
+
+        class Broken(Mixin, Base, Mixin):
+            pass
+
+        Broken().eat() #@
+        """)
+        self.assertEqual(list(node.infer()), [util.Uninferable])
+
     def test_super_invalid_types(self) -> None:
         node = builder.extract_node("""
         import collections


### PR DESCRIPTION
This PR fixes inference around functions that return `typing.Self`.

Fixes #2852.  Also I believe fixes https://github.com/pylint-dev/pylint/issues/10807