### PR TITLE
Fix: avoid TypeError from getset descriptors on PyPy 7.3.22

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,15 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Fix astroid bootstrap crash on PyPy 7.3.22 (``TypeError: expected str, got
+  getset_descriptor object``) by also catching ``TypeError`` from
+  ``getattr(obj, alias)`` in ``InspectBuilder.object_build``. PyPy 7.3.22
+  raises ``TypeError`` instead of ``AttributeError`` for unset getset
+  descriptors like ``types.FunctionType.__text_signature__``, which made
+  ``_astroid_bootstrapping()`` blow up on any call into astroid.
+
+  Refs pylint-dev/pylint#10999
+
 * Shorten ``import astroid`` by deferring imports only needed on cold paths.
   ``logging`` (used by ``modutils`` and ``raw_building`` solely to report
   stderr/stdout captured while importing a module) and ``pprint`` (used only

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -481,8 +481,15 @@ class InspectBuilder:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
                     member = getattr(obj, alias)
-            except AttributeError:
-                # damned ExtensionClass.Base, I know you're there !
+            except (AttributeError, TypeError):
+                # AttributeError: damned ExtensionClass.Base, I know you're
+                # there!
+                # TypeError: PyPy 7.3.22 raises TypeError ("expected str, got
+                # getset_descriptor object") instead of AttributeError for
+                # unset getset descriptors like
+                # ``types.FunctionType.__text_signature__`` when accessed on
+                # the type. Treat that the same as a missing attribute so
+                # ``_astroid_bootstrapping()`` doesn't crash on import.
                 attach_dummy_node(node, alias)
                 continue
             if inspect.ismethod(member) and not pypy__class_getitem__:

--- a/tests/test_raw_building.py
+++ b/tests/test_raw_building.py
@@ -138,6 +138,30 @@ class RawBuildingTC(unittest.TestCase):
         # This should not raise an exception
         AstroidBuilder(AstroidManager()).inspect_build(fm_collection, "test")
 
+    def test_module_object_with_getattr_typeerror(self) -> None:
+        # Regression test for the PyPy 7.3.22 bootstrap crash: PyPy 7.3.22
+        # raises ``TypeError("expected str, got getset_descriptor object")``
+        # instead of ``AttributeError`` for unset getset descriptors like
+        # ``types.FunctionType.__text_signature__`` when accessed on the
+        # type. ``InspectBuilder.object_build`` must treat that the same as a
+        # missing attribute, otherwise ``_astroid_bootstrapping()`` blows up
+        # on import. Refs pylint-dev/pylint#10999.
+        class _TypeErrorOnGetattr(types.ModuleType):
+            def __getattr__(self, name: str) -> Any:
+                if name == "pypy_text_signature_like":
+                    raise TypeError("expected str, got getset_descriptor object")
+                raise AttributeError(name)
+
+            def __dir__(self) -> list[str]:
+                return [*super().__dir__(), "pypy_text_signature_like"]
+
+        m = _TypeErrorOnGetattr("test_typeerror_on_getattr")
+
+        # This should not raise: the alias is skipped via attach_dummy_node,
+        # the same path used for AttributeError.
+        node = AstroidBuilder(AstroidManager()).inspect_build(m, "test")
+        self.assertIn("pypy_text_signature_like", node.locals)
+
 
 @pytest.mark.skipif(
     "posix" not in sys.builtin_module_names, reason="Platform doesn't support posix"


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

PyPy 7.3.22 changed the exception type raised when accessing certain getset descriptors on the type (rather than an instance). We froze the version in pylint to make the CI green, but this is the wrong way to fix this.

Refs pylint-dev/pylint#10999
