### PR TITLE
docs: correct ImportFrom.level description

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2863,12 +2863,11 @@ class ImportFrom(_base_nodes.ImportNode):
         and the alias that the name is assigned to (if any).
         """
 
-        # TODO When is 'level' None?
         self.level: int | None = level  # can be None
         """The level of relative import.
 
         Essentially this is the number of dots in the import.
-        This is always 0 for absolute imports.
+        This is ``None`` for absolute imports.
         """
 
         super().__init__(


### PR DESCRIPTION
## Summary

Closes #2571.

This removes the stale TODO on `ImportFrom.level` and corrects the attribute documentation to say that absolute imports use `None`, matching the current AST conversion behavior.

## Verification

- `python3 -m compileall -q astroid/nodes/node_classes.py`
- `PYTHONPATH=. python3` smoke check for `from os import path` (`level is None`) and `from . import sibling` (`level == 1`)
- `git diff --check`
