### PR TITLE
fix: avoid crash in dunder lookup with a non-class metaclass

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,13 @@ Release date: TBA
 
   References pylint-dev/pylint#872
 
+* Fix ``AttributeError`` crash when looking up a special method on a class
+  whose explicit metaclass infers to a non-class node (e.g. a function). Such
+  a metaclass has no MRO, so the dunder lookup now raises
+  ``AttributeInferenceError`` instead of crashing.
+
+  Closes #3063
+
 
 What's New in astroid 4.1.2?
 ============================

--- a/astroid/interpreter/dunder_lookup.py
+++ b/astroid/interpreter/dunder_lookup.py
@@ -62,7 +62,9 @@ def _class_lookup(
     node: nodes.ClassDef, name: str, context: InferenceContext | None = None
 ) -> list:
     metaclass = node.metaclass(context=context)
-    if metaclass is None:
+    # An explicit metaclass may infer to a non-class node (e.g. a function),
+    # which has no MRO to look the special method up in.
+    if not isinstance(metaclass, nodes.ClassDef):
         raise AttributeInferenceError(attribute=name, target=node)
 
     return _lookup_in_mro(metaclass, name)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -4293,6 +4293,20 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         with self.assertRaises(AstroidTypeError):
             inferred.getitem(nodes.Const("4"))
 
+    def test_getitem_of_class_with_non_class_metaclass(self) -> None:
+        """A metaclass that infers to a non-class node has no MRO to search.
+
+        Regression test for https://github.com/pylint-dev/astroid/issues/3063
+        """
+        node = extract_node("""
+        def fn():
+            pass
+        class C(metaclass=fn):  #@
+            pass
+        """)
+        with self.assertRaises(AstroidTypeError):
+            node.getitem(nodes.Const(0))
+
     def test_infer_arg_called_type_is_uninferable(self) -> None:
         node = extract_node("""
         def func(type):


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

``_class_lookup`` passed the result of ``ClassDef.metaclass()`` straight to ``_lookup_in_mro``, which calls ``ancestors()``. When a class declares an explicit metaclass that infers to a non-class node (e.g. a function), that node has no MRO and the lookup crashed with an ``AttributeError``. Treat such a metaclass as if no special method was found.

Closes #3063
