### PR TITLE
fix: handle PEP 695 type parameters in helpers.object_type

### DIFF
--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -66,6 +66,10 @@ def _object_type(
             yield _build_proxy_class("module", builtins)
         elif isinstance(inferred, nodes.Unknown):
             raise InferenceError
+        elif isinstance(inferred, (nodes.TypeVar, nodes.TypeVarTuple, nodes.ParamSpec)):
+            # PEP 695 generic type parameters have no concrete type at
+            # static-analysis time, so the type cannot be determined.
+            yield util.Uninferable
         elif isinstance(inferred, util.UninferableBase):
             yield inferred
         elif isinstance(inferred, (bases.Proxy, nodes.Slice, objects.Super)):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,7 +9,7 @@ import pytest
 
 from astroid import builder, helpers, manager, nodes, raw_building, util
 from astroid.builder import AstroidBuilder
-from astroid.const import IS_PYPY
+from astroid.const import IS_PYPY, PY312_PLUS
 from astroid.exceptions import InferenceError, _NonDeducibleTypeHierarchy
 
 
@@ -305,3 +305,28 @@ def test_tuple_to_container_inference_error() -> None:
 
     with pytest.raises(InferenceError):
         helpers.class_or_tuple_to_container(node.args[1])
+
+
+@pytest.mark.skipif(not PY312_PLUS, reason="PEP 695 syntax requires Python 3.12")
+def test_object_type_pep695_type_params() -> None:
+    """PEP 695 type parameters have no concrete type at static-analysis time.
+
+    Regression test for the AssertionError introduced when
+    ``generic_type_assigned_stmts`` started yielding the TypeVar/TypeVarTuple/
+    ParamSpec node itself: ``object_type`` previously crashed instead of
+    returning ``Uninferable``.
+    """
+    binop = builder.extract_node("""
+    def func[_T](var: _T) -> _T:
+        value: _T | None = None  #@
+        return var
+    """).annotation
+    assert helpers.object_type(binop) is util.Uninferable
+
+    for code in (
+        "type Alias[*Ts] = tuple[*Ts]",
+        "type Alias[**P] = Callable[P, int]",
+    ):
+        assign = builder.extract_node(code)
+        type_param_name = assign.type_params[0].name
+        assert helpers.object_type(type_param_name) is util.Uninferable


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

PR #3058 changed generic_type_assigned_stmts to yield the TypeVar/ TypeVarTuple/ParamSpec node itself instead of Const(None). As a result, inferring an expression like '_T | None' inside 'def func[_T]: ...' reached helpers._object_type with one of these new AST nodes, which it didn't recognize, raising AssertionError("We don't handle <class 'astroid.nodes.node_classes.TypeVar'> currently").

A PEP 695 type parameter has no concrete type at static-analysis time, so yield util.Uninferable for these nodes. The binop inference path already handles Uninferable operands gracefully.

Reported at https://github.com/pylint-dev/astroid/pull/3058#issuecomment-4528993032
