### PR TITLE
Fix TypeVarTuple ABC inference, fixes #10972

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -373,10 +373,15 @@ class BaseContainer(_base_nodes.ParentAssignNode, Instance, metaclass=abc.ABCMet
                 starred = util.safe_infer(elt.value, context)
                 if not starred:
                     raise InferenceError(node=self, context=context)
-                if not hasattr(starred, "elts"):
+                if isinstance(starred, TypeVarTuple):
+                    # TypeVarTuple unpacking (*Ts) represents a variadic
+                    # type parameter, not an iterable to expand.
+                    values.append(elt)
+                elif not hasattr(starred, "elts"):
                     raise InferenceError(node=self, context=context)
-                # TODO: fresh context?
-                values.extend(starred._infer_sequence_helper(context))
+                else:
+                    # TODO: fresh context?
+                    values.extend(starred._infer_sequence_helper(context))
             elif isinstance(elt, NamedExpr):
                 value = util.safe_infer(elt.value, context)
                 if not value:

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -946,7 +946,8 @@ def generic_type_assigned_stmts(
     context: InferenceContext | None = None,
     assign_path: None = None,
 ) -> Generator[nodes.NodeNG]:
-    """Hack. Return any Node so inference doesn't fail
-    when evaluating __class_getitem__. Revert if it's causing issues.
+    """Return the type parameter node itself so inference doesn't fail
+    when evaluating __class_getitem__ and so that the node's type is
+    preserved for downstream checks (e.g. TypeVarTuple starred handling).
     """
-    yield nodes.Const(None)
+    yield self

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -420,33 +420,27 @@ class TestPatternMatching:
 class TestGenericTypeSyntax:
     @staticmethod
     def test_assigned_stmts_type_var():
-        """The result is 'Uninferable' and no exception is raised."""
+        """The assigned statement is the TypeVar node itself."""
         assign_stmts = extract_node("type Point[T] = tuple[float, float]")
         type_var: nodes.TypeVar = assign_stmts.type_params[0]
         assigned = next(type_var.name.assigned_stmts())
-        # Hack so inference doesn't fail when evaluating __class_getitem__
-        # Revert if it's causing issues.
-        assert isinstance(assigned, nodes.Const)
-        assert assigned.value is None
+        assert isinstance(assigned, nodes.TypeVar)
+        assert assigned is type_var
 
     @staticmethod
     def test_assigned_stmts_type_var_tuple():
-        """The result is 'Uninferable' and no exception is raised."""
+        """The assigned statement is the TypeVarTuple node itself."""
         assign_stmts = extract_node("type Alias[*Ts] = tuple[*Ts]")
         type_var_tuple: nodes.TypeVarTuple = assign_stmts.type_params[0]
         assigned = next(type_var_tuple.name.assigned_stmts())
-        # Hack so inference doesn't fail when evaluating __class_getitem__
-        # Revert if it's causing issues.
-        assert isinstance(assigned, nodes.Const)
-        assert assigned.value is None
+        assert isinstance(assigned, nodes.TypeVarTuple)
+        assert assigned is type_var_tuple
 
     @staticmethod
     def test_assigned_stmts_param_spec():
-        """The result is 'Uninferable' and no exception is raised."""
+        """The assigned statement is the ParamSpec node itself."""
         assign_stmts = extract_node("type Alias[**P] = Callable[P, int]")
         param_spec: nodes.ParamSpec = assign_stmts.type_params[0]
         assigned = next(param_spec.name.assigned_stmts())
-        # Hack so inference doesn't fail when evaluating __class_getitem__
-        # Revert if it's causing issues.
-        assert isinstance(assigned, nodes.Const)
-        assert assigned.value is None
+        assert isinstance(assigned, nodes.ParamSpec)
+        assert assigned is param_spec

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -2685,6 +2685,28 @@ def test_ancestor_with_generic() -> None:
     ]
 
 
+@pytest.mark.skipif(not PY312_PLUS, reason="PEP 695 syntax requires Python 3.12")
+def test_ancestor_with_generic_typevartuple() -> None:
+    # https://github.com/pylint-dev/pylint/issues/10972
+    tree = builder.parse("""
+    from abc import ABC, abstractmethod
+    class Base(ABC):
+        @abstractmethod
+        def get_item(self) -> None: ...
+    class Middle[*Shape]:
+        def get_item(self) -> None:
+            raise NotImplementedError
+    class Concrete[*Shape](Middle[*Shape], Base): pass
+    """)
+    inferred_concrete = next(tree["Concrete"].infer())
+    assert [cdef.name for cdef in inferred_concrete.ancestors()] == [
+        "Middle",
+        "object",
+        "Base",
+        "ABC",
+    ]
+
+
 def test_slots_duplicate_bases_issue_1089() -> None:
     astroid = builder.parse("""
             class First(object, object): #@


### PR DESCRIPTION
Fixes inference around TypeVarTuple that causes multiple issues in pylint (https://github.com/pylint-dev/pylint/issues/10972 and https://github.com/pylint-dev/pylint/issues/10991)
