### PR TITLE
docs: clarify ImportFrom modname for relative imports

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2843,7 +2843,9 @@ class ImportFrom(_base_nodes.ImportNode):
         self.modname: str | None = fromname  # can be None
         """The module that is being imported from.
 
-        This is ``None`` for relative imports.
+        Parsed relative imports without a module name, such as
+        ``from .. import name``, use an empty string. ``None`` is accepted when
+        constructing an :class:`ImportFrom` node directly.
         """
 
         self.names: list[tuple[str, str | None]] = names


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :scroll: Docs |

## Description

Clarify the `ImportFrom.modname` API documentation to match the parser's established behavior: module-less relative imports use an empty string, while directly constructed nodes may still use `None`.

Validation:

- `PYTHONPATH=. python3` behavior check for parsed and directly constructed `ImportFrom` nodes
- `python3 -m pytest -q tests/test_nodes.py -k ImportFrom --disable-warnings` (1 passed)
- `python3 -m py_compile astroid/nodes/node_classes.py`
- `git diff --check`
- `pre-commit run --files astroid/nodes/node_classes.py` (all applicable hooks passed except the `pylint` hook, which could not run because the `pylint` executable is not installed in this runner)

Closes #1349
