### PR TITLE
cap oversized field width/precision in str.format inference

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,14 @@ Release date: TBA
 
   Refs #3107
 
+* Bound the field width and precision when inferring ``str.format`` calls.
+  A template such as ``"{:>2000000000}".format("x")`` (or a width/precision
+  supplied through a nested ``{}`` field) previously built the padded
+  multi-gigabyte string eagerly during inference; such calls now infer as
+  ``Uninferable`` when the field size would be oversized.
+
+  Refs #3131
+
 * Remove the ``asname`` keyword argument from ``Import._infer`` and
   ``ImportFrom._infer``. The alias-to-real-name translation that
   ``asname=True`` performed is now hoisted into ``ImportNode._infer_name``,

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -49,26 +49,22 @@ OBJECT_DUNDER_NEW = "object.__new__"
 # str.format() call. A crafted template such as "{:>2000000000}" would otherwise
 # eagerly build a multi-gigabyte string during inference.
 _MAX_FORMAT_FIELD_SIZE = int(1e8)
-_FORMAT_SPEC_RE = re.compile(
-    r"(?:.?[<>=^])?[-+ ]?z?#?0?(?P<width>\d+)?[_,]?(?:\.(?P<precision>\d+))?.?$"
-)
 
 
 class _BoundedFormatter(string.Formatter):
     """A ``str.format`` implementation that refuses oversized width/precision.
 
-    Nested replacement fields inside a format spec ("{:>{}}") are already
-    resolved by ``Formatter`` before ``format_field`` runs, so the check here
-    also covers widths supplied through arguments.
+    The only multi-digit numbers in a format spec are the width and the
+    precision, so bailing when any digit run exceeds the limit covers both.
+    Nested replacement fields ("{:>{}}") are already resolved by ``Formatter``
+    before ``format_field`` runs, so this also catches sizes passed as
+    arguments.
     """
 
     def format_field(self, value: object, format_spec: str) -> str:
-        match = _FORMAT_SPEC_RE.match(format_spec)
-        if match:
-            for field in ("width", "precision"):
-                size = match.group(field)
-                if size is not None and int(size) > _MAX_FORMAT_FIELD_SIZE:
-                    raise ValueError("format field size exceeds inference limit")
+        for size in re.findall(r"\d+", format_spec):
+            if int(size) > _MAX_FORMAT_FIELD_SIZE:
+                raise ValueError("format field size exceeds inference limit")
         return cast(str, super().format_field(value, format_spec))
 
 

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -7,6 +7,8 @@
 from __future__ import annotations
 
 import itertools
+import re
+import string
 from collections.abc import Callable, Iterable, Iterator
 from functools import partial
 from typing import TYPE_CHECKING, Any, NoReturn, cast
@@ -42,6 +44,33 @@ BuiltContainers = type[tuple] | type[list] | type[set] | type[frozenset]
 CopyResult = nodes.Dict | nodes.List | nodes.Set | objects.FrozenSet
 
 OBJECT_DUNDER_NEW = "object.__new__"
+
+# Largest field width/precision we are willing to materialize when inferring a
+# str.format() call. A crafted template such as "{:>2000000000}" would otherwise
+# eagerly build a multi-gigabyte string during inference.
+_MAX_FORMAT_FIELD_SIZE = int(1e8)
+_FORMAT_SPEC_RE = re.compile(
+    r"(?:.?[<>=^])?[-+ ]?z?#?0?(?P<width>\d+)?[_,]?(?:\.(?P<precision>\d+))?.?$"
+)
+
+
+class _BoundedFormatter(string.Formatter):
+    """A ``str.format`` implementation that refuses oversized width/precision.
+
+    Nested replacement fields inside a format spec ("{:>{}}") are already
+    resolved by ``Formatter`` before ``format_field`` runs, so the check here
+    also covers widths supplied through arguments.
+    """
+
+    def format_field(self, value: object, format_spec: str) -> str:
+        match = _FORMAT_SPEC_RE.match(format_spec)
+        if match:
+            for field in ("width", "precision"):
+                size = match.group(field)
+                if size is not None and int(size) > _MAX_FORMAT_FIELD_SIZE:
+                    raise ValueError("format field size exceeds inference limit")
+        return cast(str, super().format_field(value, format_spec))
+
 
 STR_CLASS = """
 class whatever(object):
@@ -1048,7 +1077,9 @@ def _infer_str_format_call(
     keyword_values: dict[str, str] = {k: v.value for k, v in inferred_keyword.items()}
 
     try:
-        formatted_string = format_template.format(*pos_values, **keyword_values)
+        formatted_string = _BoundedFormatter().format(
+            format_template, *pos_values, **keyword_values
+        )
     except (AttributeError, IndexError, KeyError, TypeError, ValueError):
         # AttributeError: named field in format string was not found in the arguments
         # IndexError: there are too few arguments to interpolate

--- a/tests/brain/test_builtin.py
+++ b/tests/brain/test_builtin.py
@@ -120,6 +120,11 @@ class TestStringNodes:
             daniel_age = 12
             "My name is {0.name}".format(daniel_age)
             """,
+            pytest.param(""""{:>2000000000}".format("x")""", id="oversized-width"),
+            pytest.param(""""{:.2000000000f}".format(1.0)""", id="oversized-precision"),
+            pytest.param(
+                """"{:>{}}".format("x", 2000000000)""", id="oversized-nested-width"
+            ),
         ],
     )
     def test_string_format_uninferable(self, format_string: str) -> None:


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`_infer_str_format_call` evaluates the template eagerly with `format_template.format(*args)`, so a tiny analyzed line like `"{:>2000000000}".format("x")` makes astroid build the padded multi-gigabyte string during inference (I saw RSS jump to ~3 GB before it settles). A width or precision handed in through a nested `{}` field, e.g. `"{:>{}}".format("x", 2000000000)`, does the same. This is the same eager-materialization problem that `**`, `<<`, and list/str multiply already guard against, just reached through the format mini-language.

The fix routes the call through a small `string.Formatter` subclass and checks the width/precision in `format_field`, which runs after nested fields are resolved, so it covers both literal and argument-supplied sizes. Oversized cases now infer as `Uninferable` and normal formatting is unchanged.

Refs #3107
