### PR TITLE
Add vararg and kwarg type comment fields

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,12 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Add ``type_comment_vararg`` and ``type_comment_kwarg`` fields to
+  ``Arguments`` nodes so that inline PEP 484 type comments on ``*args`` and
+  ``**kwargs`` can be accessed.
+
+  Closes #1508
+
 * Fix inference of a starred target that is not last in a ``for`` loop, such as
   ``for a, *b, c in ...``. The elements following the starred one were counted
   from the target's own arity rather than from the end of the iterable, so

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -638,6 +638,8 @@ class Arguments(
         "type_comment_args",
         "type_comment_kwonlyargs",
         "type_comment_posonlyargs",
+        "type_comment_vararg",
+        "type_comment_kwarg",
     )
 
     _other_fields = ("vararg", "kwarg")
@@ -693,6 +695,12 @@ class Arguments(
     the value for that argument will be None.
     """
 
+    type_comment_vararg: NodeNG | None
+    """The type annotation, passed by a type comment, of the variable length arguments."""
+
+    type_comment_kwarg: NodeNG | None
+    """The type annotation, passed by a type comment, of the variable length keyword arguments."""
+
     varargannotation: NodeNG | None
     """The type annotation for the variable length arguments."""
 
@@ -747,6 +755,8 @@ class Arguments(
         type_comment_args: list[NodeNG | None] | None = None,
         type_comment_kwonlyargs: list[NodeNG | None] | None = None,
         type_comment_posonlyargs: list[NodeNG | None] | None = None,
+        type_comment_vararg: NodeNG | None = None,
+        type_comment_kwarg: NodeNG | None = None,
     ) -> None:
         self.args = args
         self.defaults = defaults
@@ -769,6 +779,8 @@ class Arguments(
         if type_comment_posonlyargs is None:
             type_comment_posonlyargs = []
         self.type_comment_posonlyargs = type_comment_posonlyargs
+        self.type_comment_vararg = type_comment_vararg
+        self.type_comment_kwarg = type_comment_kwarg
 
     assigned_stmts = protocols.arguments_assigned_stmts
     """Returns the assigned statement (non inferred) according to the assignment type.

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -554,12 +554,16 @@ class TreeRebuilder:
         defaults = [self.visit(child, newnode) for child in node.defaults]
         varargannotation: nodes.NodeNG | None = None
         kwargannotation: nodes.NodeNG | None = None
+        type_comment_vararg: nodes.NodeNG | None = None
+        type_comment_kwarg: nodes.NodeNG | None = None
         if node.vararg:
             vararg = node.vararg.arg
             varargannotation = self.visit(node.vararg.annotation, newnode)
+            type_comment_vararg = self.check_type_comment(node.vararg, parent=newnode)
         if node.kwarg:
             kwarg = node.kwarg.arg
             kwargannotation = self.visit(node.kwarg.annotation, newnode)
+            type_comment_kwarg = self.check_type_comment(node.kwarg, parent=newnode)
 
         kwonlyargs = [self.visit(child, newnode) for child in node.kwonlyargs]
         kw_defaults = [self.visit(child, newnode) for child in node.kw_defaults]
@@ -596,6 +600,8 @@ class TreeRebuilder:
             type_comment_args=type_comment_args,
             type_comment_kwonlyargs=type_comment_kwonlyargs,
             type_comment_posonlyargs=type_comment_posonlyargs,
+            type_comment_vararg=type_comment_vararg,
+            type_comment_kwarg=type_comment_kwarg,
         )
         if start_end_lineno_pairs := [
             (arg.lineno, arg.end_lineno)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1632,6 +1632,43 @@ def test_type_comments_posonly_arguments() -> None:
                 assert actual_arg.as_string() == expected_arg
 
 
+def test_type_comments_vararg_and_kwarg_arguments() -> None:
+    module = builder.parse("""
+    def annotated(
+        *args,  # type: str
+        **kwargs,  # type: int
+    ):
+        pass
+    def unannotated(*args, **kwargs):
+        pass
+    """)
+
+    annotated_arguments = module["annotated"].args
+    assert isinstance(annotated_arguments.type_comment_vararg, nodes.Name)
+    assert annotated_arguments.type_comment_vararg.name == "str"
+    assert isinstance(annotated_arguments.type_comment_kwarg, nodes.Name)
+    assert annotated_arguments.type_comment_kwarg.name == "int"
+    assert (
+        annotated_arguments.locate_child(annotated_arguments.type_comment_vararg)[0]
+        == "type_comment_vararg"
+    )
+    assert (
+        annotated_arguments.locate_child(annotated_arguments.type_comment_kwarg)[0]
+        == "type_comment_kwarg"
+    )
+
+    for type_comment in (
+        annotated_arguments.type_comment_vararg,
+        annotated_arguments.type_comment_kwarg,
+    ):
+        assert isinstance(type_comment.parent, nodes.Expr)
+        assert type_comment.parent.parent is annotated_arguments
+
+    unannotated_arguments = module["unannotated"].args
+    assert unannotated_arguments.type_comment_vararg is None
+    assert unannotated_arguments.type_comment_kwarg is None
+
+
 def test_correct_function_type_comment_parent() -> None:
     data = """
         def f(a):


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

I added `type_comment_vararg` and `type_comment_kwarg` fields to `Arguments`
nodes and populate them from inline PEP 484 type comments on `*args` and
`**kwargs`.

Both fields default to `None` for compatibility with existing `Arguments`
construction. They are registered as Astroid fields so tree helpers such as
`locate_child` recognize the rebuilt type-comment nodes and their parent
relationships.

I added regression tests for annotated and unannotated variadic arguments,
field registration, and parent links.

Closes #1508

## Verification

- `python -m pytest tests/test_nodes.py` — 205 passed, 5 skipped
- `python -m ruff check astroid/nodes/node_classes.py astroid/rebuilder.py tests/test_nodes.py`
- `python -m black --check astroid/nodes/node_classes.py astroid/rebuilder.py tests/test_nodes.py`
- `git diff --check`
