### PR TITLE
fix: avoid DuplicateBasesError crash inferring malformed enum class

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,13 @@ Release date: TBA
 
   References pylint-dev/pylint#872
 
+* Fix ``DuplicateBasesError`` crash in the enum brain when inferring an enum
+  class with duplicate bases (e.g. ``class C(enum.Enum, enum.Enum)``).
+  ``infer_enum_class`` now catches ``MroError`` and leaves such a malformed
+  class untransformed.
+
+  Closes #3065
+
 
 What's New in astroid 4.1.2?
 ============================

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -19,6 +19,7 @@ from astroid.exceptions import (
     AstroidTypeError,
     AstroidValueError,
     InferenceError,
+    MroError,
     UseInferenceDefault,
 )
 from astroid.inference_tip import inference_tip
@@ -386,7 +387,13 @@ INT_FLAG_ADDITION_METHODS = """
 
 def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
     """Specific inference for enums."""
-    for basename in (b for cls in node.mro() for b in cls.basenames):
+    try:
+        mro = node.mro()
+    except MroError:
+        # A malformed class hierarchy (e.g. duplicate bases) has no resolvable
+        # MRO; leave the node untransformed rather than crashing.
+        return node
+    for basename in (b for cls in mro for b in cls.basenames):
         if node.root().name == "enum":
             # Skip if the class is directly from enum module.
             break

--- a/tests/brain/test_enum.py
+++ b/tests/brain/test_enum.py
@@ -559,3 +559,18 @@ class EnumBrainTest(unittest.TestCase):
 
         inferred_value = next(sunder_value.infer())
         assert inferred_value.value == 42
+
+    def test_enum_duplicate_bases_no_crash(self) -> None:
+        """An enum class with duplicate bases has no resolvable MRO.
+
+        Regression test for https://github.com/pylint-dev/astroid/issues/3065
+        """
+        node = builder.extract_node("""
+        import enum
+
+        class C(enum.Enum, enum.Enum):  #@
+            pass
+        """)
+        # Inference must not raise ``DuplicateBasesError``.
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.ClassDef)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

``infer_enum_class`` iterates over ``node.mro()`` without guarding against an unresolvable MRO. A class with duplicate bases (e.g. ``class C(enum.Enum, enum.Enum)``) made ``mro()`` raise ``DuplicateBasesError``, which escaped the transform. Catch ``MroError`` and leave such a malformed class untransformed.

Closes #3065
