### PR TITLE
Remove `kwargs` from `_infer`

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -76,6 +76,7 @@ Contributors
 - Enji Cooper <yaneurabeya@gmail.com>
 - Dani Alcala <112832187+clavedeluna@users.noreply.github.com>
 - Adrien Di Mascio <Adrien.DiMascio@logilab.fr>
+- Vincent Gao <gaobing1230@gmail.com>
 - tristanlatr <19967168+tristanlatr@users.noreply.github.com>
 - grayjk <grayjk@gmail.com>
 - emile@crater.logilab.fr <emile@crater.logilab.fr>
@@ -124,6 +125,7 @@ Contributors
 - mathieui <mathieui@users.noreply.github.com>
 - markmcclain <markmcclain@users.noreply.github.com>
 - jkmnt <git@firewood.fastmail.com>
+- Sai Asish Y <say.apm35@gmail.com>
 - ioanatia <ioanatia@users.noreply.github.com>
 - alm <alonme@users.noreply.github.com>
 - adam-grant-hendry <59346180+adam-grant-hendry@users.noreply.github.com>
@@ -223,6 +225,14 @@ Contributors
 - Alexander Scheel <alexander.m.scheel@gmail.com>
 - Alexander Presnyakov <flagist0@gmail.com>
 - Ahmed Azzaoui <ahmed.azzaoui@engie.com>
+- nanookclaw <nanook@agentmail.to>
+- SAY-5 <say.apm35@gmail.com>
+- Omkar Kabde <omkarkabde@gmail.com>
+- MJSHANG <shangmengjiajiajia@gmail.com>
+- Kyle D Kavanagh <kkavanagh@jumptrading.com>
+- KALI 834X <kali834x@gmail.com>
+- June <kimjune01@gmail.com>
+- Jam Balaya <jambalaya.pyoncafe@outlook.jp>
 
 Co-Author
 ---------

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,9 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Removed the `**kwargs` argument from all `infer` functions.
+  Users upgrading their `astroid` versions should ensure they do no pass values other than
+  `context` to `infer`.
 
 * Fix crash (``TypeError: 'UninferableBase' object is not iterable``) in the
   ``multiprocessing`` brain when a local package shadows the stdlib

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "4.2.0b3"
+__version__ = "4.2.0b4"
 version = __version__

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -146,7 +146,7 @@ class Proxy:
         return getattr(self._proxied, name)
 
     def infer(  # type: ignore[return]
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> collections.abc.Generator[InferenceResult, None, InferenceErrorInfo | None]:
         yield self
 

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import itertools
 from collections.abc import Callable, Iterable, Iterator
 from functools import partial
-from typing import TYPE_CHECKING, Any, NoReturn, cast
+from typing import TYPE_CHECKING, NoReturn, cast
 
 from astroid import arguments, helpers, nodes, objects, util
 from astroid.builder import AstroidBuilder
@@ -199,7 +199,7 @@ def register_builtin_transform(
     """
 
     def _transform_wrapper(
-        node: nodes.Call, context: InferenceContext | None = None, **kwargs: Any
+        node: nodes.Call, context: InferenceContext | None = None
     ) -> Iterator:
         result = transform(node, context=context)
         if result:
@@ -710,7 +710,8 @@ def infer_slice(node, context: InferenceContext | None = None):
 
 
 def _infer_object__new__decorator(
-    node: nodes.ClassDef, context: InferenceContext | None = None, **kwargs: Any
+    node: nodes.ClassDef,
+    context: InferenceContext | None = None,
 ) -> Iterator[Instance]:
     # Instantiate class immediately
     # since that's what @object.__new__ does
@@ -977,7 +978,7 @@ def infer_dict_fromkeys(node, context: InferenceContext | None = None):
 
 
 def _infer_copy_method(
-    node: nodes.Call, context: InferenceContext | None = None, **kwargs: Any
+    node: nodes.Call, context: InferenceContext | None = None
 ) -> Iterator[CopyResult]:
     assert isinstance(node.func, nodes.Attribute)
     inferred_orig, inferred_copy = itertools.tee(node.func.expr.infer(context=context))
@@ -1006,7 +1007,7 @@ def _is_str_format_call(node: nodes.Call) -> bool:
 
 
 def _infer_str_format_call(
-    node: nodes.Call, context: InferenceContext | None = None, **kwargs: Any
+    node: nodes.Call, context: InferenceContext | None = None
 ) -> Iterator[ConstFactoryResult | util.UninferableBase]:
     """Return a Const node based on the template and passed arguments."""
     call = arguments.CallSite.from_call(node, context=context)

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -30,9 +30,7 @@ def path_wrapper(func):
     """
 
     @functools.wraps(func)
-    def wrapped(
-        node, context: InferenceContext | None = None, _func=func, **kwargs
-    ) -> Generator:
+    def wrapped(node, context: InferenceContext | None = None, _func=func) -> Generator:
         """Wrapper function handling context."""
         if context is None:
             context = InferenceContext()
@@ -41,7 +39,7 @@ def path_wrapper(func):
 
         yielded = set()
 
-        for res in _func(node, context, **kwargs):
+        for res in _func(node, context):
             # unproxy only true instance, not const, tuple, dict...
             if res.__class__.__name__ == "Instance":
                 ares = res._proxied

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -39,7 +39,6 @@ def _inference_tip_cached(func: InferFn[_NodesT]) -> InferFn[_NodesT]:
     def inner(
         node: _NodesT,
         context: InferenceContext | None = None,
-        **kwargs: Any,
     ) -> Generator[InferenceResult]:
         partial_cache_key = (func, node)
         if partial_cache_key in _CURRENTLY_INFERRING:
@@ -62,9 +61,7 @@ def _inference_tip_cached(func: InferFn[_NodesT]) -> InferFn[_NodesT]:
             _CURRENTLY_INFERRING.add(partial_cache_key)
             try:
                 # May raise UseInferenceDefault
-                result = _cache[func, node, context] = list(
-                    func(node, context, **kwargs)
-                )
+                result = _cache[func, node, context] = list(func(node, context))
             except Exception as e:
                 # Suppress the KeyError from the cache miss.
                 raise e from None

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -339,11 +339,7 @@ class BaseContainer(_base_nodes.ParentAssignNode, Instance, metaclass=abc.ABCMet
         yield from self.elts
 
     @decorators.raise_if_nothing_inferred
-    def _infer(
-        self,
-        context: InferenceContext | None = None,
-        **kwargs: Any,
-    ) -> Iterator[Self]:
+    def _infer(self, context: InferenceContext | None = None) -> Iterator[Self]:
         has_starred_named_expr = any(
             isinstance(e, (Starred, NamedExpr)) for e in self.elts
         )
@@ -446,7 +442,7 @@ class AssignName(
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         """Infer an AssignName: need to inspect the RHS part of the
         assign node.
@@ -459,7 +455,7 @@ class AssignName(
 
     @decorators.raise_if_nothing_inferred
     def infer_lhs(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         """Infer a Name: use name lookup rules.
 
@@ -574,7 +570,7 @@ class Name(_base_nodes.LookupMixIn, _base_nodes.NoChildrenNode):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         """Infer a Name: use name lookup rules
 
@@ -1036,7 +1032,7 @@ class Arguments(
 
     @decorators.raise_if_nothing_inferred
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult]:
         # pylint: disable-next=import-outside-toplevel
         from astroid.protocols import _arguments_infer_argname
@@ -1088,9 +1084,7 @@ def _format_args(
 
 
 def _infer_attribute(
-    node: nodes.AssignAttr | nodes.Attribute,
-    context: InferenceContext | None = None,
-    **kwargs: Any,
+    node: nodes.AssignAttr | nodes.Attribute, context: InferenceContext | None = None
 ) -> Generator[InferenceResult, None, InferenceErrorInfo]:
     """Infer an AssignAttr/Attribute node by using getattr on the associated object."""
     # pylint: disable=import-outside-toplevel
@@ -1179,7 +1173,7 @@ class AssignAttr(_base_nodes.LookupMixIn, _base_nodes.ParentAssignNode):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         """Infer an AssignAttr: need to inspect the RHS part of the
         assign node.
@@ -1193,9 +1187,9 @@ class AssignAttr(_base_nodes.LookupMixIn, _base_nodes.ParentAssignNode):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def infer_lhs(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
-        return _infer_attribute(self, context, **kwargs)
+        return _infer_attribute(self, context)
 
 
 class Assert(_base_nodes.Statement):
@@ -1455,7 +1449,7 @@ class AugAssign(
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult]:
         return self._filter_operation_errors(
             self._infer_augassign, context, util.BadBinaryOperationMessage
@@ -1540,7 +1534,7 @@ class BinOp(_base_nodes.OperatorNode):
         return self.op != "**"
 
     def _infer_binop(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult]:
         """Binary operation inference logic."""
         left = self.left
@@ -1570,7 +1564,7 @@ class BinOp(_base_nodes.OperatorNode):
     @decorators.yes_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult]:
         return self._filter_operation_errors(
             self._infer_binop, context, util.BadBinaryOperationMessage
@@ -1647,7 +1641,7 @@ class BoolOp(NodeNG):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         """Infer a boolean operation (and / or / not).
 
@@ -1758,7 +1752,7 @@ class Call(NodeNG):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo]:
         """Infer a Call node by trying to guess what the function returns."""
         callcontext = copy_context(context)
@@ -1919,7 +1913,7 @@ class Compare(NodeNG):
         return retval  # it was all the same value
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[nodes.Const | util.UninferableBase]:
         """Chained comparison inference logic."""
         retval: bool | util.UninferableBase = True
@@ -2192,9 +2186,7 @@ class Const(_base_nodes.NoChildrenNode, Instance):
             return util.Uninferable if PY314_PLUS else True
         return bool(self.value)
 
-    def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
-    ) -> Iterator[Const]:
+    def _infer(self, context: InferenceContext | None = None) -> Iterator[Const]:
         yield self
 
 
@@ -2466,9 +2458,7 @@ class Dict(NodeNG, Instance):
         """
         return bool(self.items)
 
-    def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
-    ) -> Iterator[nodes.Dict]:
+    def _infer(self, context: InferenceContext | None = None) -> Iterator[nodes.Dict]:
         if not any(isinstance(k, DictUnpack) for k, _ in self.items):
             yield self
         else:
@@ -2595,7 +2585,7 @@ class EmptyNode(_base_nodes.NoChildrenNode):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult]:
         if not self.has_underlying_object():
             yield util.Uninferable
@@ -2881,9 +2871,7 @@ class ImportFrom(_base_nodes.ImportNode):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self,
-        context: InferenceContext | None = None,
-        **kwargs: Any,
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult]:
         """Infer a ImportFrom node: return the imported module/object."""
         context = context or InferenceContext()
@@ -2944,9 +2932,9 @@ class Attribute(NodeNG):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo]:
-        return _infer_attribute(self, context, **kwargs)
+        return _infer_attribute(self, context)
 
 
 class Global(_base_nodes.NoChildrenNode, _base_nodes.Statement):
@@ -3002,7 +2990,7 @@ class Global(_base_nodes.NoChildrenNode, _base_nodes.Statement):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult]:
         if context is None or context.lookupname is None:
             raise InferenceError(node=self, context=context)
@@ -3105,7 +3093,7 @@ class IfExp(NodeNG):
 
     @decorators.raise_if_nothing_inferred
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult]:
         """Support IfExp inference.
 
@@ -3202,7 +3190,6 @@ class Import(_base_nodes.ImportNode):
     def _infer(
         self,
         context: InferenceContext | None = None,
-        **kwargs: Any,
     ) -> Generator[nodes.Module]:
         """Infer an Import node: return the imported module/object."""
         context = context or InferenceContext()
@@ -3422,9 +3409,7 @@ class ParamSpec(_base_nodes.AssignTypeNode):
         self.name = name
         self.default_value = default_value
 
-    def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
-    ) -> Iterator[ParamSpec]:
+    def _infer(self, context: InferenceContext | None = None) -> Iterator[ParamSpec]:
         yield self
 
     assigned_stmts = protocols.generic_type_assigned_stmts
@@ -3624,9 +3609,7 @@ class Slice(NodeNG):
         if self.step is not None:
             yield self.step
 
-    def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
-    ) -> Iterator[Slice]:
+    def _infer(self, context: InferenceContext | None = None) -> Iterator[Slice]:
         yield self
 
 
@@ -3728,7 +3711,7 @@ class Subscript(NodeNG):
         yield self.slice
 
     def _infer_subscript(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         """Inference for subscripts.
 
@@ -3788,12 +3771,12 @@ class Subscript(NodeNG):
 
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
-    def _infer(self, context: InferenceContext | None = None, **kwargs: Any):
-        return self._infer_subscript(context, **kwargs)
+    def _infer(self, context: InferenceContext | None = None):
+        return self._infer_subscript(context)
 
     @decorators.raise_if_nothing_inferred
-    def infer_lhs(self, context: InferenceContext | None = None, **kwargs: Any):
-        return self._infer_subscript(context, **kwargs)
+    def infer_lhs(self, context: InferenceContext | None = None):
+        return self._infer_subscript(context)
 
 
 class Try(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
@@ -4115,9 +4098,7 @@ class TypeAlias(_base_nodes.AssignTypeNode, _base_nodes.Statement):
         self.type_params = type_params
         self.value = value
 
-    def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
-    ) -> Iterator[TypeAlias]:
+    def _infer(self, context: InferenceContext | None = None) -> Iterator[TypeAlias]:
         yield self
 
     assigned_stmts: ClassVar[
@@ -4175,9 +4156,7 @@ class TypeVar(_base_nodes.AssignTypeNode):
         self.bound = bound
         self.default_value = default_value
 
-    def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
-    ) -> Iterator[TypeVar]:
+    def _infer(self, context: InferenceContext | None = None) -> Iterator[TypeVar]:
         yield self
 
     assigned_stmts = protocols.generic_type_assigned_stmts
@@ -4222,9 +4201,7 @@ class TypeVarTuple(_base_nodes.AssignTypeNode):
         self.name = name
         self.default_value = default_value
 
-    def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
-    ) -> Iterator[TypeVarTuple]:
+    def _infer(self, context: InferenceContext | None = None) -> Iterator[TypeVarTuple]:
         yield self
 
     assigned_stmts = protocols.generic_type_assigned_stmts
@@ -4311,7 +4288,7 @@ class UnaryOp(_base_nodes.OperatorNode):
         return super().op_precedence()
 
     def _infer_unaryop(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[
         InferenceResult | util.BadUnaryOperationMessage, None, InferenceErrorInfo
     ]:
@@ -4377,7 +4354,7 @@ class UnaryOp(_base_nodes.OperatorNode):
     @decorators.raise_if_nothing_inferred
     @decorators.path_wrapper
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo]:
         """Infer what an UnaryOp should return when evaluated."""
         yield from self._filter_operation_errors(
@@ -4679,17 +4656,17 @@ class FormattedValue(NodeNG):
             yield self.format_spec
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         format_specs = Const("") if self.format_spec is None else self.format_spec
         uninferable_already_generated = False
-        for format_spec in format_specs.infer(context, **kwargs):
+        for format_spec in format_specs.infer(context):
             if not isinstance(format_spec, Const):
                 if not uninferable_already_generated:
                     yield util.Uninferable
                     uninferable_already_generated = True
                 continue
-            for value in self.value.infer(context, **kwargs):
+            for value in self.value.infer(context):
                 if value is util.Uninferable:
                     yield util.Uninferable
                     return
@@ -4778,7 +4755,7 @@ class JoinedStr(NodeNG):
         yield from self.values
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         if self.values:
             yield from self._infer_with_values(context)
@@ -4786,7 +4763,7 @@ class JoinedStr(NodeNG):
             yield Const("")
 
     def _infer_with_values(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         uninferable_already_generated = False
         for inferred in self._infer_from_values(self.values, context):
@@ -4802,19 +4779,19 @@ class JoinedStr(NodeNG):
 
     @classmethod
     def _infer_from_values(
-        cls, nodes: list[NodeNG], context: InferenceContext | None = None, **kwargs: Any
+        cls, nodes: list[NodeNG], context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         if not nodes:
             return
         if len(nodes) == 1:
-            for node in cls._safe_infer_from_node(nodes[0], context, **kwargs):
+            for node in cls._safe_infer_from_node(nodes[0], context):
                 if isinstance(node, Const):
                     yield node
                     continue
                 yield Const(UNINFERABLE_VALUE)
             return
-        for prefix in cls._safe_infer_from_node(nodes[0], context, **kwargs):
-            for suffix in cls._infer_from_values(nodes[1:], context, **kwargs):
+        for prefix in cls._safe_infer_from_node(nodes[0], context):
+            for suffix in cls._infer_from_values(nodes[1:], context):
                 result = ""
                 for node in (prefix, suffix):
                     if isinstance(node, Const):
@@ -4825,10 +4802,10 @@ class JoinedStr(NodeNG):
 
     @classmethod
     def _safe_infer_from_node(
-        cls, node: NodeNG, context: InferenceContext | None = None, **kwargs: Any
+        cls, node: NodeNG, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         try:
-            yield from node._infer(context, **kwargs)
+            yield from node._infer(context)
         except InferenceError:
             yield util.Uninferable
 
@@ -4981,7 +4958,7 @@ class Unknown(_base_nodes.AssignTypeNode):
     def qname(self) -> Literal["Unknown"]:
         return "Unknown"
 
-    def _infer(self, context: InferenceContext | None = None, **kwargs):
+    def _infer(self, context: InferenceContext | None = None):
         """Inference on an Unknown node immediately terminates."""
         yield util.Uninferable
 
@@ -5018,7 +4995,7 @@ class EvaluatedObject(NodeNG):
         )
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[NodeNG | util.UninferableBase]:
         yield self.value
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -10,7 +10,6 @@ from functools import cached_property
 from functools import singledispatch as _singledispatch
 from typing import (
     TYPE_CHECKING,
-    Any,
     ClassVar,
     TypeVar,
     cast,
@@ -120,7 +119,7 @@ class NodeNG:
         """
 
     def infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult]:
         """Get a generator of the inferred values.
 
@@ -144,7 +143,6 @@ class NodeNG:
                 for result in self._explicit_inference(
                     self,  # type: ignore[arg-type]
                     context,
-                    **kwargs,
                 ):
                     context.nodes_inferred += 1
                     yield result
@@ -162,7 +160,7 @@ class NodeNG:
         # Limit inference amount to help with performance issues with
         # exponentially exploding possible results.
         limit = AstroidManager().max_inferable_values
-        for i, result in enumerate(self._infer(context=context, **kwargs)):
+        for i, result in enumerate(self._infer(context=context)):
             if i >= limit or (context.nodes_inferred > context.max_inferred):
                 results.append(util.Uninferable)
                 yield util.Uninferable
@@ -555,7 +553,7 @@ class NodeNG:
         pass
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
         """We don't know how to resolve a statement by default."""
         # this method is overridden by most concrete classes

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -16,7 +16,7 @@ import os
 import sys
 from collections.abc import Generator, Iterable, Iterator, Sequence
 from functools import cached_property, lru_cache
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, NoReturn
+from typing import TYPE_CHECKING, ClassVar, Literal, NoReturn
 
 from astroid import bases, protocols, util
 from astroid.context import (
@@ -601,9 +601,7 @@ class Module(LocalsDictNodeNG):
         """
         return self
 
-    def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
-    ) -> Generator[Module]:
+    def _infer(self, context: InferenceContext | None = None) -> Generator[Module]:
         yield self
 
 
@@ -1059,9 +1057,7 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
             return found_attrs
         raise AttributeInferenceError(target=self, attribute=name)
 
-    def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
-    ) -> Generator[Lambda]:
+    def _infer(self, context: InferenceContext | None = None) -> Generator[Lambda]:
         yield self
 
     def _get_yield_nodes_skip_functions(self):
@@ -1519,7 +1515,7 @@ class FunctionDef(
         return bool(yields_without_lambdas & yields_without_functions)
 
     def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
+        self, context: InferenceContext | None = None
     ) -> Generator[objects.Property | FunctionDef, None, InferenceErrorInfo]:
         from astroid import objects  # pylint: disable=import-outside-toplevel
 
@@ -2968,7 +2964,5 @@ class ClassDef(
         """
         return self
 
-    def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
-    ) -> Generator[ClassDef]:
+    def _infer(self, context: InferenceContext | None = None) -> Generator[ClassDef]:
         yield self

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import sys
 from collections.abc import Generator, Iterator
 from functools import cached_property
-from typing import Any, Literal, NoReturn
+from typing import Literal, NoReturn
 
 from astroid import bases, util
 from astroid.context import InferenceContext
@@ -43,7 +43,7 @@ class FrozenSet(node_classes.BaseContainer):
     def pytype(self) -> Literal["builtins.frozenset"]:
         return "builtins.frozenset"
 
-    def _infer(self, context: InferenceContext | None = None, **kwargs: Any):
+    def _infer(self, context: InferenceContext | None = None):
         yield self
 
     @cached_property
@@ -88,7 +88,7 @@ class Super(node_classes.NodeNG):
             end_col_offset=scope.end_col_offset,
         )
 
-    def _infer(self, context: InferenceContext | None = None, **kwargs: Any):
+    def _infer(self, context: InferenceContext | None = None):
         yield self
 
     def super_mro(self):
@@ -380,7 +380,5 @@ class Property(scoped_nodes.FunctionDef):
     ) -> NoReturn:
         raise InferenceError("Properties are not callable")
 
-    def _infer(
-        self, context: InferenceContext | None = None, **kwargs: Any
-    ) -> Generator[Self]:
+    def _infer(self, context: InferenceContext | None = None) -> Generator[Self]:
         yield self

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from collections.abc import Callable, Generator
 from typing import (
     TYPE_CHECKING,
-    Any,
     Generic,
     Protocol,
     TypedDict,
@@ -86,7 +85,6 @@ class InferFn(Protocol, Generic[_SuccessfulInferenceResultT_contra]):
         self,
         node: _SuccessfulInferenceResultT_contra,
         context: InferenceContext | None = None,
-        **kwargs: Any,
     ) -> Iterator[InferenceResult]: ...  # pragma: no cover
 
 

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "4.2.0b3"
+current = "4.2.0b4"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

As discussed in https://github.com/pylint-dev/astroid/pull/3109

Let's remove `**kwargs` from `infer` as it only allows/creates issues with caching of inference and is no longer needed/used.