### PR TITLE
Ignore typing.overload stubs in dunder lookup

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,9 +22,7 @@ Release date: TBA
   Closes pylint-dev/pylint#10807
 
 * ``typing.overload`` stubs no longer shadow the implementation when a special
-  method is looked up in the MRO. The operator inference paths take the first
-  definition found, so an overloaded ``__truediv__`` or ``__neg__`` used to
-  infer the ``...`` body of the first stub rather than the real return value.
+  method is looked up in the MRO. 
 
   Closes #2448
 

--- a/astroid/interpreter/dunder_lookup.py
+++ b/astroid/interpreter/dunder_lookup.py
@@ -26,6 +26,24 @@ if TYPE_CHECKING:
     from astroid.context import InferenceContext
 
 
+def _drop_overloads(values: list) -> list:
+    """Drop ``typing.overload`` stubs when a real implementation is present.
+
+    A ``@overload``-decorated definition only declares a signature; the last,
+    undecorated definition is the one actually bound at runtime. Callers take
+    the first returned value, so the stubs must not shadow it.
+    """
+    implementations = [
+        value
+        for value in values
+        if not (
+            isinstance(value, nodes.FunctionDef)
+            and "typing.overload" in value.decoratornames()
+        )
+    ]
+    return implementations or values
+
+
 def _lookup_in_mro(node, name) -> list:
     attrs = node.locals.get(name, [])
 
@@ -36,7 +54,7 @@ def _lookup_in_mro(node, name) -> list:
     if not values:
         raise AttributeInferenceError(attribute=name, target=node)
 
-    return values
+    return _drop_overloads(values)
 
 
 def lookup(

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7277,3 +7277,32 @@ def test_joined_str_uninferable() -> None:
     assert formatted_value.value.as_string() == "hey()"
     inferred = next(joined_str.infer())
     assert inferred is util.Uninferable
+
+
+def test_overloaded_dunder_uses_implementation() -> None:
+    """Overload stubs must not shadow the real dunder implementation.
+
+    https://github.com/pylint-dev/astroid/issues/2448
+    """
+    code = """
+    from typing import overload
+
+    class Fraction:
+        @overload
+        def __truediv__(self, other: int) -> list: ...
+        @overload
+        def __truediv__(self, other: str) -> list: ...
+        def __truediv__(self, other):
+            return []
+
+        @overload
+        def __neg__(self) -> list: ...
+        def __neg__(self):
+            return []
+
+    Fraction() / 1  #@
+    -Fraction()  #@
+    """
+    binop, unaryop = extract_node(code)
+    assert isinstance(next(binop.infer()), nodes.List)
+    assert isinstance(next(unaryop.infer()), nodes.List)


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`_lookup_in_mro` returns every matching definition in the MRO, and the operator inference paths (`OperatorNode._invoke_binop_inference`, `UnaryOp._infer`) take `methods[0]`. When a special method is written with `@typing.overload`, that first entry is a stub whose body is `...`, so `A() / 1` and `-A()` infer `None` instead of the implementation's return value — which is what surfaces as the false `not-an-iterable` / `no-member` in the issue. Attribute access is unaffected because `igetattr` already resolves to the implementation.

This filters `typing.overload`-decorated definitions out of the dunder lookup when a real implementation is present. Added a regression test covering the binary and unary operator paths; it fails on `main` and passes with the fix, and the full test suite is green.

Closes #2448
