### PR TITLE
deduplicate keys in dict.fromkeys inference

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,12 @@ Release date: TBA
   Users upgrading their `astroid` versions should ensure they do no pass values other than
   `context` to `infer`.
 
+* Deduplicate keys when inferring ``dict.fromkeys``. ``dict.fromkeys("aab")``
+  now infers a dict with keys ``"a"``, ``"b"`` instead of ``"a"``, ``"a"``,
+  ``"b"``, matching the runtime. This also stops ``dict.fromkeys`` from
+  materializing one ``Const`` node per character for a repeated string such as
+  ``dict.fromkeys("x" * 10 ** 8)``, which is a single-key dict.
+
 * Fix crash (``TypeError: 'UninferableBase' object is not iterable``) in the
   ``multiprocessing`` brain when a local package shadows the stdlib
   ``multiprocessing`` module.

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -928,6 +928,16 @@ def infer_dict_fromkeys(node, context: InferenceContext | None = None):
         new_node.postinit(elements)
         return new_node
 
+    def _unique_const_keys(keys: Iterable[nodes.Const]) -> list[nodes.Const]:
+        # dict.fromkeys deduplicates its keys, so keep only the first Const seen
+        # for a given value. Emitting one entry per element is wrong
+        # (dict.fromkeys("aab") has keys "a", "b") and lets a repeated string
+        # balloon the inferred dict.
+        seen: dict[object, nodes.Const] = {}
+        for key in keys:
+            seen.setdefault(key.value, key)
+        return list(seen.values())
+
     call = arguments.CallSite.from_call(node, context=context)
     if call.keyword_arguments:
         raise UseInferenceDefault("TypeError: int() must take no keyword arguments")
@@ -954,13 +964,19 @@ def infer_dict_fromkeys(node, context: InferenceContext | None = None):
                 # Fallback to an empty dict
                 return _build_dict_with_elements([])
 
-        elements_with_value = [(element, default) for element in elements]
+        elements_with_value = [
+            (element, default) for element in _unique_const_keys(elements)
+        ]
         return _build_dict_with_elements(elements_with_value)
     if isinstance(inferred_values, nodes.Const) and isinstance(
         inferred_values.value, (str, bytes)
     ):
+        # Deduplicate the characters/bytes before building Const nodes so that a
+        # compact but large string, e.g. dict.fromkeys("x" * 10**8), doesn't
+        # materialize one node per character for what is a single-key dict.
         elements_with_value = [
-            (nodes.Const(element), default) for element in inferred_values.value
+            (nodes.Const(element), default)
+            for element in dict.fromkeys(inferred_values.value)
         ]
         return _build_dict_with_elements(elements_with_value)
     if isinstance(inferred_values, nodes.Dict):
@@ -970,7 +986,9 @@ def infer_dict_fromkeys(node, context: InferenceContext | None = None):
                 # Fallback to an empty dict
                 return _build_dict_with_elements([])
 
-        elements_with_value = [(element, default) for element in keys]
+        elements_with_value = [
+            (element, default) for element in _unique_const_keys(keys)
+        ]
         return _build_dict_with_elements(elements_with_value)
 
     # Fallback to an empty dictionary

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -1587,6 +1587,28 @@ def test_infer_dict_from_keys() -> None:
         assert sorted(actual_values) == ["a", "b", "c"]
 
 
+def test_infer_dict_from_keys_deduplicates() -> None:
+    # dict.fromkeys drops duplicate keys, so the inferred dict must too. As a
+    # side effect a repeated string no longer materializes one key per
+    # character (dict.fromkeys("x" * 10**8) is a single-key dict).
+    nodes_with_dupes = astroid.extract_node("""
+    dict.fromkeys("aab") #@
+    dict.fromkeys(b"aab") #@
+    dict.fromkeys([1, 1, 2]) #@
+    dict.fromkeys((1, 2, 1)) #@
+    """)
+    expected = [["a", "b"], [97, 98], [1, 2], [1, 2]]
+    for node, keys in zip(nodes_with_dupes, expected):
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.Dict)
+        assert [elem.value for elem in inferred.itered()] == keys
+
+    repeated = astroid.extract_node('dict.fromkeys("x" * 1000)')
+    inferred = next(repeated.infer())
+    assert isinstance(inferred, nodes.Dict)
+    assert [elem.value for elem in inferred.itered()] == ["x"]
+
+
 class TestFunctoolsPartial:
     @staticmethod
     def test_infer_partial() -> None:


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`infer_dict_fromkeys` keeps one entry per element without deduplicating, so `dict.fromkeys("aab")` infers a dict with keys `"a", "a", "b"` while the runtime call returns `{"a": None, "b": None}`; the same happens for list/tuple/dict inputs. Because each character becomes its own `Const` node, this also means `dict.fromkeys("x" * 10 ** 8)` (a compact string the multiplication guard deliberately allows) expands into ~10^8 dict nodes while analyzing untrusted code, for what is really a single-key dict. The fix deduplicates the keys by value in each branch, matching `dict.fromkeys` semantics, which drops the inferred dict back to its real keys and removes the per-character node blowup.