### PR TITLE
Support PEP 798 dict-comp unpacking and PEP 810 lazy imports

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,18 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Support PEP 810 explicit lazy imports (new in Python 3.15). ``Import`` and
+  ``ImportFrom`` nodes gain a ``lazy`` boolean attribute (``False`` before
+  3.15 and for eager imports), set from CPython's ``is_lazy`` AST field, and
+  ``as_string`` renders the ``lazy`` prefix. Name binding and inference are
+  unchanged from eager imports.
+
+* Support PEP 798 dict-comprehension unpacking (``{**d for d in dicts}``,
+  new in Python 3.15). The rebuilder previously crashed because CPython
+  stores the unpacked mapping in ``DictComp.key`` and leaves ``value`` as
+  ``None``; astroid now mirrors the ``{**d}`` ``Dict`` representation with a
+  ``DictUnpack`` key, and ``as_string`` round-trips the construct.
+
 * Fix astroid bootstrap crash on PyPy 7.3.22 (``TypeError: expected str, got
   getset_descriptor object``) by also catching ``TypeError`` from
   ``getattr(obj, alias)`` in ``InspectBuilder.object_build``. PyPy 7.3.22

--- a/ChangeLog
+++ b/ChangeLog
@@ -18,7 +18,7 @@ Release date: TBA
   stores the unpacked mapping in ``DictComp.key`` and leaves ``value`` as
   ``None``; astroid now mirrors the ``{**d}`` ``Dict`` representation with a
   ``DictUnpack`` key, and ``as_string`` round-trips the construct.
-  
+
 * Fix uncaught ``IndentationError`` when parsing code whose lines end in
   ``\r``: the slice of source tokenized to compute a class or function
   ``position`` is split on ``\n`` only and could be misaligned with the AST

--- a/ChangeLog
+++ b/ChangeLog
@@ -47,11 +47,8 @@ Release date: TBA
 
   Closes #3091
 
-* Support PEP 810 explicit lazy imports (new in Python 3.15). ``Import`` and
-  ``ImportFrom`` nodes gain a ``lazy`` boolean attribute (``False`` before
-  3.15 and for eager imports), set from CPython's ``is_lazy`` AST field, and
-  ``as_string`` renders the ``lazy`` prefix. Name binding and inference are
-  unchanged from eager imports.
+ Support PEP 810 lazy imports (new in Python 3.15). ``Import`` and
+  ``ImportFrom`` nodes gain a ``lazy`` boolean attribute.
 
 * Support PEP 798 comprehension unpacking (``{**d for d in dicts}``,
   new in Python 3.15).

--- a/ChangeLog
+++ b/ChangeLog
@@ -53,11 +53,8 @@ Release date: TBA
   ``as_string`` renders the ``lazy`` prefix. Name binding and inference are
   unchanged from eager imports.
 
-* Support PEP 798 dict-comprehension unpacking (``{**d for d in dicts}``,
-  new in Python 3.15). The rebuilder previously crashed because CPython
-  stores the unpacked mapping in ``DictComp.key`` and leaves ``value`` as
-  ``None``; astroid now mirrors the ``{**d}`` ``Dict`` representation with a
-  ``DictUnpack`` key, and ``as_string`` round-trips the construct.
+* Support PEP 798 comprehension unpacking (``{**d for d in dicts}``,
+  new in Python 3.15).
 
 * Fix astroid bootstrap crash on PyPy 7.3.22 (``TypeError: expected str, got
   getset_descriptor object``) by also catching ``TypeError`` from

--- a/ChangeLog
+++ b/ChangeLog
@@ -74,7 +74,7 @@ Release date: TBA
 
   Closes #3091
 
- Support PEP 810 lazy imports (new in Python 3.15). ``Import`` and
+* Support PEP 810 lazy imports (new in Python 3.15). ``Import`` and
   ``ImportFrom`` nodes gain a ``lazy`` boolean attribute.
 
 * Support PEP 798 comprehension unpacking (``{**d for d in dicts}``,

--- a/astroid/nodes/as_string.py
+++ b/astroid/nodes/as_string.py
@@ -245,11 +245,13 @@ class AsStringVisitor:
 
     def visit_dictcomp(self, node: nodes.DictComp) -> str:
         """return an nodes.DictComp node as string"""
-        return "{{{}: {} {}}}".format(
-            node.key.accept(self),
-            node.value.accept(self),
-            " ".join(n.accept(self) for n in node.generators),
-        )
+        key = node.key.accept(self)
+        value = node.value.accept(self)
+        generators = " ".join(n.accept(self) for n in node.generators)
+        if key == "**":
+            # PEP 798 dict-comprehension unpacking, e.g. ``{**d for d in dicts}``.
+            return f"{{{key}{value} {generators}}}"
+        return f"{{{key}: {value} {generators}}}"
 
     def visit_expr(self, node: nodes.Expr) -> str:
         """return an nodes.Expr node as string"""
@@ -285,8 +287,9 @@ class AsStringVisitor:
 
     def visit_importfrom(self, node: nodes.ImportFrom) -> str:
         """return an nodes.ImportFrom node as string"""
-        return "from {} import {}".format(
-            "." * (node.level or 0) + node.modname, _import_string(node.names)
+        lazy = "lazy " if node.lazy else ""
+        return "{}from {} import {}".format(
+            lazy, "." * (node.level or 0) + node.modname, _import_string(node.names)
         )
 
     def visit_joinedstr(self, node: nodes.JoinedStr) -> str:
@@ -401,7 +404,8 @@ class AsStringVisitor:
 
     def visit_import(self, node: nodes.Import) -> str:
         """return an nodes.Import node as string"""
-        return f"import {_import_string(node.names)}"
+        lazy = "lazy " if node.lazy else ""
+        return f"{lazy}import {_import_string(node.names)}"
 
     def visit_keyword(self, node: nodes.Keyword) -> str:
         """return an nodes.Keyword node as string"""

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2817,7 +2817,7 @@ class ImportFrom(_base_nodes.ImportNode):
     <ImportFrom l.1 at 0x7f23b2e415c0>
     """
 
-    _other_fields = ("modname", "names", "level")
+    _other_fields = ("modname", "names", "level", "lazy")
 
     def __init__(
         self,
@@ -2830,6 +2830,7 @@ class ImportFrom(_base_nodes.ImportNode):
         *,
         end_lineno: int | None = None,
         end_col_offset: int | None = None,
+        lazy: bool = False,
     ) -> None:
         """
         :param fromname: The module that is being imported from.
@@ -2837,6 +2838,8 @@ class ImportFrom(_base_nodes.ImportNode):
         :param names: What is being imported from the module.
 
         :param level: The level of relative import.
+
+        :param lazy: Whether this is a PEP 810 lazy import (``lazy from ...``).
 
         :param lineno: The line that this node appears on in the source code.
 
@@ -2868,6 +2871,12 @@ class ImportFrom(_base_nodes.ImportNode):
 
         Essentially this is the number of dots in the import.
         This is ``None`` for absolute imports.
+        """
+
+        self.lazy: bool = lazy
+        """Whether this is a PEP 810 lazy import (``lazy from ... import ...``).
+
+        Always ``False`` before Python 3.15.
         """
 
         super().__init__(
@@ -3162,7 +3171,7 @@ class Import(_base_nodes.ImportNode):
     <Import l.1 at 0x7f23b2e4e5c0>
     """
 
-    _other_fields = ("names",)
+    _other_fields = ("names", "lazy")
 
     def __init__(
         self,
@@ -3173,9 +3182,12 @@ class Import(_base_nodes.ImportNode):
         *,
         end_lineno: int | None = None,
         end_col_offset: int | None = None,
+        lazy: bool = False,
     ) -> None:
         """
         :param names: The names being imported.
+
+        :param lazy: Whether this is a PEP 810 lazy import (``lazy import ...``).
 
         :param lineno: The line that this node appears on in the source code.
 
@@ -3194,6 +3206,12 @@ class Import(_base_nodes.ImportNode):
 
         Each entry is a :class:`tuple` of the name being imported,
         and the alias that the name is assigned to (if any).
+        """
+
+        self.lazy: bool = lazy
+        """Whether this is a PEP 810 lazy import (``lazy import ...``).
+
+        Always ``False`` before Python 3.15.
         """
 
         super().__init__(

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1031,9 +1031,26 @@ class TreeRebuilder:
             end_col_offset=node.end_col_offset,
             parent=parent,
         )
+        key: nodes.NodeNG
+        if node.value is None:
+            # PEP 798 dict-comprehension unpacking, e.g. ``{**d for d in dicts}``.
+            # CPython stores the unpacked mapping in ``key`` and leaves
+            # ``value`` as ``None``. Mirror the ``ast.Dict`` representation of
+            # ``{**d}``: a ``DictUnpack`` key together with the real value.
+            value = self.visit(node.key, newnode)
+            key = nodes.DictUnpack(
+                lineno=value.lineno,
+                col_offset=value.col_offset,
+                end_lineno=value.end_lineno,
+                end_col_offset=value.end_col_offset,
+                parent=newnode,
+            )
+        else:
+            key = self.visit(node.key, newnode)
+            value = self.visit(node.value, newnode)
         newnode.postinit(
-            self.visit(node.key, newnode),
-            self.visit(node.value, newnode),
+            key,
+            value,
             [self.visit(child, newnode) for child in node.generators],
         )
         return newnode
@@ -1116,6 +1133,8 @@ class TreeRebuilder:
             end_lineno=node.end_lineno,
             end_col_offset=node.end_col_offset,
             parent=parent,
+            # ``is_lazy`` is a PEP 810 field only present on Python 3.15+.
+            lazy=bool(getattr(node, "is_lazy", False)),
         )
         # store From names to add them to locals after building
         self._import_from_nodes.append(
@@ -1318,6 +1337,8 @@ class TreeRebuilder:
             end_lineno=node.end_lineno,
             end_col_offset=node.end_col_offset,
             parent=parent,
+            # ``is_lazy`` is a PEP 810 field only present on Python 3.15+.
+            lazy=bool(getattr(node, "is_lazy", False)),
         )
         # save import names in parent's locals:
         for name, asname in newnode.names:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -31,7 +31,7 @@ from astroid import decorators as decoratorsmod
 from astroid.arguments import CallSite
 from astroid.bases import BoundMethod, Generator, Instance, UnboundMethod, UnionType
 from astroid.builder import AstroidBuilder, _extract_single_node, extract_node, parse
-from astroid.const import IS_PYPY, PY312_PLUS, PY314_PLUS
+from astroid.const import IS_PYPY, PY312_PLUS, PY314_PLUS, PY315_PLUS
 from astroid.context import CallContext, InferenceContext
 from astroid.exceptions import (
     AstroidTypeError,
@@ -2065,6 +2065,24 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             inferred = next(node.infer())
             self.assertIsInstance(inferred, Instance)
             self.assertEqual(inferred.qname(), "builtins.frozenset")
+
+    @pytest.mark.skipif(
+        not PY315_PLUS, reason="frozendict builtin added in 3.15 (PEP 814)"
+    )
+    def test_frozendict_builtin_inference(self) -> None:
+        node = extract_node("frozendict(x=1, y=2)")
+        inferred = next(node.infer())
+        self.assertIsInstance(inferred, Instance)
+        self.assertEqual(inferred.qname(), "builtins.frozendict")
+
+    @pytest.mark.skipif(
+        not PY315_PLUS, reason="sentinel builtin added in 3.15 (PEP 661)"
+    )
+    def test_sentinel_builtin_inference(self) -> None:
+        node = extract_node("sentinel('MISSING')")
+        inferred = next(node.infer())
+        self.assertIsInstance(inferred, Instance)
+        self.assertEqual(inferred.qname(), "builtins.sentinel")
 
     def test_set_builtin_inference(self) -> None:
         code = """

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -35,6 +35,7 @@ from astroid.const import (
     PY312_PLUS,
     PY313_PLUS,
     PY314_PLUS,
+    PY315_PLUS,
     Context,
 )
 from astroid.context import InferenceContext
@@ -531,6 +532,25 @@ class ImportNodeTest(resources.SysPathSetup, unittest.TestCase):
         super().setUp()
         self.module = resources.build_file("data/module.py", "data.module")
         self.module2 = resources.build_file("data/module2.py", "data.module2")
+
+    @pytest.mark.skipif(not PY315_PLUS, reason="PEP 810 lazy imports, new in 3.15")
+    def test_lazy_import(self) -> None:
+        node = extract_node("lazy import json")
+        assert isinstance(node, nodes.Import)
+        assert node.lazy is True
+        self.assertEqual(node.as_string(), "lazy import json")
+
+    @pytest.mark.skipif(not PY315_PLUS, reason="PEP 810 lazy imports, new in 3.15")
+    def test_lazy_import_from(self) -> None:
+        node = extract_node("lazy from pathlib import Path")
+        assert isinstance(node, nodes.ImportFrom)
+        assert node.lazy is True
+        self.assertEqual(node.as_string(), "lazy from pathlib import Path")
+
+    def test_eager_import_is_not_lazy(self) -> None:
+        # The ``lazy`` flag defaults to False on every supported version.
+        assert extract_node("import json").lazy is False
+        assert extract_node("from pathlib import Path").lazy is False
 
     def test_import_self_resolve(self) -> None:
         myos = next(self.module2.igetattr("myos"))

--- a/tests/test_python3.py
+++ b/tests/test_python3.py
@@ -9,6 +9,7 @@ import pytest
 
 from astroid import exceptions, nodes
 from astroid.builder import AstroidBuilder, extract_node
+from astroid.const import PY315_PLUS
 from astroid.manager import AstroidManager
 
 
@@ -234,6 +235,58 @@ class Python3TC(unittest.TestCase):
         code = "{'x': 1, **{'y': 2, **{'z': 3}}}"
         node = extract_node(code)
         self.assertEqual(node.as_string(), code)
+
+    @pytest.mark.skipif(
+        not PY315_PLUS, reason="PEP 798 unpacking in comprehensions, new in 3.15"
+    )
+    def test_unpacking_in_comprehensions(self) -> None:
+        list_comp = extract_node("[*L for L in lists]")
+        self.assertIsInstance(list_comp, nodes.ListComp)
+        self.assertIsInstance(list_comp.elt, nodes.Starred)
+
+        set_comp = extract_node("{*L for L in lists}")
+        self.assertIsInstance(set_comp, nodes.SetComp)
+        self.assertIsInstance(set_comp.elt, nodes.Starred)
+
+        gen_exp = extract_node("(*L for L in lists)")
+        self.assertIsInstance(gen_exp, nodes.GeneratorExp)
+        self.assertIsInstance(gen_exp.elt, nodes.Starred)
+
+    @pytest.mark.skipif(
+        not PY315_PLUS, reason="PEP 798 unpacking in comprehensions, new in 3.15"
+    )
+    def test_dict_unpacking_in_comprehension(self) -> None:
+        # CPython stores the unpacked mapping in ``DictComp.key`` and leaves
+        # ``value`` as ``None``; astroid mirrors the ``{**d}`` representation
+        # with a ``DictUnpack`` key and the real value.
+        node = extract_node("{**d for d in dicts}")
+        self.assertIsInstance(node, nodes.DictComp)
+        self.assertIsInstance(node.key, nodes.DictUnpack)
+        self.assertIsInstance(node.value, nodes.Name)
+        self.assertEqual(node.value.name, "d")
+
+    @pytest.mark.skipif(
+        not PY315_PLUS, reason="PEP 798 unpacking in comprehensions, new in 3.15"
+    )
+    def test_unpacking_in_comprehensions_as_string(self) -> None:
+        for code in (
+            "[*L for L in lists]",
+            "{*L for L in lists}",
+            "(*L for L in lists)",
+            "{**d for d in dicts}",
+        ):
+            self.assertEqual(extract_node(code).as_string(), code)
+
+    @pytest.mark.skipif(
+        not PY315_PLUS, reason="PEP 798 unpacking in comprehensions, new in 3.15"
+    )
+    def test_comprehension_target_resolves_inside_starred_elt(self) -> None:
+        # The comprehension target is in scope inside the starred element and
+        # infers to the iterated items.
+        node = extract_node("[*L for L in [[1, 2], [3, 4]]]")
+        self.assertIsInstance(node.elt, nodes.Starred)
+        inferred = [elt.as_string() for elt in node.elt.value.inferred()]
+        self.assertEqual(inferred, ["[1, 2]", "[3, 4]"])
 
     def test_unpacking_in_dict_getitem(self) -> None:
         node = extract_node("{1:2, **{2:3, 3:4}, **{5: 6}}")


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Description

Python 3.15 adds two AST-level constructs astroid did not model:

- PEP 798 dict-comprehension unpacking (``{**d for d in dicts}``). CPython stores the unpacked mapping in ``DictComp.key`` and leaves ``value`` as ``None``, which crashed the rebuilder. astroid now mirrors the ``{**d}`` Dict representation with a ``DictUnpack`` key, and ``as_string`` round-trips the construct.
- PEP 810 explicit lazy imports. ``Import`` and ``ImportFrom`` gain a ``lazy`` boolean attribute, set from CPython's ``is_lazy`` AST field and rendered by ``as_string``. Name binding and inference are unchanged.

List/set/generator comprehension unpacking already parsed; the new ``frozendict`` and ``sentinel`` builtins are inferred for free via raw-building. Tests live next to the feature they exercise (lazy imports in ImportNodeTest, comprehension unpacking in Python3TC, builtin inference in InferenceTest), gated with skipif(not PY315_PLUS).