### PR TITLE
cap oversized str/bytes multiply and shift in const_infer_binary_op

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,13 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Bound string/bytes multiplication (``"x" * n``) and integer left shifts
+  (``1 << n``) in ``const_infer_binary_op`` the same way list/tuple
+  multiplication and ``**`` already are. Inferring a constant such as
+  ``"A" * 10 ** 10`` previously materialized the multi-gigabyte result
+  eagerly; these operations now infer as ``Uninferable`` when the result
+  would be oversized.
+
 * Fix uncaught ``IndentationError`` when parsing code whose lines end in
   ``\r``: the slice of source tokenized to compute a class or function
   ``position`` is split on ``\n`` only and could be misaligned with the AST

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,7 +14,7 @@ Release date: TBA
   eagerly; these operations now infer as ``Uninferable`` when the result
   would be oversized.
 
-Refs #3107 
+Refs #3107
 
 * Fix uncaught ``IndentationError`` when parsing code whose lines end in
   ``\r``: the slice of source tokenized to compute a class or function

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,8 @@ Release date: TBA
   eagerly; these operations now infer as ``Uninferable`` when the result
   would be oversized.
 
+Refs #3107 
+
 * Fix uncaught ``IndentationError`` when parsing code whose lines end in
   ``\r``: the slice of source tokenized to compute a class or function
   ``position`` is split on ``\n`` only and could be misaligned with the AST

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -118,6 +118,30 @@ def const_infer_binary_op(
         ):
             yield not_implemented
             return
+        # Repeating a str/bytes by a large count ("x" * n or n * "x") would
+        # eagerly build the whole object, the same way list/tuple repetition
+        # is bounded in _multiply_seq_by_int. Don't materialize it.
+        if operator == "*":
+            sequence, count = self.value, other.value
+            if isinstance(sequence, int) and isinstance(count, (str, bytes)):
+                sequence, count = count, sequence
+            if (
+                isinstance(sequence, (str, bytes))
+                and isinstance(count, int)
+                and len(sequence) * count > 1e8
+            ):
+                yield util.Uninferable
+                return
+        # Left-shifting by a large amount builds an enormous int, the integer
+        # analog of the ** guard above.
+        if (
+            operator == "<<"
+            and isinstance(self.value, int)
+            and isinstance(other.value, int)
+            and other.value > 1e8
+        ):
+            yield util.Uninferable
+            return
         try:
             impl = BIN_OP_IMPL[operator]
             try:

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -334,6 +334,33 @@ class ProtocolTests(unittest.TestCase):
         parsed = extract_node("[0] * -9223372036854775809")
         assert parsed.inferred()[0].elts == []
 
+    @staticmethod
+    def test_uninferable_string_multiplication() -> None:
+        """Building the repeated string would be prohibitively expensive."""
+        parsed = extract_node('"abc" * 123456789')
+        assert parsed.inferred() == [Uninferable]
+
+        # The reflected form (int * str) must be bounded too.
+        parsed = extract_node('123456789 * "abc"')
+        assert parsed.inferred() == [Uninferable]
+
+    @staticmethod
+    def test_uninferable_bytes_multiplication() -> None:
+        """Building the repeated bytes would be prohibitively expensive."""
+        parsed = extract_node('b"abc" * 123456789')
+        assert parsed.inferred() == [Uninferable]
+
+    @staticmethod
+    def test_string_multiplication_with_zero_multiplier() -> None:
+        parsed = extract_node('"abc" * 0')
+        assert parsed.inferred()[0].value == ""
+
+    @staticmethod
+    def test_uninferable_left_shift() -> None:
+        """The shifted integer would be prohibitively expensive to build."""
+        parsed = extract_node("1 << 123456789")
+        assert parsed.inferred() == [Uninferable]
+
 
 def test_named_expr_inference() -> None:
     code = """


### PR DESCRIPTION
## Type of Changes

|     | Type           |
| --- | -------------- |
| ✓   | :bug: Bug fix  |

## Description

const_infer_binary_op evaluates `BIN_OP_IMPL[operator](self.value, other.value)` eagerly when both operands are Const. list/tuple repetition is already bounded in `_multiply_seq_by_int` and `**` is bounded inline, but string/bytes multiplication (`"x" * n` and the reflected `n * "x"`) and integer left shift (`1 << n`) were not, so inferring a small literal like `"A" * 10 ** 10` materializes a multi-gigabyte object during inference of otherwise untrusted source. bound both the same way the sibling sequence and power paths already are: yield Uninferable once `len(seq) * count` or the shift amount would be oversized, before the value is built. small ops (`"ab" * 3`, `1 << 20`, `"a" * 0`) keep inferring their exact values.
