### PR TITLE
Fix partial descriptor binding crash

### DIFF
--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -114,6 +114,8 @@ def _functools_partial_inference(
         name=inferred_wrapped_function.name,
         lineno=inferred_wrapped_function.lineno,
         col_offset=inferred_wrapped_function.col_offset,
+        end_lineno=inferred_wrapped_function.end_lineno,
+        end_col_offset=inferred_wrapped_function.end_col_offset,
         parent=node.parent,
     )
     partial_function.postinit(

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -468,7 +468,7 @@ class FunctionModel(ObjectModel):
                     "end_lineno": func.end_lineno,
                     "end_col_offset": func.end_col_offset,
                 }
-                if hasattr(func, "filled_args") and hasattr(func, "filled_keywords"):
+                if isinstance(func, astroid.objects.PartialFunction):
                     new_func_kwargs["filled_args"] = func.filled_args
                     new_func_kwargs["filled_keywords"] = func.filled_keywords
 

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -460,14 +460,19 @@ class FunctionModel(ObjectModel):
 
                 # Rebuild the original value, but with the parent set as the
                 # class where it will be bound.
-                new_func = func.__class__(
-                    name=func.name,
-                    lineno=func.lineno,
-                    col_offset=func.col_offset,
-                    parent=func.parent,
-                    end_lineno=func.end_lineno,
-                    end_col_offset=func.end_col_offset,
-                )
+                new_func_kwargs = {
+                    "name": func.name,
+                    "lineno": func.lineno,
+                    "col_offset": func.col_offset,
+                    "parent": func.parent,
+                    "end_lineno": func.end_lineno,
+                    "end_col_offset": func.end_col_offset,
+                }
+                if hasattr(func, "filled_args") and hasattr(func, "filled_keywords"):
+                    new_func_kwargs["filled_args"] = func.filled_args
+                    new_func_kwargs["filled_keywords"] = func.filled_keywords
+
+                new_func = func.__class__(**new_func_kwargs)
                 # pylint: disable=no-member
                 new_func.postinit(
                     func.args,

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -282,16 +282,33 @@ class DictValues(bases.Proxy):
 class PartialFunction(scoped_nodes.FunctionDef):
     """A class representing partial function obtained via functools.partial."""
 
-    def __init__(self, call, name=None, lineno=None, col_offset=None, parent=None):
-        # TODO: Pass end_lineno, end_col_offset as well
+    def __init__(
+        self,
+        call=None,
+        name=None,
+        lineno=None,
+        col_offset=None,
+        parent=None,
+        *,
+        end_lineno=None,
+        end_col_offset=None,
+        filled_args=None,
+        filled_keywords=None,
+    ):
         super().__init__(
             name,
             lineno=lineno,
             col_offset=col_offset,
-            end_col_offset=0,
-            end_lineno=0,
+            end_col_offset=end_col_offset,
+            end_lineno=end_lineno,
             parent=parent,
         )
+        if call is None:
+            self.filled_args = list(filled_args or [])
+            self.filled_keywords = dict(filled_keywords or {})
+            self.filled_positionals = len(self.filled_args)
+            return
+
         self.filled_args = call.positional_arguments[1:]
         self.filled_keywords = call.keyword_arguments
 

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -306,20 +306,20 @@ class PartialFunction(scoped_nodes.FunctionDef):
         if call is None:
             self.filled_args = list(filled_args or [])
             self.filled_keywords = dict(filled_keywords or {})
-            self.filled_positionals = len(self.filled_args)
-            return
+        else:
+            self.filled_args = call.positional_arguments[1:]
+            self.filled_keywords = call.keyword_arguments
 
-        self.filled_args = call.positional_arguments[1:]
-        self.filled_keywords = call.keyword_arguments
-
-        wrapped_function = call.positional_arguments[0]
-        inferred_wrapped_function = next(wrapped_function.infer())
-        if isinstance(inferred_wrapped_function, PartialFunction):
-            self.filled_args = inferred_wrapped_function.filled_args + self.filled_args
-            self.filled_keywords = {
-                **inferred_wrapped_function.filled_keywords,
-                **self.filled_keywords,
-            }
+            wrapped_function = call.positional_arguments[0]
+            inferred_wrapped_function = next(wrapped_function.infer())
+            if isinstance(inferred_wrapped_function, PartialFunction):
+                self.filled_args = (
+                    inferred_wrapped_function.filled_args + self.filled_args
+                )
+                self.filled_keywords = {
+                    **inferred_wrapped_function.filled_keywords,
+                    **self.filled_keywords,
+                }
 
         self.filled_positionals = len(self.filled_args)
 

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1607,6 +1607,30 @@ class TestFunctoolsPartial:
         assert partial.doc_node.value == "Docstring"
         assert partial.lineno == 3
         assert partial.col_offset == 0
+        assert partial.end_lineno == 5
+        assert partial.end_col_offset == 16
+
+    @staticmethod
+    def test_partial_descriptor_binding() -> None:
+        ast_nodes = astroid.extract_node("""
+        from functools import partial
+
+        def test(x):
+            return x
+
+        p = partial(test, x=1)
+        a = p.__get__({})
+        a #@
+        a() #@
+        """)
+        bound, result = ast_nodes
+        inferred_bound = next(bound.infer())
+        assert isinstance(inferred_bound, astroid.BoundMethod)
+        assert isinstance(inferred_bound._proxied._proxied, objects.PartialFunction)
+
+        inferred_result = next(result.infer())
+        assert isinstance(inferred_result, nodes.Const)
+        assert inferred_result.value == 1
 
     def test_invalid_functools_partial_calls(self) -> None:
         ast_nodes = astroid.extract_node("""


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This fixes a crash when astroid infers `functools.partial(...).__get__`.

`PartialFunction` now accepts the same end-location metadata used when function-like nodes are rebuilt for descriptor binding. Rebuilt partials also keep their pre-filled arguments and keywords, so calling the inferred bound method behaves like the original partial.

A regression test covers inferring the bound partial and calling it.

Closes #3090
