### PR TITLE
fix: avoid uncaught TokenError when computing node positions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,13 @@ Release date: TBA
 
   References pylint-dev/pylint#872
 
+* Fix uncaught ``TokenError`` when building a class or function whose source
+  slice is malformed. ``tokenize.generate_tokens`` may raise (e.g. on an
+  unterminated bracket on Python < 3.12); position computation now treats such
+  a node as having no position information instead of crashing.
+
+  Closes #2527
+
 
 What's New in astroid 4.1.2?
 ============================

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -14,7 +14,7 @@ import sys
 import token
 from collections.abc import Callable, Collection, Generator
 from io import StringIO
-from tokenize import TokenInfo, generate_tokens
+from tokenize import TokenError, TokenInfo, generate_tokens
 from typing import TYPE_CHECKING, Final, TypeVar, cast, overload
 
 from astroid import nodes
@@ -131,21 +131,26 @@ class TreeRebuilder:
         else:
             search_token = "class"
 
-        for t in generate_tokens(StringIO(data).readline):
-            if (
-                start_token is not None
-                and t.type == token.NAME
-                and t.string == node.name
-            ):
-                break
-            if t.type in keyword_tokens:
-                if t.string == search_token:
-                    start_token = t
-                    continue
-                if t.string in {"def"}:
-                    continue
-            start_token = None
-        else:
+        try:
+            for t in generate_tokens(StringIO(data).readline):
+                if (
+                    start_token is not None
+                    and t.type == token.NAME
+                    and t.string == node.name
+                ):
+                    break
+                if t.type in keyword_tokens:
+                    if t.string == search_token:
+                        start_token = t
+                        continue
+                    if t.string in {"def"}:
+                        continue
+                start_token = None
+            else:
+                return None
+        except TokenError:
+            # Malformed source can make ``generate_tokens`` raise (e.g. an
+            # unterminated bracket on Python < 3.12); no position info then.
             return None
 
         return Position(

--- a/tests/test_nodes_position.py
+++ b/tests/test_nodes_position.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import textwrap
+from tokenize import TokenError
+from unittest import mock
 
 from astroid import builder, nodes
 
@@ -157,3 +159,18 @@ class TestNodePosition:
         e = ast_nodes[4]
         assert isinstance(e, nodes.FunctionDef)
         assert e.position == (14, 0, 14, 11)
+
+    @staticmethod
+    def test_position_malformed_tokenize() -> None:
+        """A ``TokenError`` from ``tokenize`` must not crash the build.
+
+        On Python < 3.12 malformed source could make ``generate_tokens``
+        raise a ``TokenError``; ``position`` is simply unavailable then.
+        """
+        with mock.patch(
+            "astroid.rebuilder.generate_tokens",
+            side_effect=TokenError("unexpected EOF in multi-line statement", (1, 0)),
+        ):
+            node = builder.extract_node("class A:  #@\n    ...")
+        assert isinstance(node, nodes.ClassDef)
+        assert node.position is None

--- a/tests/test_nodes_position.py
+++ b/tests/test_nodes_position.py
@@ -174,3 +174,16 @@ class TestNodePosition:
             node = builder.extract_node("class A:  #@\n    ...")
         assert isinstance(node, nodes.ClassDef)
         assert node.position is None
+
+    @staticmethod
+    def test_position_unnormalized_name() -> None:
+        """No position info when the name token never matches ``node.name``.
+
+        ``node.name`` is the NFKC-normalized identifier while ``tokenize``
+        yields the raw source spelling (here the ``fi`` ligature), so the
+        name token is never matched and no position can be computed.
+        """
+        node = builder.extract_node("class ﬁ:  #@\n    ...")
+        assert isinstance(node, nodes.ClassDef)
+        assert node.name == "fi"
+        assert node.position is None


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`RebuildVisitor._get_position_info` tokenizes a slice of the source to locate the keyword/name span of a class or function definition. On Python < 3.12, `tokenize.generate_tokens` can raise `TokenError` for malformed input (e.g. an unterminated bracket), which escaped as an uncaught non-`AstroidError` exception during the build.

Position computation now catches `TokenError` and treats such a node as having no position information, instead of crashing.

Closes #2527