### PR TITLE
Add test for inference of the `decimal` modules

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,8 @@ Release date: TBA
 
   Closes #600
 
+* Add brain for `decimal` that gets applied if `_decimal` isn't available.
+
 * Removed the `**kwargs` argument from all `infer` functions.
   Users upgrading their `astroid` versions should ensure they do no pass values other than
   `context` to `infer`.

--- a/astroid/brain/brain_decimal.py
+++ b/astroid/brain/brain_decimal.py
@@ -1,0 +1,20 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
+
+from astroid import nodes
+from astroid.brain.helpers import register_module_extender
+from astroid.builder import AstroidBuilder
+from astroid.manager import AstroidManager
+
+
+def decimal_transform() -> nodes.Module:
+    """The _decimal module is not always available and the _pydecimal fallback can't be inferred."""
+    return AstroidBuilder(AstroidManager()).string_build("from _pydecimal import *")
+
+
+def register(manager: AstroidManager) -> None:
+    try:
+        import _decimal  # pylint: disable=unused-import,import-outside-toplevel
+    except ImportError:
+        register_module_extender(manager, "decimal", decimal_transform)

--- a/astroid/brain/helpers.py
+++ b/astroid/brain/helpers.py
@@ -43,6 +43,7 @@ def register_all_brains(manager: AstroidManager) -> None:
         brain_dataclasses,
         brain_datetime,
         brain_dateutil,
+        brain_decimal,
         brain_functools,
         brain_gi,
         brain_hashlib,
@@ -95,6 +96,7 @@ def register_all_brains(manager: AstroidManager) -> None:
     brain_dataclasses.register(manager)
     brain_datetime.register(manager)
     brain_dateutil.register(manager)
+    brain_decimal.register(manager)
     brain_functools.register(manager)
     brain_gi.register(manager)
     brain_hashlib.register(manager)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7277,3 +7277,19 @@ def test_joined_str_uninferable() -> None:
     assert formatted_value.value.as_string() == "hey()"
     inferred = next(joined_str.infer())
     assert inferred is util.Uninferable
+
+
+def test_decimal_inference():
+    """
+    Test we can infer the Decimal class from both the decimal and _pydecimal modules.
+
+    decimal uses _decimal by default, but that can be unavailable. The fallback can't be inferred
+    by default so we have a brain.
+    """
+    code = """
+    from decimal import Decimal #@
+    from _pydecimal import Decimal #@
+    """
+    for node in extract_node(code):
+        module = node.do_import_module(node.modname)
+        module.getattr(node.names[0][0])


### PR DESCRIPTION
Hope this can help with understanding the failure in https://github.com/pylint-dev/pylint/pull/11188.

It passes on my Mac and Linux machine, but something seems to be up in the `pylint` CI.