### PR TITLE
Fix .pyi stubs being shadowed by compiled modules in get_source_file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,7 @@ Release date: TBA
 
 * Fix ``.pyi`` stub files no longer being picked up when a compiled module
   (``.pyc``/``.pyo`` or a binary extension such as ``.so``/``.pyd``) sits next
-  to them. Compiled and bytecode extensions now fall through to the regular 
+  to them. Compiled and bytecode extensions now fall through to the regular
   stub/source lookup.
 
   Closes #3087

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,13 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Fix ``.pyi`` stub files no longer being picked up when a compiled module
+  (``.pyc``/``.pyo`` or a binary extension such as ``.so``/``.pyd``) sits next
+  to them. Compiled and bytecode extensions now fall through to the regular 
+  stub/source lookup.
+
+  Closes #3087
+
 * Fix astroid bootstrap crash on PyPy 7.3.22 (``TypeError: expected str, got
   getset_descriptor object``) by also catching ``TypeError`` from
   ``getattr(obj, alias)`` in ``InspectBuilder.object_build``. PyPy 7.3.22

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -42,6 +42,9 @@ else:
     PY_SOURCE_EXTS_STUBS_FIRST = ("pyi", "py")
     PY_COMPILED_EXTS = ("so",)
 
+# Bytecode extensions are platform-independent, unlike PY_COMPILED_EXTS above.
+PY_BYTECODE_EXTS = ("pyc", "pyo")
+
 
 # TODO: Adding `platstdlib` is a fix for a workaround in virtualenv. At some point we should
 # revisit whether this is still necessary. See https://github.com/pylint-dev/astroid/pull/1323.
@@ -480,6 +483,14 @@ def get_module_files(
     return files
 
 
+def _is_compiled_ext(ext: str) -> bool:
+    """Return whether ``ext`` (without leading dot) names a compiled module:
+    bytecode (.pyc/.pyo) or a binary extension module (.so/.pyd/.dll). Such
+    files are never source.
+    """
+    return ext in PY_BYTECODE_EXTS or ext in PY_COMPILED_EXTS
+
+
 def get_source_file(
     filename: str, include_no_ext: bool = False, prefer_stubs: bool = False
 ) -> str:
@@ -496,7 +507,14 @@ def get_source_file(
     filename = os.path.abspath(_path_from_filename(filename))
     base, orig_ext = os.path.splitext(filename)
     orig_ext = orig_ext.lstrip(".")
-    if orig_ext not in PY_SOURCE_EXTS and os.path.exists(f"{base}.{orig_ext}"):
+    # A non-standard extension (e.g. a custom suffix) is returned as-is, but a
+    # compiled file falls through to the lookup below so its .py/.pyi stub is
+    # found instead.
+    if (
+        orig_ext not in PY_SOURCE_EXTS
+        and not _is_compiled_ext(orig_ext)
+        and os.path.exists(f"{base}.{orig_ext}")
+    ):
         return f"{base}.{orig_ext}"
     for ext in PY_SOURCE_EXTS_STUBS_FIRST if prefer_stubs else PY_SOURCE_EXTS:
         source_path = f"{base}.{ext}"
@@ -636,7 +654,7 @@ def _has_init(directory: str) -> str | None:
     else return None.
     """
     mod_or_pack = os.path.join(directory, "__init__")
-    for ext in (*PY_SOURCE_EXTS, "pyc", "pyo"):
+    for ext in (*PY_SOURCE_EXTS, *PY_BYTECODE_EXTS):
         if os.path.exists(mod_or_pack + "." + ext):
             return mod_or_pack + "." + ext
     return None

--- a/doc/whatsnew/fragments/3087.bugfix
+++ b/doc/whatsnew/fragments/3087.bugfix
@@ -1,0 +1,7 @@
+``modutils.get_source_file`` no longer returns a compiled module as if it were
+source. Bytecode (``.pyc``/``.pyo``) and binary extension modules
+(``.so``/``.pyd``/``.dll``) now fall through to the regular stub/source lookup,
+so a ``.pyi`` stub sitting next to a compiled module is found again instead of
+the compiled file being handed back and then parsed as source.
+
+Closes #3087

--- a/tests/test_modutils.py
+++ b/tests/test_modutils.py
@@ -410,9 +410,7 @@ class GetSourceFileTest(unittest.TestCase):
             compiled = os.path.join(directory, "mod.pyc")
             with open(compiled, "wb"):
                 pass
-            self.assertRaises(
-                modutils.NoSourceFile, modutils.get_source_file, compiled
-            )
+            self.assertRaises(modutils.NoSourceFile, modutils.get_source_file, compiled)
 
 
 class IsStdLibModuleTest(resources.SysPathSetup, unittest.TestCase):

--- a/tests/test_modutils.py
+++ b/tests/test_modutils.py
@@ -375,6 +375,45 @@ class GetSourceFileTest(unittest.TestCase):
                 module,
             )
 
+    def test_compiled_prefers_stub(self) -> None:
+        """A compiled module handed in directly should resolve to its stub
+        rather than being returned as-is.
+
+        Regression test for https://github.com/pylint-dev/astroid/issues/3087:
+        a ``.pyc`` (or binary extension) sitting next to a ``.pyi`` must not be
+        returned as source.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            base = os.path.join(directory, "mod")
+            stub = base + ".pyi"
+            with open(stub, "w", encoding="utf-8"):
+                pass
+            for compiled_ext in ("pyc", "pyo", *modutils.PY_COMPILED_EXTS):
+                compiled = f"{base}.{compiled_ext}"
+                with open(compiled, "wb"):
+                    pass
+                self.assertEqual(
+                    modutils.get_source_file(compiled),
+                    os.path.normpath(stub),
+                )
+                self.assertEqual(
+                    modutils.get_source_file(compiled, prefer_stubs=True),
+                    os.path.normpath(stub),
+                )
+                os.remove(compiled)
+
+    def test_compiled_without_stub_raises(self) -> None:
+        """A compiled module with no source/stub alongside it has no source
+        file and must raise, not return the compiled file itself.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            compiled = os.path.join(directory, "mod.pyc")
+            with open(compiled, "wb"):
+                pass
+            self.assertRaises(
+                modutils.NoSourceFile, modutils.get_source_file, compiled
+            )
+
 
 class IsStdLibModuleTest(resources.SysPathSetup, unittest.TestCase):
     """

--- a/tests/test_modutils.py
+++ b/tests/test_modutils.py
@@ -375,6 +375,43 @@ class GetSourceFileTest(unittest.TestCase):
                 module,
             )
 
+    def test_compiled_prefers_stub(self) -> None:
+        """A compiled module handed in directly should resolve to its stub
+        rather than being returned as-is.
+
+        Regression test for https://github.com/pylint-dev/astroid/issues/3087:
+        a ``.pyc`` (or binary extension) sitting next to a ``.pyi`` must not be
+        returned as source.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            base = os.path.join(directory, "mod")
+            stub = base + ".pyi"
+            with open(stub, "w", encoding="utf-8"):
+                pass
+            for compiled_ext in ("pyc", "pyo", *modutils.PY_COMPILED_EXTS):
+                compiled = f"{base}.{compiled_ext}"
+                with open(compiled, "wb"):
+                    pass
+                self.assertEqual(
+                    modutils.get_source_file(compiled),
+                    os.path.normpath(stub),
+                )
+                self.assertEqual(
+                    modutils.get_source_file(compiled, prefer_stubs=True),
+                    os.path.normpath(stub),
+                )
+                os.remove(compiled)
+
+    def test_compiled_without_stub_raises(self) -> None:
+        """A compiled module with no source/stub alongside it has no source
+        file and must raise, not return the compiled file itself.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            compiled = os.path.join(directory, "mod.pyc")
+            with open(compiled, "wb"):
+                pass
+            self.assertRaises(modutils.NoSourceFile, modutils.get_source_file, compiled)
+
 
 class IsStdLibModuleTest(resources.SysPathSetup, unittest.TestCase):
     """


### PR DESCRIPTION


<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
https://github.com/pylint-dev/astroid/pull/2722 generalized ``get_source_file`` from "if handed a .pyi, return it" to "if handed any non-source extension, return it as-is". Unfortunately, that also matched compiled bytecode (.pyc/.pyo) and binary extension modules (.so/.pyd/.dll): when import machinery handed in a ``.pyc`` that had a ``.pyi`` stub beside it, the ``.pyc`` was returned and then parsed as source, failing with "wrong encoding".

Exclude bytecode and binary-extension suffixes from that branch so they fall through to the normal stub/source lookup. The existing non-standard-extension behavior (custom suffixes like ``.weird_ext``) is unchanged.

Closes #3087
