### PR TITLE
Fix AttributeError in Arguments.assigned_stmts called without a context

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37,6 +37,13 @@ Release date: TBA
 
   Closes #2646
 
+* Fix ``AttributeError`` crash in the ``Arguments`` ``assigned_stmts``
+  protocol when called without an inference context (the public
+  ``assigned_stmts`` API defaults ``context`` to ``None``). Resolving a
+  function's first parameter dereferenced ``context.boundnode`` while the
+  matching ``context and ...`` guard a few lines below was missing; it now
+  degrades to Uninferable.
+
 * Wrap assignment expressions (``:=``) in parentheses when emitting
   ``as_string`` output so the rendered code remains syntactically valid in
   contexts such as comparisons, where Python requires the walrus expression

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -350,7 +350,7 @@ def assend_assigned_stmts(
 
 
 def _arguments_infer_argname(
-    self, name: str | None, context: InferenceContext
+    self, name: str | None, context: InferenceContext | None
 ) -> Generator[InferenceResult]:
     # arguments information may be missing, in which case we can't do anything
     # more
@@ -372,7 +372,11 @@ def _arguments_infer_argname(
         is_metaclass = isinstance(cls, nodes.ClassDef) and cls.type == "metaclass"
         # If this is a metaclass, then the first argument will always
         # be the class, not an instance.
-        if context.boundnode and isinstance(context.boundnode, bases.Instance):
+        if (
+            context
+            and context.boundnode
+            and isinstance(context.boundnode, bases.Instance)
+        ):
             cls = context.boundnode._proxied
         if is_metaclass or functype == "classmethod":
             yield cls

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -68,6 +68,19 @@ class ProtocolTests(unittest.TestCase):
         for2_assnode = next(assign_stmts[1].nodes_of_class(nodes.AssignName))
         self.assertRaises(InferenceError, list, for2_assnode.assigned_stmts())
 
+    def test_assigned_stmts_arguments_without_context(self) -> None:
+        # Regression: the Arguments assigned_stmts protocol may be called
+        # without an inference context (the public ``assigned_stmts`` API
+        # defaults it to None). Resolving a function's first parameter that way
+        # used to crash with ``AttributeError: 'NoneType' object has no
+        # attribute 'boundnode'``; it should degrade to Uninferable instead.
+        args = extract_node("""
+        def f(x, y):  #@
+            return x
+        """).args
+        assigned = list(args.assigned_stmts(node=args.args[0]))
+        self.assertEqual(assigned, [Uninferable])
+
     def test_assigned_stmts_nested_for_tuple(self) -> None:
         assign_stmts = extract_node("""
         for a, (b, c) in [(1, (2, 3))]:  #@


### PR DESCRIPTION
## Steps

`_arguments_infer_argname` dereferences `context.boundnode` while resolving a function's first parameter, but the public `assigned_stmts()` protocol API defaults `context` to `None` — `arguments_assigned_stmts` forwards it straight through (`return _arguments_infer_argname(self, node_name, context)`). So a context-less call crashes:

```python
import astroid
args = astroid.extract_node("def f(x, y): return x").args
list(args.assigned_stmts(node=args.args[0]))
# AttributeError: 'NoneType' object has no attribute 'boundnode'
```

The same function already guards `context` a few lines below (`if context and context.callcontext:`), as does the caller `arguments_assigned_stmts` — the `boundnode` check simply missed it. The parameter was also annotated `InferenceContext` even though it can be `None`.

## Fix

Add the missing `context and` guard and correct the annotation to `InferenceContext | None`. With no context there is no bound instance to resolve, so inference degrades to `Uninferable` (verified that normal `self`/`cls` inference through `.infer()`, which always supplies a context, is unchanged).

Includes a regression test in `tests/test_protocols.py` (red before / green after) and a `ChangeLog` entry. `tests/test_protocols.py` + `tests/test_inference.py` pass (467 passed, 3 skipped, 10 xfailed).

## Notes

Found by fuzzing the protocol APIs. It is not reachable through pylint's normal inference flow (where `@path_wrapper` substitutes a fresh `InferenceContext` for `None`), but it is reachable through the documented public `assigned_stmts()` API. This pull request was prepared with the assistance of AI, under my direction and review.
