### PR TITLE
cap oversized str/bytes and sequence concatenation during inference

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,12 +9,6 @@ Release date: TBA
 
 
 * Bound str/bytes and list/tuple concatenation (``a + b``) during inference.
-  The repetition operators (``*``, ``<<``, ``**``) are size-capped, but
-  concatenation was not, so two operands each just under the cap combine past
-  it and chaining ``+`` grows the result without bound. ``const_infer_binary_op``
-  and ``tl_infer_binary_op`` now infer ``Uninferable`` once the combined length
-  exceeds ``1e8``, matching the repetition guards. The list/tuple path also
-  inferred every element of the concatenated sequence before the fix.
 
 * Fix crash (``TypeError: 'UninferableBase' object is not iterable``) in the
   ``multiprocessing`` brain when a local package shadows the stdlib

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,14 @@ What's New in astroid 4.2.0?
 Release date: TBA
 
 
+* Bound str/bytes and list/tuple concatenation (``a + b``) during inference.
+  The repetition operators (``*``, ``<<``, ``**``) are size-capped, but
+  concatenation was not, so two operands each just under the cap combine past
+  it and chaining ``+`` grows the result without bound. ``const_infer_binary_op``
+  and ``tl_infer_binary_op`` now infer ``Uninferable`` once the combined length
+  exceeds ``1e8``, matching the repetition guards. The list/tuple path also
+  inferred every element of the concatenated sequence before the fix.
+
 * Fix crash (``TypeError: 'UninferableBase' object is not iterable``) in the
   ``multiprocessing`` brain when a local package shadows the stdlib
   ``multiprocessing`` module.

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -142,6 +142,17 @@ def const_infer_binary_op(
         ):
             yield util.Uninferable
             return
+        # Concatenating str/bytes ("a" + "b") is not bounded by the repetition
+        # guard above: each side can sit just under the "*" cap, so chaining
+        # concatenations grows the result without limit. Don't materialize it.
+        if (
+            operator == "+"
+            and isinstance(self.value, (str, bytes))
+            and isinstance(other.value, type(self.value))
+            and len(self.value) + len(other.value) > 1e8
+        ):
+            yield util.Uninferable
+            return
         try:
             impl = BIN_OP_IMPL[operator]
             try:
@@ -217,6 +228,13 @@ def tl_infer_binary_op(
     context.boundnode = None
     not_implemented = nodes.Const(NotImplemented)
     if isinstance(other, self.__class__) and operator == "+":
+        # Concatenation is the additive analog of _multiply_seq_by_int: two
+        # sequences each just under the repetition cap combine past it, and
+        # chaining "+" grows the result without bound. _filter_uninferable_nodes
+        # below infers every element, so decline before walking them.
+        if len(self.elts) + len(other.elts) > 1e8:
+            yield util.Uninferable
+            return
         node = self.__class__(parent=opnode)
         node.elts = list(
             itertools.chain(

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -142,9 +142,7 @@ def const_infer_binary_op(
         ):
             yield util.Uninferable
             return
-        # Concatenating str/bytes ("a" + "b") is not bounded by the repetition
-        # guard above: each side can sit just under the "*" cap, so chaining
-        # concatenations grows the result without limit. Don't materialize it.
+        # Don't materialize an overly large str/bytes concatenation.
         if (
             operator == "+"
             and isinstance(self.value, (str, bytes))
@@ -228,10 +226,7 @@ def tl_infer_binary_op(
     context.boundnode = None
     not_implemented = nodes.Const(NotImplemented)
     if isinstance(other, self.__class__) and operator == "+":
-        # Concatenation is the additive analog of _multiply_seq_by_int: two
-        # sequences each just under the repetition cap combine past it, and
-        # chaining "+" grows the result without bound. _filter_uninferable_nodes
-        # below infers every element, so decline before walking them.
+        # Don't build (and infer every element of) an overly large sequence.
         if len(self.elts) + len(other.elts) > 1e8:
             yield util.Uninferable
             return

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -376,7 +376,7 @@ class ProtocolTests(unittest.TestCase):
 
     @staticmethod
     def test_uninferable_string_concatenation() -> None:
-        """Each side sits under the "*" cap; the concatenation exceeds it."""
+        """The concatenated string would be prohibitively expensive to build."""
         parsed = extract_node('("a" * 60000000) + ("b" * 60000000)')
         assert parsed.inferred() == [Uninferable]
 
@@ -392,8 +392,7 @@ class ProtocolTests(unittest.TestCase):
 
     @staticmethod
     def test_uninferable_list_concatenation() -> None:
-        """Concatenating two sequences under the repetition cap builds a list
-        past it, and infers every element while doing so."""
+        """The concatenated list would be prohibitively expensive to build."""
         parsed = extract_node("([1] * 50000001) + ([1] * 50000001)")
         assert parsed.inferred() == [Uninferable]
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -374,6 +374,29 @@ class ProtocolTests(unittest.TestCase):
         parsed = extract_node("1 << 123456789")
         assert parsed.inferred() == [Uninferable]
 
+    @staticmethod
+    def test_uninferable_string_concatenation() -> None:
+        """Each side sits under the "*" cap; the concatenation exceeds it."""
+        parsed = extract_node('("a" * 60000000) + ("b" * 60000000)')
+        assert parsed.inferred() == [Uninferable]
+
+    @staticmethod
+    def test_uninferable_bytes_concatenation() -> None:
+        parsed = extract_node('(b"a" * 60000000) + (b"b" * 60000000)')
+        assert parsed.inferred() == [Uninferable]
+
+    @staticmethod
+    def test_string_concatenation_small_still_infers() -> None:
+        parsed = extract_node('"ab" + "cd"')
+        assert parsed.inferred()[0].value == "abcd"
+
+    @staticmethod
+    def test_uninferable_list_concatenation() -> None:
+        """Concatenating two sequences under the repetition cap builds a list
+        past it, and infers every element while doing so."""
+        parsed = extract_node("([1] * 50000001) + ([1] * 50000001)")
+        assert parsed.inferred() == [Uninferable]
+
 
 def test_named_expr_inference() -> None:
     code = """


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

the repetition operators are size-capped in `const_infer_binary_op` (`*`, `<<`) and `_multiply_seq_by_int` (`*`), but concatenation with `+` is not, and each operand can sit just under the cap. `("a" * 90000000) + ("b" * 90000000)` is 34 source characters yet materializes a 180 MB `Const` string during inference, and chaining more `+` terms grows it without bound. the list/tuple path in `tl_infer_binary_op` is worse: `_filter_uninferable_nodes` infers every element of the concatenated sequence, so `([0] * 90000000) + ([0] * 90000000)` walks ~1.8e8 elements. both `+` branches now yield `Uninferable` once the combined length passes `1e8`, the additive analog of the existing repetition guards. small concatenations keep inferring their exact value.