### PR TITLE
fix: avoid TypeError crash for functional Enum with non-string member

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,12 @@ Release date: TBA
 
   References pylint-dev/pylint#872
 
+* Fix ``TypeError`` crash in the enum brain when a functional ``Enum`` call
+  has a non-string member name (e.g. ``Enum("e", (1,))``). Such a definition
+  is invalid, so inference now falls back to the default instead of crashing.
+
+  Closes #3068
+
 
 What's New in astroid 4.1.2?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -73,7 +73,7 @@ Release date: TBA
   is invalid, so inference now falls back to the default instead of crashing.
 
   Closes #3068
-  
+
 
 What's New in astroid 4.1.2?
 ============================

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -137,6 +137,11 @@ def infer_func_form(
         attributes = [str(attr) for attr in attributes]
         # XXX this should succeed *unless* __str__/__repr__ is incorrect or throws
         # in which case we should not have inferred these values and raised earlier
+    if any(not isinstance(attr, str) for attr in attributes):
+        # Enum members must be named by strings; a non-string attribute (e.g.
+        # ``Enum("e", (1,))``) means the definition is invalid, so fall back to
+        # the default inference instead of crashing.
+        raise UseInferenceDefault
     attributes = [attr for attr in attributes if " " not in attr]
 
     # If we can't infer the name of the class, don't crash, up to this point

--- a/tests/brain/test_enum.py
+++ b/tests/brain/test_enum.py
@@ -9,7 +9,7 @@ import unittest
 import pytest
 
 import astroid
-from astroid import bases, builder, nodes, objects
+from astroid import bases, builder, nodes, objects, util
 from astroid.exceptions import InferenceError
 
 
@@ -165,6 +165,18 @@ class EnumBrainTest(unittest.TestCase):
         instance = next(instance.infer())
         self.assertIsInstance(instance, nodes.Const)
         self.assertIsInstance(instance.value, str)
+
+    def test_enum_func_form_non_string_attribute_no_crash(self) -> None:
+        """A functional Enum with a non-string member name is invalid.
+
+        Regression test for https://github.com/pylint-dev/astroid/issues/3068
+        """
+        node = builder.extract_node("""
+        from enum import Enum
+        Enum("e", (1,))  #@
+        """)
+        # Inference must not raise ``TypeError``; it falls back to default.
+        assert next(node.infer()) is util.Uninferable
 
     def test_infer_enum_value_as_the_right_type(self) -> None:
         string_value, int_value = builder.extract_node("""


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

``infer_func_form`` filters whitespace out of member names with ``" " not in attr``, assuming every attribute is a string. A functional ``Enum`` call such as ``Enum("e", (1,))`` yields an integer member name, making that check raise ``TypeError``. Such a definition is invalid, so raise ``UseInferenceDefault`` and let inference fall back instead.

Closes #3068
