### PR TITLE
cap str/bytes node expansion in container and dict.fromkeys inference

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,13 @@ Release date: TBA
 
   Closes pylint-dev/pylint#10014
 
+* Bound the number of nodes built when inferring ``list``/``set``/``tuple``/
+  ``frozenset`` and ``dict.fromkeys`` from a ``str``/``bytes`` constant. These
+  built one ``Const`` node per character with no cap, so ``list(("a" * 10 ** 8)
+  + "b")`` (concatenation is not size-bounded) materialized hundreds of millions
+  of nodes. They now fall back to the default inference past ``1e8`` characters,
+  matching the sequence-repetition guard.
+
 * Bound string/bytes multiplication (``"x" * n``) and integer left shifts
   (``1 << n``) in ``const_infer_binary_op`` the same way list/tuple
   multiplication and ``**`` already are. Inferring a constant such as

--- a/ChangeLog
+++ b/ChangeLog
@@ -93,6 +93,8 @@ Release date: TBA
   of nodes. They now fall back to the default inference past ``1e8`` characters,
   matching the sequence-repetition guard.
 
+Refs #3127 
+
 * Bound string/bytes multiplication (``"x" * n``) and integer left shifts
   (``1 << n``) in ``const_infer_binary_op`` the same way list/tuple
   multiplication and ``**`` already are. Inferring a constant such as

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -291,6 +291,12 @@ def _container_generic_transform(
             for item in arg.items
         ]
     elif isinstance(arg, nodes.Const) and isinstance(arg.value, (str, bytes)):
+        # Building one Const node per character would blow up the same way an
+        # oversized sequence repetition does in _multiply_seq_by_int. A string
+        # constant is only bounded by the source, and concatenation ("a" + "b")
+        # is not size-capped, so decline instead of materializing it.
+        if len(arg.value) > 1e8:
+            return None
         elts = arg.value
     else:
         return None
@@ -959,6 +965,11 @@ def infer_dict_fromkeys(node, context: InferenceContext | None = None):
     if isinstance(inferred_values, nodes.Const) and isinstance(
         inferred_values.value, (str, bytes)
     ):
+        # Same guard as the container builders: a str/bytes constant would
+        # produce one key node per character, so fall back rather than
+        # materializing an oversized dict.
+        if len(inferred_values.value) > 1e8:
+            return _build_dict_with_elements([])
         elements_with_value = [
             (nodes.Const(element), default) for element in inferred_values.value
         ]

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -49,6 +49,10 @@ OBJECT_DUNDER_NEW = "object.__new__"
 # eagerly build a multi-gigabyte string during inference.
 _MAX_FORMAT_FIELD_SIZE = int(1e8)
 
+# Largest str/bytes constant we are willing to expand into one node per
+# character when inferring container calls and dict.fromkeys.
+_MAX_INFERABLE_STR_LEN = int(1e8)
+
 
 @lru_cache(maxsize=1)
 def _get_bounded_formatter():
@@ -322,11 +326,8 @@ def _container_generic_transform(
             for item in arg.items
         ]
     elif isinstance(arg, nodes.Const) and isinstance(arg.value, (str, bytes)):
-        # Building one Const node per character would blow up the same way an
-        # oversized sequence repetition does in _multiply_seq_by_int. A string
-        # constant is only bounded by the source, and concatenation ("a" + "b")
-        # is not size-capped, so decline instead of materializing it.
-        if len(arg.value) > 1e8:
+        # Don't expand an oversized string into one Const node per character.
+        if len(arg.value) > _MAX_INFERABLE_STR_LEN:
             return None
         elts = arg.value
     else:
@@ -1008,10 +1009,8 @@ def infer_dict_fromkeys(node, context: InferenceContext | None = None):
     if isinstance(inferred_values, nodes.Const) and isinstance(
         inferred_values.value, (str, bytes)
     ):
-        # Same guard as the container builders: a str/bytes constant would
-        # produce one key node per character, so fall back rather than
-        # materializing an oversized dict.
-        if len(inferred_values.value) > 1e8:
+        # Same cap as the container builders above.
+        if len(inferred_values.value) > _MAX_INFERABLE_STR_LEN:
             return _build_dict_with_elements([])
         # Deduplicate the characters/bytes before building Const nodes so that a
         # compact but large string, e.g. dict.fromkeys("x" * 10**8), doesn't

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1587,6 +1587,30 @@ def test_infer_dict_from_keys() -> None:
         assert sorted(actual_values) == ["a", "b", "c"]
 
 
+def test_container_transform_oversized_str_declines() -> None:
+    """list/set/tuple/frozenset must not build one Const per character for a
+    huge str/bytes constant."""
+    for builtin in ("list", "set", "tuple", "frozenset"):
+        node = astroid.extract_node(f'{builtin}(("A" * 10 ** 8) + "B")')
+        inferred = next(node.infer())
+        assert isinstance(inferred, Instance)
+
+    # Small strings still infer their exact contents.
+    node = astroid.extract_node('list("abc")')
+    inferred = next(node.infer())
+    assert isinstance(inferred, nodes.List)
+    assert [elem.value for elem in inferred.elts] == ["a", "b", "c"]
+
+
+def test_infer_dict_fromkeys_oversized_str_declines() -> None:
+    """dict.fromkeys must not build one key per character for a huge str/bytes
+    constant."""
+    node = astroid.extract_node('dict.fromkeys(("A" * 10 ** 8) + "B")')
+    inferred = next(node.infer())
+    assert isinstance(inferred, nodes.Dict)
+    assert inferred.items == []
+
+
 class TestFunctoolsPartial:
     @staticmethod
     def test_infer_partial() -> None:

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -8,6 +8,7 @@ import io
 import re
 import sys
 import unittest
+from unittest.mock import patch
 
 import pytest
 
@@ -1589,11 +1590,12 @@ def test_infer_dict_from_keys() -> None:
 
 def test_container_transform_oversized_str_declines() -> None:
     """list/set/tuple/frozenset must not build one Const per character for a
-    huge str/bytes constant."""
-    for builtin in ("list", "set", "tuple", "frozenset"):
-        node = astroid.extract_node(f'{builtin}(("A" * 10 ** 8) + "B")')
-        inferred = next(node.infer())
-        assert isinstance(inferred, Instance)
+    str/bytes constant longer than the cap."""
+    with patch("astroid.brain.brain_builtin_inference._MAX_INFERABLE_STR_LEN", 4):
+        for builtin in ("list", "set", "tuple", "frozenset"):
+            node = astroid.extract_node(f'{builtin}("abcdef")')
+            inferred = next(node.infer())
+            assert isinstance(inferred, Instance)
 
     # Small strings still infer their exact contents.
     node = astroid.extract_node('list("abc")')
@@ -1603,12 +1605,13 @@ def test_container_transform_oversized_str_declines() -> None:
 
 
 def test_infer_dict_fromkeys_oversized_str_declines() -> None:
-    """dict.fromkeys must not build one key per character for a huge str/bytes
-    constant."""
-    node = astroid.extract_node('dict.fromkeys(("A" * 10 ** 8) + "B")')
-    inferred = next(node.infer())
-    assert isinstance(inferred, nodes.Dict)
-    assert inferred.items == []
+    """dict.fromkeys must not build one key per character for a str/bytes
+    constant longer than the cap."""
+    with patch("astroid.brain.brain_builtin_inference._MAX_INFERABLE_STR_LEN", 4):
+        node = astroid.extract_node('dict.fromkeys("abcdef")')
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.Dict)
+        assert inferred.items == []
 
 
 def test_infer_dict_from_keys_deduplicates() -> None:


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`_container_generic_transform` (for `list`/`set`/`tuple`/`frozenset`) and `infer_dict_fromkeys` build one `Const` node per character when their argument infers to a `str`/`bytes` constant, with no size cap. the multiply guard in `const_infer_binary_op` bounds `"x" * n`, but string concatenation (`"a" + "b"`) is not size-bounded and neither is a large literal, so `list(("a" * 10 ** 8) + "b")` walks the whole string and materializes ~100 million `Const` nodes (tens of GB) during inference of otherwise untrusted source. cap both sites the same way `_multiply_seq_by_int` already caps sequence repetition: fall back to the default inference once the string exceeds `1e8` characters, before the nodes are built. small calls (`list("abc")`, `dict.fromkeys("ab")`) keep inferring their exact contents.