### PR TITLE
Add brain tip for numpy.fromfile inference support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ Release date: TBA
   ``numpy.ndarray`` instead of ``Uninferable``.
 
   Closes #600
+
 * Removed the `**kwargs` argument from all `infer` functions.
   Users upgrading their `astroid` versions should ensure they do no pass values other than
   `context` to `infer`.

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,12 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Add brain tip for ``numpy.fromfile`` so that calls to
+  ``np.fromfile(...)`` are correctly inferred as returning
+  ``numpy.ndarray`` instead of ``Uninferable``.
+
+  Closes #600
+
 * Fix astroid bootstrap crash on PyPy 7.3.22 (``TypeError: expected str, got
   getset_descriptor object``) by also catching ``TypeError`` from
   ``getattr(obj, alias)`` in ``InspectBuilder.object_build``. PyPy 7.3.22

--- a/astroid/brain/brain_numpy_core_multiarray.py
+++ b/astroid/brain/brain_numpy_core_multiarray.py
@@ -43,6 +43,8 @@ METHODS_TO_BE_INFERRED = {
             return numpy.ndarray([0, 0])""",
     "empty": """def empty(shape, dtype=float, order='C'):
             return numpy.ndarray([0, 0])""",
+    "fromfile": """def fromfile(file, dtype=float, count=-1, sep='', offset=0):
+            return numpy.ndarray([0, 0])""",
     "bincount": """def bincount(x, weights=None, minlength=0):
             return numpy.ndarray([0, 0])""",
     "busday_count": """def busday_count(

--- a/tests/brain/numpy/test_core_multiarray.py
+++ b/tests/brain/numpy/test_core_multiarray.py
@@ -27,6 +27,7 @@ class BrainNumpyCoreMultiarrayTest(unittest.TestCase):
         ("datetime_as_string", "['2012-02', '2012-03']"),
         ("dot", "[1, 2]", "[1, 2]"),
         ("empty_like", "[1, 2]"),
+        ("fromfile", '"data.bin"'),
         ("inner", "[1, 2]", "[1, 2]"),
         ("is_busday", "['2011-07-01', '2011-07-02', '2011-07-18']"),
         ("lexsort", "(('toto', 'tutu'), ('riri', 'fifi'))"),


### PR DESCRIPTION
## What does this PR do?

This PR adds inference support for numpy.fromfile in astroid’s NumPy brain plugin. It teaches astroid that np.fromfile(...) returns a numpy.ndarray, consistent with other NumPy functions already defined in the brain plugin (e.g., zeros, ones, empty).

## Why was this PR needed?

Astroid is the static analysis engine used by pylint to understand Python code without executing it. It relies on "brain plugins" to infer behavior of external libraries like NumPy.

Previously, numpy.fromfile was missing from astroid’s brain plugin, which caused astroid to return "Uninferable" when analyzing calls to np.fromfile(...). This reduces the accuracy of static analysis in pylint and other tools built on astroid.

This PR fixes that gap by adding a proper brain entry and corresponding test case.

## What are the relevant issue numbers?

Closes #600

## Changes made

- Added "fromfile" entry to METHODS_TO_BE_INFERRED in astroid/brain/brain_numpy_core_multiarray.py
- Added test case for fromfile in tests/brain/numpy/test_core_multiarray.py

## Testing

- Ran pytest tests/brain/numpy/test_core_multiarray.py -v
- All existing tests pass
- New fromfile inference test passes

## Notes for reviewers

This follows the existing pattern used for other NumPy functions in the same file (zeros, ones, empty, etc.). No structural changes were made.
