### PR TITLE
Fix pathlib parents subscript inference via an intermediate name

### DIFF
--- a/astroid/brain/brain_pathlib.py
+++ b/astroid/brain/brain_pathlib.py
@@ -19,10 +19,30 @@ Path
 """
 
 
+def _looks_like_parents_value(node: nodes.NodeNG) -> bool:
+    """Whether ``node`` refers to a ``.parents`` attribute access.
+
+    A name is accepted when it is assigned such an attribute access, so that
+    ``parents = path.parents`` followed by ``parents[0]`` is recognised too.
+    """
+    if isinstance(node, nodes.Attribute) and node.attrname == "parents":
+        return True
+
+    if isinstance(node, nodes.Name):
+        _, assignments = node.lookup(node.name)
+        return any(
+            isinstance(assignment, nodes.AssignName)
+            and isinstance(assignment.parent, nodes.Assign)
+            and isinstance(assignment.parent.value, nodes.Attribute)
+            and assignment.parent.value.attrname == "parents"
+            for assignment in assignments
+        )
+
+    return False
+
+
 def _looks_like_parents_subscript(node: nodes.Subscript) -> bool:
-    if not (
-        isinstance(node.value, nodes.Attribute) and node.value.attrname == "parents"
-    ):
+    if not _looks_like_parents_value(node.value):
         return False
 
     try:

--- a/tests/brain/test_pathlib.py
+++ b/tests/brain/test_pathlib.py
@@ -45,6 +45,25 @@ def test_inference_parents_subscript_index() -> None:
         assert inferred[0].qname() == "pathlib.Path"
 
 
+def test_inference_parents_assigned_to_name_subscript_index() -> None:
+    """Test ``parents`` assigned to a name, then accessed by index."""
+    path = astroid.extract_node("""
+    from pathlib import Path
+
+    current_path = Path().resolve()
+    path_parents = current_path.parents
+    path_parents[2]  #@
+    """)
+
+    inferred = path.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], bases.Instance)
+    if PY313:
+        assert inferred[0].qname() == "pathlib._local.Path"
+    else:
+        assert inferred[0].qname() == "pathlib.Path"
+
+
 def test_inference_parents_subscript_slice() -> None:
     """Test inference of ``pathlib.Path.parents``, accessed by slice."""
     name_node = astroid.extract_node("""


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`_looks_like_parents_subscript` only matched when the subscripted node was the `.parents` attribute access itself, so binding it to a variable first (`parents = path.parents`; `parents[0]`) missed the brain tip and inferred a plain tuple element instead of a `Path`. The predicate now also accepts a `Name` assigned a `.parents` attribute access, keeping the existing check that the inferred value really is pathlib's parents sequence.

Added regression test fails on `main` and passes with the fix.

Closes #2864
