### PR TITLE
perf: defer cold-path imports to shorten ``import astroid``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,13 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Shorten ``import astroid`` by deferring imports only needed on cold paths.
+  ``logging`` (used by ``modutils`` and ``raw_building`` solely to report
+  stderr/stdout captured while importing a module) and ``pprint`` (used only
+  to format debug ``__repr__`` / ``repr_tree`` output) are now imported
+  lazily, and ``astroid.exceptions`` imports ``astroid.typing`` under
+  ``TYPE_CHECKING``.
+
 * Fix ``AttributeError`` crash in ``starred_assigned_stmts`` when a starred
   unpacking target is an attribute (e.g. ``for *o.attr, x in ...``) rather
   than a simple name.

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import contextlib
-import pprint
 from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING
 
@@ -154,6 +153,8 @@ class InferenceContext:
         )
 
     def __str__(self) -> str:
+        import pprint  # pylint: disable=import-outside-toplevel
+
         state = (
             f"{field}={pprint.pformat(getattr(self, field), width=80 - len(field))}"
             for field in self.__slots__

--- a/astroid/exceptions.py
+++ b/astroid/exceptions.py
@@ -9,11 +9,10 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Any
 
-from astroid.typing import InferenceResult, SuccessfulInferenceResult
-
 if TYPE_CHECKING:
     from astroid import arguments, bases, nodes, objects
     from astroid.context import InferenceContext
+    from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
 __all__ = (
     "AstroidBuildingError",

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import itertools
 import os
-import pprint
 import types
 from collections.abc import Iterator
 from functools import lru_cache
@@ -82,6 +81,8 @@ class ObjectModel:
         self._instance = None
 
     def __repr__(self):
+        import pprint  # pylint: disable=import-outside-toplevel
+
         result = []
         cname = type(self).__name__
         string = "%(cname)s(%(fields)s)"

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -21,7 +21,6 @@ import importlib.machinery
 import importlib.util
 import io
 import itertools
-import logging
 import os
 import sys
 import sysconfig
@@ -33,9 +32,6 @@ from sys import stdlib_module_names
 
 from astroid.const import IS_JYTHON
 from astroid.interpreter._import import spec, util
-
-logger = logging.getLogger(__name__)
-
 
 if sys.platform.startswith("win"):
     PY_SOURCE_EXTS = ("py", "pyw", "pyi")
@@ -177,15 +173,19 @@ def load_module_from_name(dotted_name: str) -> types.ModuleType:
         module = importlib.import_module(dotted_name)
 
     stderr_value = stderr.getvalue()
-    if stderr_value:
-        logger.error(
-            "Captured stderr while importing %s:\n%s", dotted_name, stderr_value
-        )
     stdout_value = stdout.getvalue()
-    if stdout_value:
-        logger.info(
-            "Captured stdout while importing %s:\n%s", dotted_name, stdout_value
-        )
+    if stderr_value or stdout_value:
+        import logging  # pylint: disable=import-outside-toplevel
+
+        logger = logging.getLogger(__name__)
+        if stderr_value:
+            logger.error(
+                "Captured stderr while importing %s:\n%s", dotted_name, stderr_value
+            )
+        if stdout_value:
+            logger.info(
+                "Captured stdout while importing %s:\n%s", dotted_name, stdout_value
+            )
 
     return module
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import pprint
 import sys
 from collections.abc import Generator, Iterator
 from functools import cached_property
@@ -187,6 +186,8 @@ class NodeNG:
         return ""
 
     def __str__(self) -> str:
+        import pprint  # pylint: disable=import-outside-toplevel
+
         rname = self.repr_name()
         cname = type(self).__name__
         if rname:
@@ -646,6 +647,7 @@ class NodeNG:
         """
 
         # pylint: disable = too-many-statements
+        import pprint  # pylint: disable=import-outside-toplevel
 
         @_singledispatch
         def _repr_tree(node, result, done, cur_indent="", depth=1):

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import builtins
 import inspect
 import io
-import logging
 import os
 import sys
 import types
@@ -26,8 +25,6 @@ from astroid.nodes import node_classes
 
 if TYPE_CHECKING:
     from astroid.manager import AstroidManager
-
-logger = logging.getLogger(__name__)
 
 
 _FunctionTypes = (
@@ -570,21 +567,26 @@ class InspectBuilder:
                 ):
                     getattr(sys.modules[modname], name)
                     stderr_value = stderr.getvalue()
-                    if stderr_value:
-                        logger.error(
-                            "Captured stderr while getting %s from %s:\n%s",
-                            name,
-                            sys.modules[modname],
-                            stderr_value,
-                        )
                     stdout_value = stdout.getvalue()
-                    if stdout_value:
-                        logger.info(
-                            "Captured stdout while getting %s from %s:\n%s",
-                            name,
-                            sys.modules[modname],
-                            stdout_value,
-                        )
+                    if stderr_value or stdout_value:
+                        # pylint: disable=import-outside-toplevel
+                        import logging
+
+                        logger = logging.getLogger(__name__)
+                        if stderr_value:
+                            logger.error(
+                                "Captured stderr while getting %s from %s:\n%s",
+                                name,
+                                sys.modules[modname],
+                                stderr_value,
+                            )
+                        if stdout_value:
+                            logger.info(
+                                "Captured stdout while getting %s from %s:\n%s",
+                                name,
+                                sys.modules[modname],
+                                stdout_value,
+                            )
             except (KeyError, AttributeError):
                 attach_dummy_node(node, name, member)
             else:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -6006,6 +6006,13 @@ def test_igetattr_idempotent() -> None:
     assert util.Uninferable not in instance.igetattr("item", context_to_be_used_twice)
 
 
+def test_inference_context_str() -> None:
+    """``str()`` of an ``InferenceContext`` renders each slot without crashing."""
+    rendered = str(InferenceContext())
+    assert rendered.startswith("InferenceContext(")
+    assert rendered.endswith(")")
+
+
 @patch("astroid.nodes.Call._infer")
 def test_cache_usage_without_explicit_context(mock) -> None:
     code = """


### PR DESCRIPTION
## Summary

`import astroid` eagerly imported three modules that a normal lint run
never actually needs. This PR defers them:

- **`logging`** — `modutils` and `raw_building` imported it only for a
  module-level `logger`, used solely when an imported module emits
  stderr/stdout (a rare diagnostic path). Moved the import + logger
  creation into that branch; this also drops `logging`'s transitive
  `traceback`/`weakref` chain.
- **`pprint`** — `context`, `interpreter.objectmodel` and `nodes.node_ng`
  imported it only to format debug `__str__`/`__repr__`/`repr_tree`
  output. Moved into those methods.
- **`astroid.typing` in `exceptions`** — `InferenceResult` /
  `SuccessfulInferenceResult` are used only in annotations; moved the
  import under `TYPE_CHECKING`.

Each module is genuinely eliminated, not relocated: a normal parse +
inference run never reaches these paths. `import astroid` drops from 165
to 156 loaded modules.

Lazy brain-loading — the larger change — is split into #3069; the two
PRs touch disjoint files and can merge in any order.

## Test plan

- [x] Full test suite passes locally (1956 passed, 53 skipped, 16 xfailed)