### PR TITLE
Compute constraints in `and`, `or` operations

### DIFF
--- a/astroid/constraint.py
+++ b/astroid/constraint.py
@@ -243,27 +243,44 @@ class EqualityConstraint(Constraint):
 
 def get_constraints(
     expr: _NameNodes, frame: nodes.LocalsDictNodeNG
-) -> dict[nodes.If | nodes.IfExp, set[Constraint]]:
+) -> dict[nodes.If | nodes.IfExp | nodes.BoolOp, set[Constraint]]:
     """Returns the constraints for the given expression.
 
     The returned dictionary maps the node where the constraint was generated to the
     corresponding constraint(s).
 
     Constraints are computed statically by analysing the code surrounding expr.
-    Currently this only supports constraints generated from if conditions.
+    Currently this only supports constraints generated from if conditions and
+    preceding operands in boolean operations.
     """
     current_node: nodes.NodeNG | None = expr
-    constraints_mapping: dict[nodes.If | nodes.IfExp, set[Constraint]] = {}
+    constraints_mapping: dict[
+        nodes.If | nodes.IfExp | nodes.BoolOp, set[Constraint]
+    ] = {}
     while current_node is not None and current_node is not frame:
         parent = current_node.parent
+        constraints: set[Constraint] | None = None
+
         if isinstance(parent, (nodes.If, nodes.IfExp)):
             branch, _ = parent.locate_child(current_node)
-            constraints: set[Constraint] | None = None
             if branch == "body":
                 constraints = set(_match_constraint(expr, parent.test))
             elif branch == "orelse":
                 constraints = set(_match_constraint(expr, parent.test, invert=True))
+            if constraints:
+                constraints_mapping[parent] = constraints
 
+        elif isinstance(parent, nodes.BoolOp):
+            for index, value in enumerate(parent.values):
+                if value is current_node:
+                    constraints = set()
+                    for previous_value in parent.values[:index]:
+                        constraints.update(
+                            _match_constraint(
+                                expr, previous_value, invert=parent.op == "or"
+                            )
+                        )
+                    break
             if constraints:
                 constraints_mapping[parent] = constraints
         current_node = parent

--- a/astroid/constraint.py
+++ b/astroid/constraint.py
@@ -304,28 +304,44 @@ class _CompoundConstraint(Constraint):
 
 def get_constraints(
     expr: _NameNodes, frame: nodes.LocalsDictNodeNG
-) -> dict[nodes.NodeNG, set[Constraint]]:
+) -> dict[nodes.If | nodes.IfExp | nodes.BoolOp, set[Constraint]]:
     """Returns the constraints for the given expression.
 
     The returned dictionary maps the node where the constraint was generated to the
     corresponding constraint(s).
 
     Constraints are computed statically by analysing the code surrounding expr.
-    Currently this only supports constraints generated from if conditions and
-    comprehension conditions.
+    Currently this only supports constraints generated from if conditions,
+    comprehension conditions and preceding operands in boolean operations.
     """
     current_node: nodes.NodeNG | None = expr
-    constraints_mapping: dict[nodes.NodeNG, set[Constraint]] = {}
+    constraints_mapping: dict[
+        nodes.If | nodes.IfExp | nodes.BoolOp, set[Constraint]
+    ] = {}
     while current_node is not None and current_node is not frame:
         parent = current_node.parent
+        constraints: set[Constraint] | None = None
+
         if isinstance(parent, (nodes.If, nodes.IfExp)):
             branch, _ = parent.locate_child(current_node)
-            constraints: set[Constraint] | None = None
             if branch == "body":
                 constraints = set(_match_constraint(expr, parent.test))
             elif branch == "orelse":
                 constraints = set(_match_constraint(expr, parent.test, invert=True))
+            if constraints:
+                constraints_mapping[parent] = constraints
 
+        elif isinstance(parent, nodes.BoolOp):
+            for index, value in enumerate(parent.values):
+                if value is current_node:
+                    constraints = set()
+                    for previous_value in parent.values[:index]:
+                        constraints.update(
+                            _match_constraint(
+                                expr, previous_value, invert=parent.op == "or"
+                            )
+                        )
+                    break
             if constraints:
                 constraints_mapping[parent] = constraints
         elif isinstance(parent, nodes.Comprehension):

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -78,7 +78,7 @@ class InferenceContext:
         """Context that needs to be passed down through call stacks for call arguments."""
 
         self.constraints: dict[
-            str, dict[nodes.If | nodes.IfExp, set[constraint.Constraint]]
+            str, dict[nodes.If | nodes.IfExp | nodes.BoolOp, set[constraint.Constraint]]
         ] = {}
         """The constraints on nodes."""
 

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -77,7 +77,9 @@ class InferenceContext:
         self.extra_context: dict[SuccessfulInferenceResult, InferenceContext] = {}
         """Context that needs to be passed down through call stacks for call arguments."""
 
-        self.constraints: dict[str, dict[nodes.NodeNG, set[constraint.Constraint]]] = {}
+        self.constraints: dict[
+            str, dict[nodes.If | nodes.IfExp | nodes.BoolOp, set[constraint.Constraint]]
+        ] = {}
         """The constraints on nodes."""
 
     @property

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -717,7 +717,7 @@ def test_if_exp_instance_attr(
     assert len(inferred) == 2
     assert isinstance(inferred[0], nodes.Const)
     assert inferred[0].value == satisfy_val
-    assert inferred[1].value is Uninferable
+    assert inferred[1] is Uninferable
 
 
 @common_params(node="self.x")
@@ -740,7 +740,139 @@ def test_if_exp_instance_attr_varname_collision(
     assert len(inferred) == 2
     assert isinstance(inferred[0], nodes.Const)
     assert inferred[0].value == fail_val
-    assert inferred[1].value is Uninferable
+    assert inferred[1] is Uninferable
+
+
+@common_params(node="x")
+def test_and_op_apply_constraint_to_later_operand(
+    condition: str, satisfy_val: int | None, fail_val: int | None
+) -> None:
+    """Test that a constraint in an `and` operation is applied to the later operand."""
+    node1, node2 = builder.extract_node(f"""
+    def f1(x = {fail_val}):
+        if {condition} and x:  #@
+            pass
+
+    def f2(x = {satisfy_val}):
+        if ({condition}) and x:  #@
+            pass
+    """)
+
+    inferred = node1.test.values[1].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node2.test.values[1].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == satisfy_val
+    assert inferred[1] is Uninferable
+
+
+@common_params(node="x")
+def test_or_op_apply_constraint_to_later_operand(
+    condition: str, satisfy_val: int | None, fail_val: int | None
+) -> None:
+    """Test that a constraint in an `or` operation is applied to the later operand."""
+    node1, node2 = builder.extract_node(f"""
+    def f1(x = {fail_val}):
+        if ({condition}) or x:  #@
+            pass
+
+    def f2(x = {satisfy_val}):
+        if ({condition}) or x:  #@
+            pass
+    """)
+
+    inferred = node1.test.values[1].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == fail_val
+    assert inferred[1] is Uninferable
+
+    inferred = node2.test.values[1].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+
+@common_params(node="x")
+def test_bool_op_constraint_not_apply_to_earlier_operand(
+    condition: str, satisfy_val: int | None, fail_val: int | None
+) -> None:
+    """Test that a constraint in a boolean operation does not apply to the earlier operand."""
+    node1, node2 = builder.extract_node(f"""
+    def f1(x = {satisfy_val}):
+        if x or ({condition}):  #@
+            pass
+
+    def f2(x = {fail_val}):
+        if x and ({condition}):  #@
+            pass
+    """)
+
+    inferred = node1.test.values[0].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == satisfy_val
+    assert inferred[1] is Uninferable
+
+    inferred = node2.test.values[0].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == fail_val
+    assert inferred[1] is Uninferable
+
+
+@common_params(node="x")
+def test_and_op_propagate_constraint_to_later_operand(
+    condition: str, satisfy_val: int | None, fail_val: int | None
+) -> None:
+    """Test that a constraint from an earlier `and` operand applies to a later operand."""
+    node1, node2 = builder.extract_node(f"""
+    def f1(y, x = {fail_val}):
+        if ({condition}) and y and x:  #@
+            pass
+
+    def f2(y, x = {satisfy_val}):
+        if ({condition}) and y and x:  #@
+            pass
+    """)
+
+    inferred = node1.test.values[2].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node2.test.values[2].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == satisfy_val
+    assert inferred[1] is Uninferable
+
+
+@common_params(node="x")
+def test_or_op_propagate_constraint_to_later_operand(
+    condition: str, satisfy_val: int | None, fail_val: int | None
+) -> None:
+    """Test that a constraint from an earlier `or` operand applies to a later operand."""
+    node1, node2 = builder.extract_node(f"""
+    def f1(y, x = {fail_val}):
+        if ({condition}) or y or x:  #@
+            pass
+
+    def f2(y, x = {satisfy_val}):
+        if ({condition}) or y or x:  #@
+            pass
+    """)
+
+    inferred = node1.test.values[2].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == fail_val
+    assert inferred[1] is Uninferable
+
+    inferred = node2.test.values[2].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
 
 
 def test_isinstance_equal_types() -> None:
@@ -1141,3 +1273,65 @@ def test_equality_fractions():
         assert isinstance(inferred[0], Instance), msg
         assert isinstance(inferred[0]._proxied, nodes.ClassDef), msg
         assert inferred[0]._proxied.name == "Fraction", msg
+
+
+def test_and_op_apply_all_previous_constraints() -> None:
+    """Test that constraints from all preceding operands in an `and` operation apply."""
+    node1, node2, node3 = builder.extract_node("""
+    def f1(x = None):
+        if x is not None and x != 1 and x:  #@
+            pass
+
+    def f2(x = 1):
+        if x is not None and x != 1 and x:  #@
+            pass
+
+    def f3(x = 3):
+        if x is not None and x != 1 and x:  #@
+            pass
+    """)
+
+    inferred = node1.test.values[2].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node2.test.values[2].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node3.test.values[2].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 3
+    assert inferred[1] is Uninferable
+
+
+def test_or_op_apply_all_previous_constraints() -> None:
+    """Test that constraints from all preceding operands in an `or` operation apply."""
+    node1, node2, node3 = builder.extract_node("""
+    def f1(x = None):
+        if x is None or x == 1 or x:  #@
+            pass
+
+    def f2(x = 1):
+        if x is None or x == 1 or x:  #@
+            pass
+
+    def f3(x = 3):
+        if x is None or x == 1 or x:  #@
+            pass
+    """)
+
+    inferred = node1.test.values[2].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node2.test.values[2].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node3.test.values[2].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 3
+    assert inferred[1] is Uninferable

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -719,7 +719,7 @@ def test_if_exp_instance_attr(
     assert len(inferred) == 2
     assert isinstance(inferred[0], nodes.Const)
     assert inferred[0].value == satisfy_val
-    assert inferred[1].value is Uninferable
+    assert inferred[1] is Uninferable
 
 
 @common_params(node="self.x")
@@ -742,7 +742,139 @@ def test_if_exp_instance_attr_varname_collision(
     assert len(inferred) == 2
     assert isinstance(inferred[0], nodes.Const)
     assert inferred[0].value == fail_val
-    assert inferred[1].value is Uninferable
+    assert inferred[1] is Uninferable
+
+
+@common_params(node="x")
+def test_and_op_apply_constraint_to_later_operand(
+    condition: str, satisfy_val: int | None, fail_val: int | None
+) -> None:
+    """Test that a constraint in an `and` operation is applied to the later operand."""
+    node1, node2 = builder.extract_node(f"""
+    def f1(x = {fail_val}):
+        if {condition} and x:  #@
+            pass
+
+    def f2(x = {satisfy_val}):
+        if ({condition}) and x:  #@
+            pass
+    """)
+
+    inferred = node1.test.values[1].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node2.test.values[1].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == satisfy_val
+    assert inferred[1] is Uninferable
+
+
+@common_params(node="x")
+def test_or_op_apply_constraint_to_later_operand(
+    condition: str, satisfy_val: int | None, fail_val: int | None
+) -> None:
+    """Test that a constraint in an `or` operation is applied to the later operand."""
+    node1, node2 = builder.extract_node(f"""
+    def f1(x = {fail_val}):
+        if ({condition}) or x:  #@
+            pass
+
+    def f2(x = {satisfy_val}):
+        if ({condition}) or x:  #@
+            pass
+    """)
+
+    inferred = node1.test.values[1].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == fail_val
+    assert inferred[1] is Uninferable
+
+    inferred = node2.test.values[1].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+
+@common_params(node="x")
+def test_bool_op_constraint_not_apply_to_earlier_operand(
+    condition: str, satisfy_val: int | None, fail_val: int | None
+) -> None:
+    """Test that a constraint in a boolean operation does not apply to the earlier operand."""
+    node1, node2 = builder.extract_node(f"""
+    def f1(x = {satisfy_val}):
+        if x or ({condition}):  #@
+            pass
+
+    def f2(x = {fail_val}):
+        if x and ({condition}):  #@
+            pass
+    """)
+
+    inferred = node1.test.values[0].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == satisfy_val
+    assert inferred[1] is Uninferable
+
+    inferred = node2.test.values[0].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == fail_val
+    assert inferred[1] is Uninferable
+
+
+@common_params(node="x")
+def test_and_op_propagate_constraint_to_later_operand(
+    condition: str, satisfy_val: int | None, fail_val: int | None
+) -> None:
+    """Test that a constraint from an earlier `and` operand applies to a later operand."""
+    node1, node2 = builder.extract_node(f"""
+    def f1(y, x = {fail_val}):
+        if ({condition}) and y and x:  #@
+            pass
+
+    def f2(y, x = {satisfy_val}):
+        if ({condition}) and y and x:  #@
+            pass
+    """)
+
+    inferred = node1.test.values[2].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node2.test.values[2].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == satisfy_val
+    assert inferred[1] is Uninferable
+
+
+@common_params(node="x")
+def test_or_op_propagate_constraint_to_later_operand(
+    condition: str, satisfy_val: int | None, fail_val: int | None
+) -> None:
+    """Test that a constraint from an earlier `or` operand applies to a later operand."""
+    node1, node2 = builder.extract_node(f"""
+    def f1(y, x = {fail_val}):
+        if ({condition}) or y or x:  #@
+            pass
+
+    def f2(y, x = {satisfy_val}):
+        if ({condition}) or y or x:  #@
+            pass
+    """)
+
+    inferred = node1.test.values[2].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == fail_val
+    assert inferred[1] is Uninferable
+
+    inferred = node2.test.values[2].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
 
 
 def test_isinstance_equal_types() -> None:
@@ -1463,3 +1595,65 @@ def test_expression_with_non_constraint_is_ignored(
     assert len(inferred) == 1
     assert isinstance(inferred[0], nodes.Const)
     assert inferred[0].value == value
+
+
+def test_and_op_apply_all_previous_constraints() -> None:
+    """Test that constraints from all preceding operands in an `and` operation apply."""
+    node1, node2, node3 = builder.extract_node("""
+    def f1(x = None):
+        if x is not None and x != 1 and x:  #@
+            pass
+
+    def f2(x = 1):
+        if x is not None and x != 1 and x:  #@
+            pass
+
+    def f3(x = 3):
+        if x is not None and x != 1 and x:  #@
+            pass
+    """)
+
+    inferred = node1.test.values[2].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node2.test.values[2].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node3.test.values[2].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 3
+    assert inferred[1] is Uninferable
+
+
+def test_or_op_apply_all_previous_constraints() -> None:
+    """Test that constraints from all preceding operands in an `or` operation apply."""
+    node1, node2, node3 = builder.extract_node("""
+    def f1(x = None):
+        if x is None or x == 1 or x:  #@
+            pass
+
+    def f2(x = 1):
+        if x is None or x == 1 or x:  #@
+            pass
+
+    def f3(x = 3):
+        if x is None or x == 1 or x:  #@
+            pass
+    """)
+
+    inferred = node1.test.values[2].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node2.test.values[2].inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node3.test.values[2].inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 3
+    assert inferred[1] is Uninferable


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

Currently, constraints are applied when inferring values inside conditional branches:
```
x = None

if x is not None:
    x  # `None` is filtered out
```

This PR extends constraint inference to later operands of `and`, `or` operations:
```
x = None

if x is not None and x:  # `None` is filtered out for rightmost `x`
    pass

if x is None or x:  # `None` is filtered out for rightmost `x`
    pass
```

For `and`, constraints from preceding operands are applied directly. For `or`, they are inverted because a later operand is evaluated only when all preceding operands are falsy. Constraints from multiple preceding operands are accumulated.

Operands that do not constrain the inferred value do not affect inference:
```
x, y = None, None

if y and x:  # `x` is inferred as `None`
    pass
```

The implementation supports flat boolean operations with any number of operands. Nested `BoolOp` operands are not yet decomposed:
```
x = None

if (x and x is None) and x:  # rightmost `x` is still inferred as `None`
    pass

if not x and x is None or x:  # rightmost `x` is still inferred as `None`
    pass
``` 

Support for these nested cases should be handled in #2977.

<!-- If this PR references an issue without fixing it: -->

Refs https://github.com/pylint-dev/pylint/issues/1498

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

