### PR TITLE
Add CodSpeed CI with end-to-end primer benchmarks (flask + black) and a cold start test using initial imports

### DIFF
--- a/.github/workflows/codspeed-walltime.yaml
+++ b/.github/workflows/codspeed-walltime.yaml
@@ -25,33 +25,35 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   benchmarks:
     name: Run cold-start benchmarks
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v6.0.2
 
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         id: python
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           check-latest: true
 
       - name: Install dependencies
         run: |
           python -m pip install -U pip
           # Install pylint first (it pulls in a published astroid as a
-          # dependency); the editable install below then replaces that
-          # astroid with the version under test. pylint is invoked as a
+          # dependency); the install below then replaces that astroid
+          # with the version under test. pylint is invoked as a
           # subprocess by the cold-start benchmark.
           pip install pylint pytest-codspeed
-          pip install -e .
+          pip install .
 
       - name: Run cold-start benchmarks
         uses: CodSpeedHQ/action@v4.13.0

--- a/.github/workflows/codspeed-walltime.yaml
+++ b/.github/workflows/codspeed-walltime.yaml
@@ -1,0 +1,60 @@
+name: CodSpeed (walltime)
+
+# Cold-start benchmarks (currently just test_bench_endtoend_cold_lint)
+# shell out to a fresh Python subprocess. mode: simulation only measures
+# Python-side instructions and would report the subprocess as ~300 µs of
+# subprocess.run overhead. mode: walltime measures the wall-clock end to
+# end including the subprocess, which is what we want.
+#
+# Walltime on a shared GitHub runner is noisier than CodSpeed's dedicated
+# macro runners. If cold_lint starts producing false-positive regressions,
+# raise its per-benchmark threshold on the CodSpeed dashboard (Actions
+# menu on the benchmark page).
+
+on:
+  push:
+    branches:
+      - main
+      - maintenance/**
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  benchmarks:
+    name: Run cold-start benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python 3.13
+        id: python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.13"
+          check-latest: true
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          # Install pylint first (it pulls in a published astroid as a
+          # dependency); the editable install below then replaces that
+          # astroid with the version under test. pylint is invoked as a
+          # subprocess by the cold-start benchmark.
+          pip install pylint pytest-codspeed
+          pip install -e .
+
+      - name: Run cold-start benchmarks
+        uses: CodSpeedHQ/action@v4.13.0
+        with:
+          mode: walltime
+          run: pytest tests/benchmarks/ --codspeed -k "cold_lint"

--- a/.github/workflows/codspeed-walltime.yaml
+++ b/.github/workflows/codspeed-walltime.yaml
@@ -31,9 +31,6 @@ jobs:
     name: Run cold-start benchmarks
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -25,9 +25,6 @@ jobs:
   benchmarks:
     name: Run benchmarks
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     # mode: simulation captures a callgraph per benchmark for per-function
     # attribution on the dashboard. That instrumentation is ~10-50x slower
     # than wall-clock, so end-to-end benches over real codebases need

--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -1,0 +1,58 @@
+name: CodSpeed (simulation)
+
+# In-process benches under callgraph instrumentation for per-function
+# attribution on the dashboard. Cold-start subprocess benches need
+# wall-clock measurement and live in codspeed-walltime.yaml.
+
+on:
+  push:
+    branches:
+      - main
+      - maintenance/**
+  pull_request:
+  # `workflow_dispatch` allows CodSpeed to trigger backtest
+  # performance analysis in order to generate initial data.
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  benchmarks:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    # mode: simulation captures a callgraph per benchmark for per-function
+    # attribution on the dashboard. That instrumentation is ~10-50x slower
+    # than wall-clock, so end-to-end benches over real codebases need
+    # generous budget. The 3-bench suite takes ~22 min on the baseline;
+    # a perf regression PR can easily double that.
+    timeout-minutes: 60
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python 3.13
+        id: python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.13"
+          check-latest: true
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install pytest-codspeed
+          pip install -e .
+
+      - name: Run in-process benchmarks
+        uses: CodSpeedHQ/action@v4.13.0
+        with:
+          mode: simulation
+          # Skip cold_lint here — it shells out to a subprocess that
+          # simulation mode cannot see into; see codspeed-walltime.yaml.
+          run: pytest tests/benchmarks/ --codspeed -k "not cold_lint"

--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -20,12 +20,14 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   benchmarks:
     name: Run benchmarks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     # mode: simulation captures a callgraph per benchmark for per-function
     # attribution on the dashboard. That instrumentation is ~10-50x slower
     # than wall-clock, so end-to-end benches over real codebases need
@@ -36,18 +38,18 @@ jobs:
       - name: Check out code from GitHub
         uses: actions/checkout@v6.0.2
 
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         id: python
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           check-latest: true
 
       - name: Install dependencies
         run: |
           python -m pip install -U pip
           pip install pytest-codspeed
-          pip install -e .
+          pip install .
 
       - name: Run in-process benchmarks
         uses: CodSpeedHQ/action@v4.13.0

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,20 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
+
+"""Skip the benchmark suite when ``pytest-codspeed`` is not installed.
+
+The ``benchmark`` fixture used by every test in this directory is provided
+by the ``pytest-codspeed`` plugin. CI installs it explicitly in the
+CodSpeed workflow, but contributors running ``pytest tests/`` locally will
+not have it. Without this guard pytest would error out with
+``fixture 'benchmark' not found`` (and, because ``filterwarnings = "error"``
+is set in ``pyproject.toml``, even a warning would abort collection).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+if importlib.util.find_spec("pytest_codspeed") is None:
+    collect_ignore_glob = ["test_bench_*.py"]

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -12,9 +12,7 @@ not have it. Without this guard pytest would error out with
 is set in ``pyproject.toml``, even a warning would abort collection).
 """
 
-from __future__ import annotations
-
-import importlib.util
-
-if importlib.util.find_spec("pytest_codspeed") is None:
+try:
+    import pytest_codspeed  # noqa: F401  # pylint: disable=unused-import
+except ImportError:
     collect_ignore_glob = ["test_bench_*.py"]

--- a/tests/benchmarks/test_bench_endtoend.py
+++ b/tests/benchmarks/test_bench_endtoend.py
@@ -18,6 +18,16 @@ real project and calling ``safe_infer`` on the nodes that matter
   optimizations like deferring brain-plugin registration are invisible
   to those benches.
 
+  Scope note: this bench exists to *protect* targeted lazy imports of
+  modules that are not on the general code path — brain plugins for
+  libraries a given project does not use, and debug-only stdlib
+  modules like ``pprint`` / ``logging`` deferred in #3062. Such
+  function-local / ``TYPE_CHECKING`` imports work on all supported
+  Python versions; they do not depend on PEP 810 lazy imports landing
+  in 3.15. It is **not** an argument for lazifying modules astroid
+  imports unconditionally — those just trade one fixed cost for
+  another and bloat the import graph for marginal wins.
+
   Cold-lint runs in a dedicated **walltime** CodSpeed workflow
   (``.github/workflows/codspeed-walltime.yaml``) because the
   ``simulation`` mode used by the in-process suite

--- a/tests/benchmarks/test_bench_endtoend.py
+++ b/tests/benchmarks/test_bench_endtoend.py
@@ -2,55 +2,12 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-"""End-to-end benchmarks: cold import + parse + walk + infer real projects.
+"""End-to-end benchmarks running astroid over real projects the way pylint
+does: parse, walk every node, and ``safe_infer`` the ones that matter
+(``Call``, ``Attribute``, ``Name``), plus a cold-start subprocess lint to
+catch import-time regressions the in-process benches cannot see.
 
-These exercise astroid the way pylint does: walking every node of a
-real project and calling ``safe_infer`` on the nodes that matter
-(``Call``, ``Attribute``, ``Name``).
-
-- ``test_bench_endtoend_cold_lint`` — shells out
-  ``python -m pylint <minimal module>`` per iteration. ~98 % of wall
-  time is startup (Python import, pylint init, ``import astroid``,
-  brain-plugin registration); only ~2 % is actual linting work on the
-  one-line target. This captures cold-start cost that the in-process
-  benches below miss: within a single pytest session ``astroid`` is
-  imported once at module load and stays in ``sys.modules``, so
-  optimizations like deferring brain-plugin registration are invisible
-  to those benches.
-
-  Scope note: this bench exists to *protect* targeted lazy imports of
-  modules that are not on the general code path — brain plugins for
-  libraries a given project does not use, and debug-only stdlib
-  modules like ``pprint`` / ``logging`` deferred in #3062. Such
-  function-local / ``TYPE_CHECKING`` imports work on all supported
-  Python versions; they do not depend on PEP 810 lazy imports landing
-  in 3.15. It is **not** an argument for lazifying modules astroid
-  imports unconditionally — those just trade one fixed cost for
-  another and bloat the import graph for marginal wins.
-
-  Cold-lint runs in a dedicated **walltime** CodSpeed workflow
-  (``.github/workflows/codspeed-walltime.yaml``) because the
-  ``simulation`` mode used by the in-process suite
-  (``.github/workflows/codspeed.yaml``) only measures Python-side
-  instructions and cannot see into the subprocess.
-- Two projects pinned to the SHAs used by pylint's primer corpus so the
-  workload composition is stable and directly comparable with what
-  pylint sees nightly:
-
-  * **Flask** (~50 ``.py`` files under ``src/flask``) — small,
-    well-typed. Parse-only (isolates the rebuilder hot path) and
-    full pylint-shaped traversal.
-  * **Black** (``src/black``, ``src/blackd``, ``src/blib2to3``,
-    ~250 files) — medium, classic AST handling with deep class
-    hierarchies.
-
-We deliberately do *not* ship pure-Python microbenchmarks: at
-microsecond scale CodSpeed CI shows >40 % StdDev, which is too noisy
-for regression detection. End-to-end benches each take milliseconds
-to tens of seconds per iteration, so per-run noise becomes a small
-fraction of the measurement.
-
-Source of truth for URL + SHA:
+Projects and their pinned SHAs mirror pylint's primer corpus:
 https://github.com/pylint-dev/pylint/blob/main/tests/primer/packages_to_prime.json
 """
 
@@ -62,11 +19,14 @@ from __future__ import annotations
 import subprocess
 import sys
 from pathlib import Path
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import pytest
 
 from astroid import helpers, manager, nodes
+
+if TYPE_CHECKING:
+    from pytest_codspeed import BenchmarkFixture
 
 
 class _Project(NamedTuple):
@@ -171,9 +131,6 @@ def _walk_and_infer(files: list[Path], mgr: manager.AstroidManager) -> int:
     return count
 
 
-# -- Cold start: pylint a tiny module in a fresh subprocess. --
-
-
 _MINIMAL_LINT_TARGET = '''\
 """Minimal module for the cold-start benchmark.
 
@@ -215,29 +172,31 @@ def _pylint_one_file(target: Path) -> None:
     )
 
 
-def test_bench_endtoend_cold_lint(benchmark, minimal_module: Path) -> None:
+def test_bench_endtoend_cold_lint(
+    benchmark: BenchmarkFixture, minimal_module: Path
+) -> None:
     benchmark(_pylint_one_file, minimal_module)
 
 
-# -- Flask: small, parse + walk_infer (parse isolates rebuilder cost). --
-
-
-def test_bench_endtoend_parse_flask(benchmark, flask_files: list[Path]) -> None:
+def test_bench_endtoend_parse_flask(
+    benchmark: BenchmarkFixture, flask_files: list[Path]
+) -> None:
     assert flask_files, "Expected at least one .py file in flask"
     mgr = manager.AstroidManager()
     benchmark(_parse_all, flask_files, mgr)
 
 
-def test_bench_endtoend_walk_infer_flask(benchmark, flask_files: list[Path]) -> None:
+def test_bench_endtoend_walk_infer_flask(
+    benchmark: BenchmarkFixture, flask_files: list[Path]
+) -> None:
     assert flask_files, "Expected at least one .py file in flask"
     mgr = manager.AstroidManager()
     benchmark(_walk_and_infer, flask_files, mgr)
 
 
-# -- Black: medium, walk_infer only. --
-
-
-def test_bench_endtoend_walk_infer_black(benchmark, black_files: list[Path]) -> None:
+def test_bench_endtoend_walk_infer_black(
+    benchmark: BenchmarkFixture, black_files: list[Path]
+) -> None:
     assert black_files, "Expected at least one .py file in black"
     mgr = manager.AstroidManager()
     benchmark(_walk_and_infer, black_files, mgr)

--- a/tests/benchmarks/test_bench_endtoend.py
+++ b/tests/benchmarks/test_bench_endtoend.py
@@ -1,0 +1,233 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
+
+"""End-to-end benchmarks: cold import + parse + walk + infer real projects.
+
+These exercise astroid the way pylint does: walking every node of a
+real project and calling ``safe_infer`` on the nodes that matter
+(``Call``, ``Attribute``, ``Name``).
+
+- ``test_bench_endtoend_cold_lint`` — shells out
+  ``python -m pylint <minimal module>`` per iteration. ~98 % of wall
+  time is startup (Python import, pylint init, ``import astroid``,
+  brain-plugin registration); only ~2 % is actual linting work on the
+  one-line target. This captures cold-start cost that the in-process
+  benches below miss: within a single pytest session ``astroid`` is
+  imported once at module load and stays in ``sys.modules``, so
+  optimizations like deferring brain-plugin registration are invisible
+  to those benches.
+
+  Cold-lint runs in a dedicated **walltime** CodSpeed workflow
+  (``.github/workflows/codspeed-walltime.yaml``) because the
+  ``simulation`` mode used by the in-process suite
+  (``.github/workflows/codspeed.yaml``) only measures Python-side
+  instructions and cannot see into the subprocess.
+- Two projects pinned to the SHAs used by pylint's primer corpus so the
+  workload composition is stable and directly comparable with what
+  pylint sees nightly:
+
+  * **Flask** (~50 ``.py`` files under ``src/flask``) — small,
+    well-typed. Parse-only (isolates the rebuilder hot path) and
+    full pylint-shaped traversal.
+  * **Black** (``src/black``, ``src/blackd``, ``src/blib2to3``,
+    ~250 files) — medium, classic AST handling with deep class
+    hierarchies.
+
+We deliberately do *not* ship pure-Python microbenchmarks: at
+microsecond scale CodSpeed CI shows >40 % StdDev, which is too noisy
+for regression detection. End-to-end benches each take milliseconds
+to tens of seconds per iteration, so per-run noise becomes a small
+fraction of the measurement.
+
+Source of truth for URL + SHA:
+https://github.com/pylint-dev/pylint/blob/main/tests/primer/packages_to_prime.json
+"""
+
+# Fixture-name / argument-name match is the standard pytest idiom.
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+
+from astroid import helpers, manager, nodes
+
+
+class _Project(NamedTuple):
+    url: str
+    sha: str
+    subdirs: tuple[tuple[str, ...], ...]
+
+
+# Mirrors tests/primer/packages_to_prime.json in pylint.
+_PROJECTS: dict[str, _Project] = {
+    "flask": _Project(
+        url="https://github.com/pallets/flask",
+        sha="4cae5d8e411b1e69949d8fae669afeacbd3e5908",
+        subdirs=(("src", "flask"),),
+    ),
+    "black": _Project(
+        url="https://github.com/psf/black",
+        sha="acc73dc4ff97d2c1d5999914a9a182b6e2728b8a",
+        subdirs=(("src", "black"), ("src", "blackd"), ("src", "blib2to3")),
+    ),
+}
+
+_INFERABLE = (nodes.Call, nodes.Attribute, nodes.Name)
+
+
+def _clone_primer_project(
+    name: str, tmp_path_factory: pytest.TempPathFactory
+) -> list[Path]:
+    """Sparse-clone a primer project at its pinned SHA, return its ``.py`` files.
+
+    ``--filter=blob:none`` skips fetching file contents until they are
+    needed; ``sparse-checkout`` restricts that fetch to the project's
+    declared source subdirs (essential for huge repos like pandas).
+    """
+    project = _PROJECTS[name]
+    clone_root = tmp_path_factory.mktemp(f"{name}-bench")
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "--no-checkout",
+            "--filter=blob:none",
+            "--no-tags",
+            "--single-branch",
+            project.url,
+            str(clone_root),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(clone_root),
+            "sparse-checkout",
+            "set",
+            *("/".join(parts) for parts in project.subdirs),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(clone_root), "checkout", project.sha],
+        check=True,
+        capture_output=True,
+    )
+    files: list[Path] = []
+    for subdir in project.subdirs:
+        files.extend(clone_root.joinpath(*subdir).rglob("*.py"))
+    return sorted(files)
+
+
+@pytest.fixture(scope="session")
+def flask_files(tmp_path_factory: pytest.TempPathFactory) -> list[Path]:
+    return _clone_primer_project("flask", tmp_path_factory)
+
+
+@pytest.fixture(scope="session")
+def black_files(tmp_path_factory: pytest.TempPathFactory) -> list[Path]:
+    return _clone_primer_project("black", tmp_path_factory)
+
+
+def _parse_all(files: list[Path], mgr: manager.AstroidManager) -> int:
+    """Cold-cache parse of every file (rebuilder hot path)."""
+    mgr.clear_cache()
+    for f in files:
+        mgr.ast_from_file(str(f))
+    return len(files)
+
+
+def _walk_and_infer(files: list[Path], mgr: manager.AstroidManager) -> int:
+    """Pylint-shaped traversal: parse, walk, safe_infer call sites."""
+    mgr.clear_cache()
+    count = 0
+    for f in files:
+        mod = mgr.ast_from_file(str(f))
+        for node in mod.nodes_of_class(nodes.NodeNG):
+            if isinstance(node, _INFERABLE):
+                helpers.safe_infer(node)
+                count += 1
+    return count
+
+
+# -- Cold start: pylint a tiny module in a fresh subprocess. --
+
+
+_MINIMAL_LINT_TARGET = '''\
+"""Minimal module for the cold-start benchmark.
+
+Intentionally tiny but exercises brain_builtin_inference (always-on,
+loaded by both the eager and lazy registration paths) without
+triggering any optional brain plugin: no stdlib imports, no
+dataclasses, no typing, no enum. That keeps cold-start cost dominated
+by Python + pylint + astroid startup, which is the point.
+"""
+
+
+def add(a, b):
+    return a + b
+
+
+result = add(len("ab"), 2)
+'''
+
+
+@pytest.fixture(scope="session")
+def minimal_module(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Tiny Python file used as the lint target for cold-start runs."""
+    path = tmp_path_factory.mktemp("lint-target") / "minimal.py"
+    path.write_text(_MINIMAL_LINT_TARGET, encoding="utf-8")
+    return path
+
+
+def _pylint_one_file(target: Path) -> None:
+    """Run ``python -m pylint <target>`` in a fresh subprocess.
+
+    pylint exits non-zero whenever it emits any message (warnings,
+    refactor hints, etc.), which is expected on most files. We don't
+    care about the exit code here, only the wall time.
+    """
+    subprocess.run(
+        [sys.executable, "-m", "pylint", str(target)],
+        check=False,
+        capture_output=True,
+    )
+
+
+def test_bench_endtoend_cold_lint(benchmark, minimal_module: Path) -> None:
+    benchmark(_pylint_one_file, minimal_module)
+
+
+# -- Flask: small, parse + walk_infer (parse isolates rebuilder cost). --
+
+
+def test_bench_endtoend_parse_flask(benchmark, flask_files: list[Path]) -> None:
+    assert flask_files, "Expected at least one .py file in flask"
+    mgr = manager.AstroidManager()
+    benchmark(_parse_all, flask_files, mgr)
+
+
+def test_bench_endtoend_walk_infer_flask(benchmark, flask_files: list[Path]) -> None:
+    assert flask_files, "Expected at least one .py file in flask"
+    mgr = manager.AstroidManager()
+    benchmark(_walk_and_infer, flask_files, mgr)
+
+
+# -- Black: medium, walk_infer only. --
+
+
+def test_bench_endtoend_walk_infer_black(benchmark, black_files: list[Path]) -> None:
+    assert black_files, "Expected at least one .py file in black"
+    mgr = manager.AstroidManager()
+    benchmark(_walk_and_infer, black_files, mgr)


### PR DESCRIPTION
Adds CodSpeed CI to astroid with three end-to-end benchmarks for black and flask, alongside a cold start test to exercice the import time which is important because we often lint single file in parallel inside pre-commit.

Supersedes #3022.

Result can be seen in #3080 (but also on currently opened performance branches : #3069, #3046, #3048). For the lazy loading of brains, the result is not visible because the threshold is at 2% change (already close to noise). We won't see performance change in brains as we don't parse lib specific code in this benchmark. 
