### PR TITLE
Don't crash when a local package shadows the stdlib `multiprocessing`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,12 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Fix crash (``TypeError: 'UninferableBase' object is not iterable``) in the
+  ``multiprocessing`` brain when a local package shadows the stdlib
+  ``multiprocessing`` module.
+
+  Closes pylint-dev/pylint#10014
+
 * Fix uncaught ``IndentationError`` when parsing code whose lines end in
   ``\r``: the slice of source tokenized to compute a class or function
   ``position`` is split on ``\n`` only and could be misaligned with the AST

--- a/astroid/brain/brain_multiprocessing.py
+++ b/astroid/brain/brain_multiprocessing.py
@@ -8,6 +8,7 @@ from astroid.builder import parse
 from astroid.exceptions import InferenceError
 from astroid.manager import AstroidManager
 from astroid.nodes.scoped_nodes import FunctionDef
+from astroid.util import UninferableBase
 
 
 def _multiprocessing_transform():
@@ -28,6 +29,9 @@ def _multiprocessing_transform():
         context = next(node["default"].infer())
         base = next(node["base"].infer())
     except (InferenceError, StopIteration):
+        return module
+
+    if isinstance(context, UninferableBase) or isinstance(base, UninferableBase):
         return module
 
     for node in (context, base):

--- a/tests/brain/test_multiprocessing.py
+++ b/tests/brain/test_multiprocessing.py
@@ -10,6 +10,7 @@ import unittest
 
 import astroid
 from astroid import builder, nodes
+from astroid.manager import AstroidManager
 
 try:
     import multiprocessing  # pylint: disable=unused-import
@@ -107,3 +108,23 @@ class MultiprocessingBrainTest(unittest.TestCase):
         # Verify that we have these attributes
         self.assertTrue(manager.getattr("start"))
         self.assertTrue(manager.getattr("shutdown"))
+
+
+def test_multiprocessing_shadowed_by_local_package(tmp_path, monkeypatch) -> None:
+    """When a local package named ``multiprocessing`` shadows the stdlib one,
+    ``multiprocessing.context`` cannot be resolved and inference yields
+    ``Uninferable``. The brain must not crash trying to iterate its locals.
+    """
+    pkg = tmp_path / "multiprocessing"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    manager = AstroidManager()
+    # drop any cached stdlib ``multiprocessing``
+    manager.clear_cache()
+    try:
+        module = manager.ast_from_module_name("multiprocessing")
+        assert isinstance(module, nodes.Module)
+    finally:
+        manager.clear_cache()


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

When a local package named `multiprocessing` shadows the stdlib module, `multiprocessing.context` can't be resolved and inference yields `Uninferable`. The brain then crashed iterating its `locals` (`TypeError: 'UninferableBase' object is not iterable`). Guard against `Uninferable` before the loop.

Closes pylint-dev/pylint#10014
