### PR TITLE
Fix extract_node() skipping docstring nodes

### DIFF
--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -381,6 +381,12 @@ def _find_statement_by_line(node: nodes.NodeNG, line: int) -> nodes.NodeNG | Non
     if node_line == line:
         return node
 
+    # A docstring is not part of get_children(), so it has to be checked
+    # explicitly, otherwise a selector placed on it is never matched.
+    doc_node = getattr(node, "doc_node", None)
+    if doc_node is not None and doc_node.lineno == line:
+        return doc_node
+
     for child in node.get_children():
         result = _find_statement_by_line(child, line)
         if result:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -877,6 +877,25 @@ def test_arguments_of_signature() -> None:
     assert all(i.args.args is None for i in classdef.getattr("__dir__"))
 
 
+def test_extract_node_docstring() -> None:
+    """A selector on a docstring line extracts the docstring node itself."""
+    for code in (
+        """
+        class A:
+            "cls doc"  #@
+            pass
+        """,
+        """
+        def f():
+            "fn doc"  #@
+            pass
+        """,
+    ):
+        node = builder.extract_node(code)
+        assert isinstance(node, nodes.Const)
+        assert node.value.endswith("doc")
+
+
 class HermeticInterpreterTest(unittest.TestCase):
     """Modeled on https://github.com/pylint-dev/astroid/pull/1207#issuecomment-951455588."""
 


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

A `#@` selector placed on a class or function docstring matched nothing, because `_find_statement_by_line()` recurses through `get_children()`, which does not include `doc_node`. `extract_node()` therefore returned an empty list instead of the docstring node.

`doc_node` is now checked explicitly before recursing into the children.

Note: no ChangeLog entry is included because the extensionless `ChangeLog` file is rejected by the tooling I run changes through; happy to add the entry if you prefer it in the PR.

Closes #2675
