### PR TITLE
cap oversized old-style % string formatting during inference

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -55,6 +55,16 @@ Release date: TBA
 
 * Bound str/bytes and list/tuple concatenation (``a + b``) during inference.
 
+* Bound oversized old-style (``%``) string/bytes formatting during inference.
+  A tiny literal such as ``"%1000000000d" % 1`` made
+  ``_infer_old_style_string_formatting`` eagerly build a multi-gigabyte
+  ``Const`` while inferring otherwise untrusted source. The width and
+  precision are now read out of the conversion specifiers (including ``*``
+  fields) and the interpolation infers as ``Uninferable`` past ``1e8``,
+  mirroring the repetition, concatenation and ``str.format`` caps. Bytes
+  ``%`` formatting is routed through the same handler so it is bounded too;
+  small format strings keep inferring their exact value.
+
 * Fix crash (``TypeError: 'UninferableBase' object is not iterable``) in the
   ``multiprocessing`` brain when a local package shadows the stdlib
   ``multiprocessing`` module.

--- a/astroid/nodes/_base_nodes.py
+++ b/astroid/nodes/_base_nodes.py
@@ -10,7 +10,6 @@ Previously these were called Mixin nodes.
 from __future__ import annotations
 
 import itertools
-import re
 from collections.abc import Callable, Generator, Iterator
 from functools import cached_property, lru_cache, partial
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -44,13 +43,6 @@ if TYPE_CHECKING:
         ],
         list[partial[Generator[InferenceResult]]],
     ]
-
-
-# A single ``%`` conversion specifier, capturing its width and precision so an
-# oversized field can be detected before the interpolation is materialized.
-_OLD_STYLE_FORMAT_SPEC = re.compile(
-    r"%(?:\([^)]*\))?[#0\- +]*(\*|\d+)?(?:\.(\*|\d+))?[hlL]?[diouxXeEfFgGcrsab%]"
-)
 
 
 class Statement(NodeNG):
@@ -418,40 +410,16 @@ class OperatorNode(NodeNG):
         else:
             return (util.Uninferable,)
 
-        if OperatorNode._old_style_format_too_large(instance.value, values):
+        # pylint: disable-next=import-outside-toplevel
+        from astroid.protocols import _old_style_format_too_large
+
+        if _old_style_format_too_large(instance.value, values):
             return (util.Uninferable,)
 
         try:
             return (nodes.const_factory(instance.value % values),)
         except (TypeError, KeyError, ValueError):
             return (util.Uninferable,)
-
-    @staticmethod
-    def _old_style_format_too_large(template: str | bytes, values: object) -> bool:
-        """Whether ``template % values`` would build an oversized string.
-
-        A tiny literal like ``"%1000000000d" % 1`` interpolates to a multi-
-        gigabyte string, so the field width and precision are read out of the
-        conversion specifiers (including ``*`` fields taken from the argument
-        tuple) and compared against the same 1e8 cap the repetition and
-        concatenation paths use, before the result is materialized.
-        """
-        if isinstance(template, bytes):
-            template = template.decode("latin-1")
-        has_star = False
-        for width, precision in _OLD_STYLE_FORMAT_SPEC.findall(template):
-            for field in (width, precision):
-                if field == "*":
-                    has_star = True
-                elif field and (len(field) > 9 or int(field) > 1e8):
-                    # len > 9 already exceeds the cap, and avoids int() choking
-                    # on an absurdly long digit run.
-                    return True
-        if has_star:
-            candidates = values if isinstance(values, tuple) else (values,)
-            if any(isinstance(v, int) and v > 1e8 for v in candidates):
-                return True
-        return False
 
     @staticmethod
     def _invoke_binop_inference(

--- a/astroid/nodes/_base_nodes.py
+++ b/astroid/nodes/_base_nodes.py
@@ -10,6 +10,7 @@ Previously these were called Mixin nodes.
 from __future__ import annotations
 
 import itertools
+import re
 from collections.abc import Callable, Generator, Iterator
 from functools import cached_property, lru_cache, partial
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -43,6 +44,13 @@ if TYPE_CHECKING:
         ],
         list[partial[Generator[InferenceResult]]],
     ]
+
+
+# A single ``%`` conversion specifier, capturing its width and precision so an
+# oversized field can be detected before the interpolation is materialized.
+_OLD_STYLE_FORMAT_SPEC = re.compile(
+    r"%(?:\([^)]*\))?[#0\- +]*(\*|\d+)?(?:\.(\*|\d+))?[hlL]?[diouxXeEfFgGcrsab%]"
+)
 
 
 class Statement(NodeNG):
@@ -410,10 +418,40 @@ class OperatorNode(NodeNG):
         else:
             return (util.Uninferable,)
 
+        if OperatorNode._old_style_format_too_large(instance.value, values):
+            return (util.Uninferable,)
+
         try:
             return (nodes.const_factory(instance.value % values),)
         except (TypeError, KeyError, ValueError):
             return (util.Uninferable,)
+
+    @staticmethod
+    def _old_style_format_too_large(template: str | bytes, values: object) -> bool:
+        """Whether ``template % values`` would build an oversized string.
+
+        A tiny literal like ``"%1000000000d" % 1`` interpolates to a multi-
+        gigabyte string, so the field width and precision are read out of the
+        conversion specifiers (including ``*`` fields taken from the argument
+        tuple) and compared against the same 1e8 cap the repetition and
+        concatenation paths use, before the result is materialized.
+        """
+        if isinstance(template, bytes):
+            template = template.decode("latin-1")
+        has_star = False
+        for width, precision in _OLD_STYLE_FORMAT_SPEC.findall(template):
+            for field in (width, precision):
+                if field == "*":
+                    has_star = True
+                elif field and (len(field) > 9 or int(field) > 1e8):
+                    # len > 9 already exceeds the cap, and avoids int() choking
+                    # on an absurdly long digit run.
+                    return True
+        if has_star:
+            candidates = values if isinstance(values, tuple) else (values,)
+            if any(isinstance(v, int) and v > 1e8 for v in candidates):
+                return True
+        return False
 
     @staticmethod
     def _invoke_binop_inference(
@@ -432,7 +470,7 @@ class OperatorNode(NodeNG):
 
         if (
             isinstance(instance, nodes.Const)
-            and isinstance(instance.value, str)
+            and isinstance(instance.value, (str, bytes))
             and op == "%"
         ):
             return iter(

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -99,6 +99,68 @@ for _KEY, _IMPL in list(BIN_OP_IMPL.items()):
     BIN_OP_IMPL[_KEY + "="] = _IMPL
 
 
+def _old_style_format_too_large(template: str | bytes, values: object) -> bool:
+    """Whether ``template % values`` would exceed the 1e8 size cap.
+
+    Walks the conversion specifiers the way CPython parses them, resolving
+    ``*`` width/precision fields from the positional arguments.
+    """
+    if isinstance(template, bytes):
+        template = template.decode("latin-1")
+    if isinstance(values, dict):
+        args: tuple[object, ...] = ()
+    elif isinstance(values, tuple):
+        args = values
+    else:
+        args = (values,)
+    index = 0  # next positional argument
+    i, end = 0, len(template)
+    while i < end:
+        if template[i] != "%":
+            i += 1
+            continue
+        i += 1
+        if i < end and template[i] == "(":
+            # Skip the mapping key, counting nested parentheses like CPython.
+            depth, i = 1, i + 1
+            while i < end and depth:
+                if template[i] == "(":
+                    depth += 1
+                elif template[i] == ")":
+                    depth -= 1
+                i += 1
+        while i < end and template[i] in "#0- +":
+            i += 1
+        for dot in ("", "."):  # width, then precision
+            if dot:
+                if i >= end or template[i] != ".":
+                    break
+                i += 1
+            if i < end and template[i] == "*":
+                i += 1
+                if index < len(args):
+                    star = args[index]
+                    index += 1
+                    # A negative width means left-justify with that magnitude.
+                    if isinstance(star, int) and abs(star) > 1e8:
+                        return True
+            else:
+                start = i
+                while i < end and "0" <= template[i] <= "9":
+                    i += 1
+                digits = template[start:i]
+                # len > 9 already exceeds the cap and avoids int() choking.
+                if digits and (len(digits) > 9 or int(digits) > 1e8):
+                    return True
+        while i < end and template[i] in "hlL":
+            i += 1
+        if i < end:
+            if template[i] != "%":
+                index += 1  # the conversion itself consumes an argument
+            i += 1
+    return False
+
+
 @decorators.yes_if_nothing_inferred
 def const_infer_binary_op(
     self: nodes.Const,
@@ -148,6 +210,15 @@ def const_infer_binary_op(
             and isinstance(self.value, (str, bytes))
             and isinstance(other.value, type(self.value))
             and len(self.value) + len(other.value) > 1e8
+        ):
+            yield util.Uninferable
+            return
+        # An oversized width or precision ("%1000000000d" % 1) would
+        # materialize the whole interpolation, like the repetition above.
+        if (
+            operator in {"%", "%="}
+            and isinstance(self.value, (str, bytes))
+            and _old_style_format_too_large(self.value, other.value)
         ):
             yield util.Uninferable
             return

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7242,14 +7242,25 @@ class TestOldStyleStringFormatting:
             '"%-1000000000s" % "x"',
             '"%.1000000000f" % 1.0',
             '"%*s" % (1000000000, "x")',
+            '"%*s" % (-1000000000, "x")',
+            '"%.*f" % (1000000000, 1.0)',
             '"%(x)1000000000s" % {"x": "y"}',
+            '"%((x))1000000000s" % {"(x)": "y"}',
             'b"%1000000000d" % 1',
+            'x = "%1000000000d"\nx %= 1\nx',
         ],
     )
     def test_old_style_string_formatting_oversized(self, format_string: str) -> None:
         # A tiny literal must not materialize a multi-gigabyte string.
-        node: nodes.Call = _extract_single_node(format_string)
+        node = _extract_single_node(format_string)
         assert next(node.infer()) is util.Uninferable
+
+    def test_old_style_string_formatting_star_not_width(self) -> None:
+        # Only arguments consumed by a * width/precision count toward the cap.
+        node = _extract_single_node('"%*d %d" % (5, 7, 200000001)')
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == "    7 200000001"
 
 
 def test_sys_argv_uninferable() -> None:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7255,6 +7255,13 @@ class TestOldStyleStringFormatting:
         node = _extract_single_node(format_string)
         assert next(node.infer()) is util.Uninferable
 
+    def test_old_style_string_formatting_length_modifier(self) -> None:
+        # h/l/L length modifiers are skipped and do not affect the size cap.
+        node = _extract_single_node('"%ld" % 5')
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == "5"
+
     def test_old_style_string_formatting_star_not_width(self) -> None:
         # Only arguments consumed by a * width/precision count toward the cap.
         node = _extract_single_node('"%*d %d" % (5, 7, 200000001)')

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7235,6 +7235,22 @@ class TestOldStyleStringFormatting:
         assert isinstance(inferred, nodes.Const)
         assert inferred.value == "My name is Daniel, I'm 12.00"
 
+    @pytest.mark.parametrize(
+        "format_string",
+        [
+            '"%1000000000d" % 1',
+            '"%-1000000000s" % "x"',
+            '"%.1000000000f" % 1.0',
+            '"%*s" % (1000000000, "x")',
+            '"%(x)1000000000s" % {"x": "y"}',
+            'b"%1000000000d" % 1',
+        ],
+    )
+    def test_old_style_string_formatting_oversized(self, format_string: str) -> None:
+        # A tiny literal must not materialize a multi-gigabyte string.
+        node: nodes.Call = _extract_single_node(format_string)
+        assert next(node.infer()) is util.Uninferable
+
 
 def test_sys_argv_uninferable() -> None:
     """Regression test for https://github.com/pylint-dev/pylint/issues/7710."""

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -14,6 +14,7 @@ import pytest
 import astroid
 from astroid import extract_node, nodes
 from astroid.const import PY312_PLUS
+from astroid.context import InferenceContext
 from astroid.exceptions import InferenceError
 from astroid.manager import AstroidManager
 from astroid.util import Uninferable, UninferableBase
@@ -407,6 +408,19 @@ class ProtocolTests(unittest.TestCase):
         """The concatenated list would be prohibitively expensive to build."""
         parsed = extract_node("([1] * 50000001) + ([1] * 50000001)")
         assert parsed.inferred() == [Uninferable]
+
+    @staticmethod
+    def test_uninferable_oversized_percent_formatting() -> None:
+        """The % guard in const_infer_binary_op backs up the dedicated handler.
+
+        Normal inference routes str/bytes % through
+        _infer_old_style_string_formatting, so invoke the protocol directly.
+        """
+        parsed = extract_node('"%1000000000d" % 1')
+        result = parsed.left.infer_binary_op(
+            parsed, "%", parsed.right, InferenceContext(), None
+        )
+        assert list(result) == [Uninferable]
 
 
 def test_named_expr_inference() -> None:


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

old-style `%` formatting is evaluated eagerly in `_infer_old_style_string_formatting`, which runs `template % values` without bounding the output. width and precision come straight from the conversion specs, so a 17-character literal like `"%1000000000d" % 1` interpolates a 1 GB `Const` while inferring otherwise untrusted source, the printf sibling of the repetition, concatenation and `str.format` caps already in the tree. the width/precision (including `*` fields pulled from the argument tuple) are now read out of the specs and the result infers as `Uninferable` past `1e8` before it is built. bytes `%` never reached this handler at all, it fell through `_invoke_binop_inference` into the generic binop path unbounded, so the dispatch now routes bytes through the same guarded code. small format strings keep inferring their exact value.
