### PR TITLE
fix: handle non-callable __class_getitem__ in ClassDef.getitem

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -55,6 +55,13 @@ Release date: TBA
 
   Closes #3063
 
+* Fix ``AttributeError`` crash in ``ClassDef.getitem`` when ``__class_getitem__``
+  resolves to a non-callable node (e.g. an ``AssignName``). ``getitem`` now
+  raises ``AstroidTypeError`` in that case, consistent with its documented
+  behaviour.
+
+  Closes #3064
+
 * Fix ``DuplicateBasesError`` crash in the enum brain when inferring an enum
   class with duplicate bases (e.g. ``class C(enum.Enum, enum.Enum)``).
   ``infer_enum_class`` now catches ``MroError`` and leaves such a malformed
@@ -68,12 +75,6 @@ Release date: TBA
 
   Closes #3067
 
-* Fix ``AttributeError`` crash in ``ClassDef.getitem`` when ``__class_getitem__``
-  resolves to a non-callable node (e.g. an ``AssignName``). ``getitem`` now
-  raises ``AstroidTypeError`` in that case, consistent with its documented
-  behaviour.
-
-  Closes #3064
 
 What's New in astroid 4.1.2?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -68,6 +68,13 @@ Release date: TBA
 
   Closes #3067
 
+* Fix ``AttributeError`` crash in ``ClassDef.getitem`` when ``__class_getitem__``
+  resolves to a non-callable node (e.g. an ``AssignName``). ``getitem`` now
+  raises ``AstroidTypeError`` in that case, consistent with its documented
+  behaviour.
+
+  Closes #3064
+
 What's New in astroid 4.1.2?
 ============================
 Release date: 2026-03-22

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2586,7 +2586,7 @@ class ClassDef(
 
         try:
             return next(method.infer_call_result(self, new_context), util.Uninferable)
-        except AttributeError:
+        except AttributeError as exc:
             # Starting with python3.9, builtin types list, dict etc...
             # are subscriptable thanks to __class_getitem___ classmethod.
             # However in such case the method is bound to an EmptyNode and
@@ -2597,6 +2597,10 @@ class ClassDef(
                 and self.pytype() == "builtins.type"
             ):
                 return self
+            # ``__class_getitem__`` may resolve to a non-callable node (e.g. an
+            # ``AssignName``), which has no ``infer_call_result`` method.
+            if not hasattr(method, "infer_call_result"):
+                raise AstroidTypeError(node=self, context=context) from exc
             raise
         except InferenceError:
             return util.Uninferable

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2598,8 +2598,9 @@ class ClassDef(
             ):
                 return self
             # ``__class_getitem__`` may resolve to a non-callable node (e.g. an
-            # ``AssignName``), which has no ``infer_call_result`` method.
-            if not hasattr(method, "infer_call_result"):
+            # ``AssignName`` or an ``Import``), which has no
+            # ``infer_call_result`` method.
+            if not method.callable():
                 raise AstroidTypeError(node=self, context=context) from exc
             raise
         except InferenceError:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -4309,16 +4309,21 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
 
     def test_getitem_with_non_callable_class_getitem(self) -> None:
         """``__class_getitem__`` may resolve to a non-callable node (e.g. an
-        ``AssignName``), which has no ``infer_call_result``.
+        ``AssignName`` or an ``Import``), which has no ``infer_call_result``.
 
         Regression test for https://github.com/pylint-dev/astroid/issues/3064
         """
-        node = extract_node("""
-        class C:  #@
-            __class_getitem__ = classmethod(tuple)
-        """)
-        with self.assertRaises(AstroidTypeError):
-            node.getitem(nodes.Const(0))
+        for body in (
+            "__class_getitem__ = classmethod(tuple)",
+            "import os as __class_getitem__",
+            "from os import getcwd as __class_getitem__",
+        ):
+            node = extract_node(f"""
+            class C:  #@
+                {body}
+            """)
+            with self.assertRaises(AstroidTypeError):
+                node.getitem(nodes.Const(0))
 
     def test_infer_arg_called_type_is_uninferable(self) -> None:
         node = extract_node("""

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -4307,6 +4307,19 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         with self.assertRaises(AstroidTypeError):
             node.getitem(nodes.Const(0))
 
+    def test_getitem_with_non_callable_class_getitem(self) -> None:
+        """``__class_getitem__`` may resolve to a non-callable node (e.g. an
+        ``AssignName``), which has no ``infer_call_result``.
+
+        Regression test for https://github.com/pylint-dev/astroid/issues/3064
+        """
+        node = extract_node("""
+        class C:  #@
+            __class_getitem__ = classmethod(tuple)
+        """)
+        with self.assertRaises(AstroidTypeError):
+            node.getitem(nodes.Const(0))
+
     def test_infer_arg_called_type_is_uninferable(self) -> None:
         node = extract_node("""
         def func(type):


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

When subscripting a class, ``getitem`` falls back to ``__class_getitem__`` and assumes the resolved node is callable. If it instead resolves to a non-callable node such as an ``AssignName`` (e.g. ``dataclasses.Field``, whose ``__class_getitem__`` is assigned rather than ``def``-ined), calling ``infer_call_result`` raised an ``AttributeError`` that escaped inference. Raise ``AstroidTypeError`` instead, matching ``getitem``'s documented contract.

Closes #3064
