### PR TITLE
fix: avoid InferenceError crash in slots() for annotation-only __slots__

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,12 @@ Release date: TBA
 
   References pylint-dev/pylint#872
 
+* Fix ``InferenceError`` crash in ``ClassDef.slots()`` when ``__slots__`` is
+  declared as an annotation without a value (e.g. ``__slots__: None``). Such a
+  ``__slots__`` cannot be inferred, so ``slots()`` now returns ``None``.
+
+  Closes #3067
+
 
 What's New in astroid 4.1.2?
 ============================

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2708,7 +2708,13 @@ class ClassDef(
         """Return an iterator with the inferred slots."""
         if "__slots__" not in self.locals:
             return None
-        for slots in self.igetattr("__slots__"):
+        try:
+            slots_attributes = list(self.igetattr("__slots__"))
+        except InferenceError:
+            # ``__slots__`` is present in ``locals`` but cannot be inferred,
+            # e.g. an annotation-only ``__slots__: ...`` with no assigned value.
+            return None
+        for slots in slots_attributes:
             # check if __slots__ is a valid type
             for meth in ITER_METHODS:
                 try:

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -1569,6 +1569,22 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         cls = module["B"]
         self.assertIsNone(cls.slots())
 
+    def test_slots_annotation_only_without_value(self) -> None:
+        """An annotation-only ``__slots__`` has no inferable value.
+
+        Regression test for https://github.com/pylint-dev/astroid/issues/3067
+        """
+        module = builder.parse("""
+        class Klass:
+            __slots__: None
+
+            def method(self):
+                self.attr = 1
+        """)
+        # ``__slots__`` is in ``locals`` but cannot be inferred; ``slots()``
+        # must return None instead of raising ``InferenceError``.
+        self.assertIsNone(module["Klass"].slots())
+
     def test_slots_added_dynamically_still_inferred(self) -> None:
         code = """
         class NodeBase(object):


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

``_islots`` checks for ``__slots__`` in ``locals`` and then infers it via ``igetattr``. When ``__slots__`` is declared as a bare annotation with no value (e.g. ``__slots__: None``), it is present in ``locals`` but cannot be inferred, so ``igetattr`` raised an ``InferenceError`` that escaped ``slots()``. Treat such a ``__slots__`` as not inferable and return None.

Closes #3067
