### PR TITLE
Fix AttributeError in ClassDef.infer_call_result called without a call context

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,12 @@ Release date: TBA
   matching ``context and ...`` guard a few lines below was missing; it now
   degrades to Uninferable.
 
+* Fix ``AttributeError`` crash in ``ClassDef.infer_call_result`` when called
+  through the public API without a context (it defaults to ``None``) for a
+  class whose metaclass defines ``__call__``: the callee was assigned to
+  ``context.callcontext.callee`` without checking that a call context exists.
+  It is now guarded, matching the surrounding code.
+
 * Wrap assignment expressions (``:=``) in parentheses when emitting
   ``as_string`` output so the rendered code remains syntactically valid in
   contexts such as comparisons, where Python requires the walrus expression

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2106,7 +2106,11 @@ class ClassDef(
             # Call type.__call__ if not set metaclass
             # (since type is the default metaclass)
             context = bind_context_to_node(context, self)
-            context.callcontext.callee = dunder_call
+            # ``infer_call_result`` may be called through the public API without
+            # a call context (it defaults to None); only annotate the callee
+            # when there is a call context to annotate.
+            if context.callcontext:
+                context.callcontext.callee = dunder_call
             yield from dunder_call.infer_call_result(caller, context)
         else:
             yield self.instantiate_class()

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -2627,6 +2627,27 @@ def test_metaclass_cannot_infer_call_yields_an_instance() -> None:
     assert isinstance(inferred, Instance)
 
 
+def test_metaclass_call_result_without_context() -> None:
+    # Regression: ClassDef.infer_call_result may be called through the public
+    # API without a context (it defaults to None). For a class whose metaclass
+    # defines __call__, that path set context.callcontext.callee without
+    # guarding, crashing with "AttributeError: 'NoneType' object has no
+    # attribute 'callee'". It should infer the __call__ result instead.
+    call = builder.extract_node("""
+    class Meta(type):
+        def __call__(cls, *args, **kwargs):
+            return 42
+    class C(metaclass=Meta):
+        pass
+    C() #@
+    """)
+    cls = next(call.func.infer())
+    assert isinstance(cls, nodes.ClassDef)
+    for caller in (call, None):
+        inferred = list(cls.infer_call_result(caller=caller))
+        assert [getattr(n, "value", None) for n in inferred] == [42]
+
+
 @pytest.mark.parametrize(
     "func",
     [


### PR DESCRIPTION
## Steps

`ClassDef.infer_call_result(caller, context=None)` can be called through the public API without a context. For a class whose metaclass defines `__call__`, the metaclass branch does:

```python
context = bind_context_to_node(context, self)
context.callcontext.callee = dunder_call
```

`bind_context_to_node(None, ...)` returns a fresh `InferenceContext` whose `callcontext` is `None`, so the assignment crashes:

```python
import astroid
cls = next(astroid.extract_node('''
class Meta(type):
    def __call__(cls, *args, **kwargs): return 42
class C(metaclass=Meta): pass
C() #@
''').func.infer())
list(cls.infer_call_result(caller=None))
# AttributeError: 'NoneType' object has no attribute 'callee'
```

This is not reachable through normal `.infer()` (where `Call._infer` always supplies a `callcontext`), but it is reachable through the public `infer_call_result` API whose `context` is optional.

## Fix

Guard the assignment on `context.callcontext`. With no call context there is nothing to annotate, and inference of the `__call__` result proceeds normally — `infer_call_result(caller=None)` and `(caller=call)` now both yield `[<Const.int 42>]`, and normal `C().infer()` is unchanged.

Includes a regression test in `tests/test_scoped_nodes.py` (red before / green after). `tests/test_scoped_nodes.py` + `tests/test_inference.py` pass (615 passed).

## Notes

Same family as #3110 — an unguarded `context` / `context.callcontext` dereference reachable through a public inference API. Found by fuzzing the public APIs. This pull request was prepared with the assistance of AI, under my direction and review.
