### PR TITLE
Fix starred inference in a for loop when the star isn't last

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,11 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Fix inference of a starred target that is not last in a ``for`` loop, such as
+  ``for a, *b, c in ...``. The elements following the starred one were counted
+  from the target's own arity rather than from the end of the iterable, so
+  ``b`` was truncated whenever the iterable was longer than the target.
+
 * Add ``qname()`` method to the ``Slice`` node class, returning
   ``"builtins.slice"``, so that the node can be used in contexts
   that require a qualified name (e.g. pylint's ``basic_checker``).

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -867,9 +867,15 @@ def starred_assigned_stmts(  # noqa: C901
         last_element_index, last_element_length = lookups[-1]
         is_starred_last = last_element_index == (last_element_length - 1)
 
+        # The elements after the starred one are counted back from the end of the
+        # iterable, whose length is unrelated to the target's.
         lookup_slice = slice(
             last_element_index,
-            None if is_starred_last else (last_element_length - last_element_index),
+            (
+                None
+                if is_starred_last
+                else -(last_element_length - last_element_index - 1)
+            ),
         )
         last_lookup = lookup_slice
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -130,6 +130,18 @@ class ProtocolTests(unittest.TestCase):
         assert isinstance(assigned, nodes.List)
         assert assigned.as_string() == "[1, 2]"
 
+    def test_assigned_stmts_starred_for_not_last(self) -> None:
+        """A starred target that isn't last must not truncate to its own arity."""
+        assign_stmts = extract_node("""
+        for a, *b, c in ((1, 2, 3, 4),): #@
+            pass
+        """)
+
+        starred = next(assign_stmts.nodes_of_class(nodes.Starred))
+        assigned = next(starred.assigned_stmts())
+        assert isinstance(assigned, nodes.List)
+        assert assigned.as_string() == "[2, 3]"
+
     def _get_starred_stmts(self, code: str) -> list | UninferableBase:
         assign_stmt = extract_node(f"{code} #@")
         starred = next(assign_stmt.nodes_of_class(nodes.Starred))


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

A starred target in a `for` loop is truncated whenever it isn't the last element and the iterable is longer than the target.

```python
for a, *b, c in [[1, 2, 3, 4, 5]]:
    b  # astroid infers [2], Python gives [2, 3, 4]
```

`starred_assigned_stmts` ends the slice at `last_element_length - last_element_index` — a **positive** index computed from the *target's* arity. The elements after the star have to be counted back from the end of the *iterable*, whose length is unrelated. It happens to be right only when the two lengths coincide.

### Reproducer

```
for a, *b, c in [[1,2,3,4]]      astroid=['[2]']        python=[2, 3]
for a, *b, c in [[1,2,3,4,5]]    astroid=['[2]']        python=[2, 3, 4]
for *b, c in [[1,2,3,4]]         astroid=['[1, 2]']     python=[1, 2, 3]
```

The control — same loop, star **last** — is correct, so this is the not-last path specifically:

```
for a, *b in [[1,2,3,4]]         astroid=['[2, 3, 4]']  python=[2, 3, 4]
```

And the sibling assignment path, given the identical target shape and data, already gets it right:

```
a, *b, c = (1, 2, 3, 4, 5)          → ['[2, 3, 4]']   correct
for a, *b, c in [(1, 2, 3, 4, 5)]   → ['[2]']         wrong
```

### Why no test caught it

The slice is accidentally correct when the iterable is exactly as long as the target:

```
for a, *b, c in [[1,2,3]]        astroid=['[2]']  python=[2]   ✓
```

`test_assigned_stmts_starred_for` iterates `((1, 2, 3), (4, 5, 6, 7))` — so it *does* contain a mismatched case, but it only asserts `next(...)`, i.e. the first tuple, where the lengths happen to match. The `(4, 5, 6, 7)` element is never checked. No test asserts the current behaviour, so nothing had to change.

### Downstream effect

It isn't only a wrong value — it makes valid code uninferable, which is what feeds pylint's sequence-index checks:

```python
for a, *b, c in [[1, 2, 3, 4, 5]]:
    b[2]   # before: InferenceError: Inference failed for <Subscript l.2>
           # after:  ['4']
```

`object_len(b)` likewise returned `1` instead of `3`.

## Tests

Added `test_assigned_stmts_starred_for_not_last`, next to the existing starred-for test. It fails on `main` (`- [2, 3]` / `+ [2]`) and passes here.

Full suite, same command and tree both ways: **1948 passed with the fix vs. 1947 on `main`** — the extra one is the new test, and the failure lists are identical (one pre-existing `test_identify_old_namespace_package_protocol` in my sandbox, missing `pkg_resources`). `ruff` and `black` clean.

ChangeLog entry added under 4.2.0.

## Disclosure

AI-assisted, and I'd rather say so plainly. The reproducer, the star-last control, the Assign-vs-For comparison, the equal-length case that explains the coverage gap, the `b[2]` consequence, and the `main`-vs-branch baseline diff are all things I ran and read myself rather than assumed.

One thing I noticed and deliberately left alone: `protocols.py:770` hardcodes `stmt.targets[0]`, so a chained assignment like `a, *b = *c, d = [1, 2, 3, 4]` resolves the second target's star against the first target's shape. It's independent of this fix and needs exotic code to hit, so I'd rather not bundle it — happy to open a separate issue if it's worth tracking.
