### PR TITLE
Remove `asname` kwarg from Import/ImportFrom `_infer`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,7 +14,24 @@ Release date: TBA
   eagerly; these operations now infer as ``Uninferable`` when the result
   would be oversized.
 
-Refs #3107
+  Refs #3107
+
+* Remove the ``asname`` keyword argument from ``Import._infer`` and
+  ``ImportFrom._infer``. The alias-to-real-name translation that
+  ``asname=True`` performed is now hoisted into ``ImportNode._infer_name``,
+  which runs in ``_infer_stmts`` before ``_infer`` is dispatched. Direct
+  callers of ``Import.infer`` / ``ImportFrom.infer`` (previously the
+  ``asname=False`` path) now consistently resolve the lookup name as-is.
+
+  The two flows used to collapse into a single inference cache entry
+  because the ``asname`` kwarg was not part of the cache key, so the
+  second call returned the cached result of the first regardless of
+  which one ran. With the translation hoisted upstream, the two flows
+  set different ``lookupname`` values and therefore land on distinct
+  cache keys, eliminating the collision.
+
+  Refs pylint-dev/pylint#10193
+  Closes #3007
 
 * Fix uncaught ``IndentationError`` when parsing code whose lines end in
   ``\r``: the slice of source tokenized to compute a class or function

--- a/astroid/nodes/_base_nodes.py
+++ b/astroid/nodes/_base_nodes.py
@@ -143,7 +143,10 @@ class ImportNode(FilterStmtsBaseNode, NoChildrenNode, Statement):
     """
 
     def _infer_name(self, frame, name):
-        return name
+        try:
+            return self.real_name(name)
+        except AttributeInferenceError:
+            return None
 
     def do_import_module(self, modname: str | None = None) -> nodes.Module:
         """Return the ast for a module whose name is <modname> imported by <self>."""

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2883,7 +2883,6 @@ class ImportFrom(_base_nodes.ImportNode):
     def _infer(
         self,
         context: InferenceContext | None = None,
-        asname: bool = True,
         **kwargs: Any,
     ) -> Generator[InferenceResult]:
         """Infer a ImportFrom node: return the imported module/object."""
@@ -2891,12 +2890,6 @@ class ImportFrom(_base_nodes.ImportNode):
         name = context.lookupname
         if name is None:
             raise InferenceError(node=self, context=context)
-        if asname:
-            try:
-                name = self.real_name(name)
-            except AttributeInferenceError as exc:
-                # See https://github.com/pylint-dev/pylint/issues/4692
-                raise InferenceError(node=self, context=context) from exc
         try:
             module = self.do_import_module()
         except AstroidBuildingError as exc:
@@ -3209,7 +3202,6 @@ class Import(_base_nodes.ImportNode):
     def _infer(
         self,
         context: InferenceContext | None = None,
-        asname: bool = True,
         **kwargs: Any,
     ) -> Generator[nodes.Module]:
         """Infer an Import node: return the imported module/object."""
@@ -3219,10 +3211,7 @@ class Import(_base_nodes.ImportNode):
             raise InferenceError(node=self, context=context)
 
         try:
-            if asname:
-                yield self.do_import_module(self.real_name(name))
-            else:
-                yield self.do_import_module(name)
+            yield self.do_import_module(name)
         except AstroidBuildingError as exc:
             raise InferenceError(node=self, context=context) from exc
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -29,7 +29,14 @@ from astroid import (
 )
 from astroid import decorators as decoratorsmod
 from astroid.arguments import CallSite
-from astroid.bases import BoundMethod, Generator, Instance, UnboundMethod, UnionType
+from astroid.bases import (
+    BoundMethod,
+    Generator,
+    Instance,
+    UnboundMethod,
+    UnionType,
+    _infer_stmts,
+)
 from astroid.builder import AstroidBuilder, _extract_single_node, extract_node, parse
 from astroid.const import IS_PYPY, PY312_PLUS, PY314_PLUS
 from astroid.context import CallContext, InferenceContext
@@ -1039,8 +1046,6 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         ``ImportNode._infer_name``, the two flows use distinct lookup
         names and therefore distinct cache keys.
         """
-        from astroid.bases import _infer_stmts
-
         import_node = extract_node("import os.path as os")
 
         # _infer_stmts is the path used when resolving a Name reference. It

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1023,6 +1023,45 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         ):
             import_node.do_import_module()
 
+    def test_import_alias_shadowing_module(self) -> None:
+        """An ``import x.y as x`` alias shadowing the head of its own dotted
+        name must not poison the inference cache.
+
+        Regression test for pylint-dev/pylint#10193: inferring the alias
+        name through ``_infer_stmts`` (which yields the real module ``x.y``)
+        used to share a cache key with a direct ``Import._infer`` call
+        (which is meant to resolve to the raw alias ``x``). The two
+        distinct semantics were collapsed because the cache key omitted
+        the differentiating kwarg, so the second call returned the cached
+        module from the first regardless of which one ran first.
+
+        After hoisting the ``real_name`` translation into
+        ``ImportNode._infer_name``, the two flows use distinct lookup
+        names and therefore distinct cache keys.
+        """
+        from astroid.bases import _infer_stmts
+
+        import_node = extract_node("import os.path as os")
+
+        # _infer_stmts is the path used when resolving a Name reference. It
+        # invokes ``_infer_name`` which now translates the alias before
+        # ``_infer`` runs, so the result is the aliased module ``os.path``.
+        translated_ctx = InferenceContext()
+        translated_ctx.lookupname = "os"
+        translated = list(_infer_stmts([import_node], translated_ctx))
+        self.assertEqual(len(translated), 1)
+        self.assertEqual(translated[0].name, "os.path")
+
+        # Direct ``Import._infer`` (the path pylint's
+        # ``_infer_name_module`` uses) resolves the lookup name as-is,
+        # yielding the raw stdlib ``os`` module. Pre-fix, this returned the
+        # cached ``os.path`` from the previous call.
+        raw_ctx = InferenceContext()
+        raw_ctx.lookupname = "os"
+        raw = list(import_node.infer(raw_ctx))
+        self.assertEqual(len(raw), 1)
+        self.assertEqual(raw[0].name, "os")
+
     def _test_const_inferred(self, node: nodes.AssignName, value: float | str) -> None:
         inferred = list(node.infer())
         self.assertEqual(len(inferred), 1)


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
|     | :bug: Bug fix          |
|     | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Description

Closes #3007
Refs pylint-dev/pylint#10193

Per @jacobtylerwalls's suggestion in #2992 — remove the `asname` keyword from `Import._infer` and `ImportFrom._infer` rather than thread it through the inference cache key. The translation that `asname=True` performed (`self.real_name(name)` on the `lookupname`) is hoisted into `ImportNode._infer_name`, the per-statement hook that `_infer_stmts` runs before dispatching `_infer`.

### Why the kwarg was load-bearing — and why removing it fixes pylint#10193

`node_ng.py` keys the inference cache on `(self, context.lookupname, context.callcontext, context.boundnode)`. The `asname` kwarg was *not* in that key, so two semantically distinct calls collapsed onto the same entry:

* The default `asname=True` flow (used by the implicit transforms astroid runs during `parse()`, by `_infer_stmts`, etc.) translated the alias to the underlying module name and returned the aliased module.
* The `asname=False` flow (used only by pylint's `_infer_name_module` in `pylint/checkers/variables.py`) skipped that translation and returned the raw alias's module.

Whichever ran first wrote its result into the cache; the second pulled it back unchanged. For `import my_module.utils as my_module` (#10193's repro) the implicit transforms cached `my_module.utils` first, so pylint's later `asname=False` call asking for `my_module` got `my_module.utils` instead. `_check_module_attrs` then walked the *wrong* module's `getattr` and reported a spurious `E0611: No name 'utils' in module 'my_module.utils'`.

I reproduced the collision locally with stdlib modules:

```python
import astroid
from astroid.context import InferenceContext, _invalidate_cache

code = "import os.path as os"
import_node = astroid.parse(code).body[0]
_invalidate_cache()

ctx_a = InferenceContext(); ctx_a.lookupname = "os"
print([r.name for r in import_node.infer(ctx_a)])               # ['os.path']  (asname=True default)

ctx_b = InferenceContext(); ctx_b.lookupname = "os"
print([r.name for r in import_node.infer(ctx_b, asname=False)]) # ['os.path']  ← wrong, should be ['os']
```

After this PR, the two flows reach `_infer` with different `lookupname` values (`os.path` vs `os`) and therefore land on different cache keys.

### What changed

1. **`astroid/nodes/_base_nodes.py`** — `ImportNode._infer_name` now calls `self.real_name(name)`, returning `None` when no alias maps to that name. Because `_infer_stmts` sets `context.lookupname` from the return value, returning `None` lets `_infer`'s existing `if name is None: raise InferenceError` guard handle the unresolvable case the same way the old `asname=True` branch did (preserving the handling of pylint#4692).
2. **`astroid/nodes/node_classes.py`** — drop the `asname` parameter from `ImportFrom._infer` and `Import._infer`. The bodies now unconditionally use the lookupname as-is. `**kwargs` still swallows any leftover `asname=` from external callers, so pylint's existing `node.infer(context, asname=False)` keeps working unchanged while it is updated downstream.
3. **`tests/test_inference.py`** — add `InferenceTest.test_import_alias_shadowing_module`, which runs `_infer_stmts` and then `import_node.infer(...)` against the same `import os.path as os` node, in the order that previously triggered the collision. The test asserts `_infer_stmts` returns `os.path` (alias translated upstream) and the direct `infer` returns the raw stdlib `os` (lookupname used as-is). Before this PR the second assertion failed with `'os.path' != 'os'`.
4. **`ChangeLog`** — entry under `astroid 4.2.0`.

### Tested

* `python -m pytest tests/test_inference.py` — 442 passed.
* `python -m pytest tests --ignore=tests/brain` — 1586 passed, 1 pre-existing unrelated failure (`test_get_relative_base_path.py::test_symlink_resolution`, fails on `main` too in this sandbox).
* `python -m pytest tests/brain --ignore=tests/brain/numpy` — 383 passed (excluding the unrelated `test_pydantic_field` failure that also reproduces on `main`).
* `ruff check astroid/nodes/_base_nodes.py astroid/nodes/node_classes.py tests/test_inference.py` — clean.
* `black --check` on the three changed source files — clean.
* The regression test fails on `main` (`'os.path' != 'os'`) and passes on this branch.

### Note for callers

Pylint's `pylint/checkers/variables.py::_infer_name_module` still passes `asname=False`. The PR keeps `**kwargs` on `_infer` so the call is silently accepted. A follow-up PR on the pylint side can drop the now-vestigial `asname=False` argument; this PR is intentionally scoped to astroid so the cache collision is resolved on the side that owns the cache.