### PR TITLE
Few fixes to brain_gi

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -126,6 +126,8 @@ Release date: TBA
 
   Closes #3068
 
+* Fix detecting static/class methods and inspecting IntFlag types in
+  GObject-based libraries (GLib, Gtk etc)
 
 What's New in astroid 4.1.2?
 ============================

--- a/astroid/brain/brain_gi.py
+++ b/astroid/brain/brain_gi.py
@@ -9,6 +9,7 @@ Helps with understanding everything imported from 'gi.repository'
 
 # pylint:disable=import-error,import-outside-toplevel
 
+import enum
 import inspect
 import itertools
 import re
@@ -130,6 +131,14 @@ def _gi_build_stub(parent):  # noqa: C901
         else:
             # Assume everything else is some manner of constant
             constants[name] = 0
+    # iterating enum.IntFlag doesn't include the zero value
+    if inspect.isclass(parent) and issubclass(parent, enum.IntFlag):
+        try:
+            zero_name = parent(0).name
+            if zero_name:
+                constants[zero_name] = 0
+        except TypeError:
+            pass
 
     ret = ""
 

--- a/astroid/brain/brain_gi.py
+++ b/astroid/brain/brain_gi.py
@@ -163,7 +163,17 @@ def _gi_build_stub(parent):  # noqa: C901
     if methods:
         ret += f"# {parent.__name__} methods\n\n"
     for name in sorted(methods):
-        ret += f"def {name}(self, *args, **kwargs):\n"
+        static = False
+        try:
+            if not methods[name].is_method():
+                static = True
+        except AttributeError:
+            pass
+        if static:
+            ret += "@staticmethod\n"
+            ret += f"def {name}(*args, **kwargs):\n"
+        else:
+            ret += f"def {name}(self, *args, **kwargs):\n"
         ret += "    pass\n"
 
     if ret:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Few fixes to brain_gi:
1. Fix enumerating `IntFlag`-based enums - the 0'th element isn't returned by `dir(parent)`, so add it manually. Otherwise pylint gives false positives like `Class 'OptionFlags' has no 'NONE' member (no-member)`
2. Add detecting static/class methods, otherwise pylint gives false positives like `No value for argument 'self' in unbound method call (no-value-for-parameter)`. This is re-surface of https://github.com/pylint-dev/astroid/issues/2594 in with gobject (unsure which version broke it, but at least gobject-introspection-1.86.0 is affected).
