### PR TITLE
bound oversized format width and precision during inference

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,12 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Avoid materializing a multi-gigabyte string while inferring a small literal
+  such as ``"{:>2000000000}".format("x")`` or ``f"{1.5:.2000000000f}"``.
+  ``_infer_str_format_call`` and ``FormattedValue._infer`` now yield
+  ``Uninferable`` when a format spec asks for a width or precision over 1e8,
+  mirroring the sequence/repetition caps in ``astroid.protocols``.
+
 * Fix uncaught ``IndentationError`` when parsing code whose lines end in
   ``\r``: the slice of source tokenized to compute a class or function
   ``position`` is split on ``\n`` only and could be misaligned with the AST

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import itertools
+import string
 from collections.abc import Callable, Iterable, Iterator
 from functools import partial
 from typing import TYPE_CHECKING, Any, NoReturn, cast
@@ -1046,6 +1047,13 @@ def _infer_str_format_call(
         inferred_keyword[k] = one_inferred
 
     keyword_values: dict[str, str] = {k: v.value for k, v in inferred_keyword.items()}
+
+    try:
+        fields = list(string.Formatter().parse(format_template))
+    except ValueError:
+        return iter([util.Uninferable])
+    if any(spec and util.format_spec_too_large(spec) for _, _, spec, _ in fields):
+        return iter([util.Uninferable])
 
     try:
         formatted_string = format_template.format(*pos_values, **keyword_values)

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import itertools
-import string
 from collections.abc import Callable, Iterable, Iterator
 from functools import partial
 from typing import TYPE_CHECKING, Any, NoReturn, cast
@@ -1047,6 +1046,8 @@ def _infer_str_format_call(
         inferred_keyword[k] = one_inferred
 
     keyword_values: dict[str, str] = {k: v.value for k, v in inferred_keyword.items()}
+
+    import string  # pylint: disable=import-outside-toplevel
 
     try:
         fields = list(string.Formatter().parse(format_template))

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4707,6 +4707,12 @@ class FormattedValue(NodeNG):
                 value_to_format = value
                 if isinstance(value, Const):
                     value_to_format = value.value
+                if isinstance(format_spec.value, str) and util.format_spec_too_large(
+                    format_spec.value
+                ):
+                    yield util.Uninferable
+                    uninferable_already_generated = True
+                    continue
                 try:
                     formatted = format(value_to_format, format_spec.value)
                     yield Const(

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import re
 import warnings
 from typing import TYPE_CHECKING, Any, Final, Literal
 
@@ -49,6 +50,30 @@ class UninferableBase:
 
 
 Uninferable: Final = UninferableBase()
+
+# Width/precision in a format spec drive how large a formatted string gets.
+# Match the leading width and the optional ``.precision`` from the start of a
+# format spec (PEP 3101 / format mini-language).
+_FORMAT_SPEC_SIZE = re.compile(
+    r"(?:.?[<>=^])?[-+ ]?z?#?0?(?P<width>\d+)?(?:[,_])?(?:\.(?P<precision>\d+))?"
+)
+# Mirrors the sequence/repetition caps in astroid.protocols.
+MAX_FORMATTED_SIZE = 10**8
+
+
+def format_spec_too_large(format_spec: str) -> bool:
+    """Whether a format spec asks for an oversized width or precision.
+
+    Used to avoid materializing a multi-gigabyte string while inferring a tiny
+    literal such as ``"{:>2000000000}".format("x")`` or ``f"{1.5:.2e9f}"``.
+    """
+    match = _FORMAT_SPEC_SIZE.match(format_spec)
+    if match is None:  # pragma: no cover
+        return False
+    return any(
+        size is not None and int(size) > MAX_FORMATTED_SIZE
+        for size in match.group("width", "precision")
+    )
 
 
 class BadOperationMessage:

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -67,9 +67,8 @@ def format_spec_too_large(format_spec: str) -> bool:
     Used to avoid materializing a multi-gigabyte string while inferring a tiny
     literal such as ``"{:>2000000000}".format("x")`` or ``f"{1.5:.2e9f}"``.
     """
+    # Every group in _FORMAT_SPEC_SIZE is optional, so match is never None.
     match = _FORMAT_SPEC_SIZE.match(format_spec)
-    if match is None:  # pragma: no cover
-        return False
     return any(
         size is not None and int(size) > MAX_FORMATTED_SIZE
         for size in match.group("width", "precision")

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -5316,6 +5316,20 @@ def test_fstring_large_width_no_memory_error() -> None:
     assert inferred[0] is util.Uninferable
 
 
+@pytest.mark.parametrize(
+    "code",
+    [
+        "f'{1:>2000000000}'",
+        "f'{0:030000000000}'",
+        "f'{1.5:.2000000000f}'",
+    ],
+)
+def test_fstring_oversized_width_uninferable(code: str) -> None:
+    """A huge width/precision must not materialize a multi-gigabyte string."""
+    node = extract_node(code)
+    assert list(node.infer()) == [util.Uninferable]
+
+
 def test_augassign_recursion() -> None:
     """Make sure inference doesn't throw a RecursionError.
 
@@ -7177,6 +7191,19 @@ def test_empty_format_spec() -> None:
     assert isinstance(node, nodes.JoinedStr)
 
     assert list(node.infer()) == [util.Uninferable]
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        '"{:>2000000000}".format("x")',
+        '"{:.2000000000f}".format(1.5)',
+    ],
+)
+def test_str_format_oversized_width_uninferable(code: str) -> None:
+    """str.format() with a huge width/precision must stay Uninferable."""
+    node = _extract_single_node(code)
+    assert next(node.infer()) is util.Uninferable
 
 
 @pytest.mark.parametrize(

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7207,6 +7207,19 @@ def test_str_format_oversized_width_uninferable(code: str) -> None:
 
 
 @pytest.mark.parametrize(
+    "code",
+    [
+        '"{".format()',
+        '"}{".format()',
+    ],
+)
+def test_str_format_malformed_template_uninferable(code: str) -> None:
+    """A template Formatter().parse() rejects must stay Uninferable."""
+    node = _extract_single_node(code)
+    assert next(node.infer()) is util.Uninferable
+
+
+@pytest.mark.parametrize(
     "source, expected",
     [
         (


### PR DESCRIPTION
## Type of Changes

|     | Type           |
| --- | -------------- |
| ✓   | :bug: Bug fix  |

## Description

**Format-spec width/precision can materialize a multi-gigabyte string during inference**

A tiny literal like `"{:>2000000000}".format("x")` or `f"{1.5:.2000000000f}"` makes astroid eagerly run the format and build a 2 GB string while inferring otherwise untrusted source. `_infer_str_format_call` and `FormattedValue._infer` format with an attacker-controlled width/precision before checking its size; the existing `MemoryError` catch in `FormattedValue._infer` only fires once allocation actually OOMs, so on a machine with enough RAM it just succeeds and detonates. Both paths now read the width and precision out of the spec and yield Uninferable past 1e8, the same cap the sequence/repetition paths in `protocols.py` already use. Small specs keep inferring their exact values.