### PR TITLE
fix: avoid uncaught IndentationError when computing node positions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,14 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Fix uncaught ``IndentationError`` when parsing code whose lines end in
+  ``\r``: the slice of source tokenized to compute a class or function
+  ``position`` is split on ``\n`` only and could be misaligned with the AST
+  line numbers. Such nodes now simply have no position information, as
+  already done when ``tokenize`` raises ``TokenError``.
+
+  Closes #3091
+
 * Fix astroid bootstrap crash on PyPy 7.3.22 (``TypeError: expected str, got
   getset_descriptor object``) by also catching ``TypeError`` from
   ``getattr(obj, alias)`` in ``InspectBuilder.object_build``. PyPy 7.3.22

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -148,9 +148,12 @@ class TreeRebuilder:
                 start_token = None
             else:
                 return None
-        except TokenError:
-            # Malformed source can make ``generate_tokens`` raise (e.g. an
-            # unterminated bracket on Python < 3.12); no position info then.
+        except (TokenError, SyntaxError):
+            # ``generate_tokens`` can raise on input it cannot tokenize, e.g.
+            # ``TokenError`` for an unterminated bracket on Python < 3.12, or
+            # ``IndentationError`` when ``\r``-terminated lines make the slice
+            # of ``self._data`` (split on ``\n`` only) misaligned with the AST
+            # line numbers; no position info then.
             return None
 
         return Position(

--- a/tests/test_nodes_position.py
+++ b/tests/test_nodes_position.py
@@ -176,6 +176,23 @@ class TestNodePosition:
         assert node.position is None
 
     @staticmethod
+    def test_position_carriage_return_line_endings() -> None:
+        """Lines ending in ``\\r`` must not crash the build (#3091).
+
+        The tokenizer treats a lone ``\\r`` as a line terminator while the
+        source kept by the rebuilder is split on ``\\n`` only, so the slice
+        tokenized for the position can be misaligned and raise
+        ``IndentationError``; ``position`` is simply unavailable then.
+        """
+        module = builder.parse("\rclass C:\n def f():\n  1\n 2")
+        klass = module.body[0]
+        assert isinstance(klass, nodes.ClassDef)
+        func = klass.body[0]
+        assert isinstance(func, nodes.FunctionDef)
+        assert klass.position is None
+        assert func.position is None
+
+    @staticmethod
     def test_position_unnormalized_name() -> None:
         """No position info when the name token never matches ``node.name``.
 


### PR DESCRIPTION
## Description

`astroid.builder.parse('\rclass C:\n def f():\n  1\n 2')` raised an uncaught `IndentationError` even though CPython parses this code fine.

The tokenizer treats a lone `\r` as a line terminator, while `RebuildVisitor` keeps the source as `data.split("\n")`. For `\r`-terminated lines the two disagree on line numbers, so the slice that `_get_position_info` tokenizes to locate the keyword/name span can be misaligned (here it tokenizes `"  1\n 2"` for `f`, which dedents to a level that was never seen) and the C tokenizer on Python >= 3.12 raises `IndentationError` instead of `TokenError`.

This catches `SyntaxError` (the base of `IndentationError`) alongside the existing `TokenError` guard from #3075, so such nodes simply have no `position` information, the same degradation already chosen there. The AST-derived `lineno`/`col_offset` of the nodes are unaffected. `self._data` is only used by `_get_position_info`, so the misalignment cannot leak anywhere else.

The regression test uses the real input from the issue rather than a mock.

Note: the pylint pre-commit hook flags `astroid/rebuilder.py:123: E1136 (unsubscriptable-object)` for me, but it does so on an unmodified checkout too (latest pylint, `self._data` is guarded two lines above) — unrelated to this change.

Closes #3091
