### PR TITLE
Remove Python 2 era dead code and outdated comments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,12 @@ Release date: TBA
   a variable: checking a value made the ``isinstance`` classinfo uninferable
   for the checks of the following values.
 
+* Remove Python 2 era dead code and outdated comments.
+  Notably: the internal ``TreeRebuilder`` constructor no longer takes a
+  ``parser_module`` argument.
+
+  Refs #3154
+
 * Fix inference of a starred target that is not last in a ``for`` loop, such as
   ``for a, *b, c in ...``. The elements following the starred one were counted
   from the target's own arity rather than from the end of the iterable, so

--- a/astroid/_ast.py
+++ b/astroid/_ast.py
@@ -98,5 +98,4 @@ def _contexts_from_module() -> dict[type[ast.expr_context], Context]:
         ast.Load: Context.Load,
         ast.Store: Context.Store,
         ast.Del: Context.Del,
-        ast.Param: Context.Store,
     }

--- a/astroid/_ast.py
+++ b/astroid/_ast.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import ast
-from typing import NamedTuple
+from typing import Final, NamedTuple
 
 from astroid.const import Context
 
@@ -15,87 +15,55 @@ class FunctionType(NamedTuple):
     returns: ast.expr
 
 
-class ParserModule(NamedTuple):
-    unary_op_classes: dict[type[ast.unaryop], str]
-    cmp_op_classes: dict[type[ast.cmpop], str]
-    bool_op_classes: dict[type[ast.boolop], str]
-    bin_op_classes: dict[type[ast.operator], str]
-    context_classes: dict[type[ast.expr_context], Context]
-
-    def parse(
-        self, string: str, type_comments: bool = True, filename: str | None = None
-    ) -> ast.Module:
-        if filename:
-            return ast.parse(string, filename=filename, type_comments=type_comments)
-        return ast.parse(string, type_comments=type_comments)
-
-
 def parse_function_type_comment(type_comment: str) -> FunctionType | None:
     """Given a correct type comment, obtain a FunctionType object."""
     func_type = ast.parse(type_comment, "<type_comment>", "func_type")
     return FunctionType(argtypes=func_type.argtypes, returns=func_type.returns)
 
 
-def get_parser_module(type_comments: bool = True) -> ParserModule:
-    unary_op_classes = _unary_operators_from_module()
-    cmp_op_classes = _compare_operators_from_module()
-    bool_op_classes = _bool_operators_from_module()
-    bin_op_classes = _binary_operators_from_module()
-    context_classes = _contexts_from_module()
+UNARY_OP_CLASSES: Final[dict[type[ast.unaryop], str]] = {
+    ast.UAdd: "+",
+    ast.USub: "-",
+    ast.Not: "not",
+    ast.Invert: "~",
+}
 
-    return ParserModule(
-        unary_op_classes,
-        cmp_op_classes,
-        bool_op_classes,
-        bin_op_classes,
-        context_classes,
-    )
+BIN_OP_CLASSES: Final[dict[type[ast.operator], str]] = {
+    ast.Add: "+",
+    ast.BitAnd: "&",
+    ast.BitOr: "|",
+    ast.BitXor: "^",
+    ast.Div: "/",
+    ast.FloorDiv: "//",
+    ast.MatMult: "@",
+    ast.Mod: "%",
+    ast.Mult: "*",
+    ast.Pow: "**",
+    ast.Sub: "-",
+    ast.LShift: "<<",
+    ast.RShift: ">>",
+}
 
+BOOL_OP_CLASSES: Final[dict[type[ast.boolop], str]] = {
+    ast.And: "and",
+    ast.Or: "or",
+}
 
-def _unary_operators_from_module() -> dict[type[ast.unaryop], str]:
-    return {ast.UAdd: "+", ast.USub: "-", ast.Not: "not", ast.Invert: "~"}
+CMP_OP_CLASSES: Final[dict[type[ast.cmpop], str]] = {
+    ast.Eq: "==",
+    ast.Gt: ">",
+    ast.GtE: ">=",
+    ast.In: "in",
+    ast.Is: "is",
+    ast.IsNot: "is not",
+    ast.Lt: "<",
+    ast.LtE: "<=",
+    ast.NotEq: "!=",
+    ast.NotIn: "not in",
+}
 
-
-def _binary_operators_from_module() -> dict[type[ast.operator], str]:
-    return {
-        ast.Add: "+",
-        ast.BitAnd: "&",
-        ast.BitOr: "|",
-        ast.BitXor: "^",
-        ast.Div: "/",
-        ast.FloorDiv: "//",
-        ast.MatMult: "@",
-        ast.Mod: "%",
-        ast.Mult: "*",
-        ast.Pow: "**",
-        ast.Sub: "-",
-        ast.LShift: "<<",
-        ast.RShift: ">>",
-    }
-
-
-def _bool_operators_from_module() -> dict[type[ast.boolop], str]:
-    return {ast.And: "and", ast.Or: "or"}
-
-
-def _compare_operators_from_module() -> dict[type[ast.cmpop], str]:
-    return {
-        ast.Eq: "==",
-        ast.Gt: ">",
-        ast.GtE: ">=",
-        ast.In: "in",
-        ast.Is: "is",
-        ast.IsNot: "is not",
-        ast.Lt: "<",
-        ast.LtE: "<=",
-        ast.NotEq: "!=",
-        ast.NotIn: "not in",
-    }
-
-
-def _contexts_from_module() -> dict[type[ast.expr_context], Context]:
-    return {
-        ast.Load: Context.Load,
-        ast.Store: Context.Store,
-        ast.Del: Context.Del,
-    }
+CONTEXT_CLASSES: Final[dict[type[ast.expr_context], Context]] = {
+    ast.Load: Context.Load,
+    ast.Store: Context.Store,
+    ast.Del: Context.Del,
+}

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -670,7 +670,6 @@ class BoundMethod(UnboundMethod):
             bases=bases.elts,
             body=[empty],
             decorators=None,
-            newstyle=True,
             metaclass=mcs,
             keywords=[],
         )

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -396,9 +396,9 @@ class Instance(BaseInstance):
 
         The truth value of an instance is determined by these conditions:
 
-           * if it implements __bool__ on Python 3 or __nonzero__
-             on Python 2, then its bool value will be determined by
-             calling this special method and checking its result.
+           * if it implements __bool__, then its bool value will be
+             determined by calling this special method and checking
+             its result.
            * when this method is not defined, __len__() is called, if it
              is defined, and the object is considered true if its result is
              nonzero. If a class defines neither __len__() nor __bool__(),

--- a/astroid/brain/brain_collections.py
+++ b/astroid/brain/brain_collections.py
@@ -58,7 +58,6 @@ def _deque_mock():
         def __setitem__(self, index, value): pass
         def __delitem__(self, index): pass
         def __bool__(self): return bool(self.iterable)
-        def __nonzero__(self): return bool(self.iterable)
         def __contains__(self, o): return o in self.iterable
         def __len__(self): return len(self.iterable)
         def __copy__(self): return deque(self.iterable)

--- a/astroid/brain/brain_gi.py
+++ b/astroid/brain/brain_gi.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-"""Astroid hooks for the Python 2 GObject introspection bindings.
+"""Astroid hooks for the GObject introspection bindings.
 
 Helps with understanding everything imported from 'gi.repository'
 """
@@ -39,7 +39,6 @@ _special_methods = frozenset(
         "__delitem__",
         "__len__",
         "__bool__",
-        "__nonzero__",
         "__next__",
         "__str__",
         "__contains__",

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -22,7 +22,6 @@ from tokenize import detect_encoding
 from typing import TYPE_CHECKING, cast
 
 from astroid import bases, modutils, nodes, raw_building, rebuilder, util
-from astroid._ast import ParserModule, get_parser_module
 from astroid.const import PY312_PLUS, PY314_PLUS
 from astroid.exceptions import AstroidBuildingError, AstroidSyntaxError, InferenceError
 
@@ -182,9 +181,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
     ) -> tuple[nodes.Module, rebuilder.TreeRebuilder]:
         """Build tree node from data and add some informations."""
         try:
-            node, parser_module = _parse_string(
-                data, type_comments=True, modname=modname
-            )
+            node = _parse_string(data, type_comments=True, modname=modname)
         except (TypeError, ValueError, SyntaxError, MemoryError) as exc:
             raise AstroidSyntaxError(
                 "Parsing Python code failed:\n{error}",
@@ -206,7 +203,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
                 path is not None
                 and os.path.splitext(os.path.basename(path))[0] == "__init__"
             )
-        builder = rebuilder.TreeRebuilder(self._manager, parser_module, data)
+        builder = rebuilder.TreeRebuilder(self._manager, data)
         module = builder.visit_module(node, modname, node_file, package)
         return module, builder
 
@@ -485,11 +482,10 @@ def _extract_single_node(code: str, module_name: str = "") -> nodes.NodeNG:
 
 def _parse_string(
     data: str, type_comments: bool = True, modname: str | None = None
-) -> tuple[ast.Module, ParserModule]:
-    parser_module = get_parser_module(type_comments=type_comments)
+) -> ast.Module:
     try:
-        parsed = parser_module.parse(
-            data + "\n", type_comments=type_comments, filename=modname
+        parsed = ast.parse(
+            data + "\n", filename=modname or "<unknown>", type_comments=type_comments
         )
     except SyntaxError as exc:
         # If the type annotations are misplaced for some reason, we do not want
@@ -500,6 +496,5 @@ def _parse_string(
         if not (type_annot_related and type_comments):
             raise
 
-        parser_module = get_parser_module(type_comments=False)
-        parsed = parser_module.parse(data + "\n", type_comments=False)
-    return parsed, parser_module
+        parsed = ast.parse(data + "\n", type_comments=False)
+    return parsed

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -614,15 +614,14 @@ class Arguments(
     <Arguments l.1 at 0x7effe1db82e8>
     """
 
-    # Python 3.4+ uses a different approach regarding annotations,
-    # each argument is a new class, _ast.arg, which exposes an
-    # 'annotation' attribute. In astroid though, arguments are exposed
-    # as is in the Arguments node and the only way to expose annotations
-    # is by using something similar with Python 3.3:
-    #  - we expose 'varargannotation' and 'kwargannotation' of annotations
-    #    of varargs and kwargs.
-    #  - we expose 'annotation', a list with annotations for
-    #    for each normal argument. If an argument doesn't have an
+    # In the ast module, each argument is a new class, _ast.arg, which
+    # exposes an 'annotation' attribute. In astroid though, arguments are
+    # exposed as is in the Arguments node, so annotations are exposed
+    # separately:
+    #  - we expose 'varargannotation' and 'kwargannotation' for the
+    #    annotations of varargs and kwargs.
+    #  - we expose 'annotations', a list with annotations for
+    #    each normal argument. If an argument doesn't have an
     #    annotation, its value will be None.
     _astroid_fields = (
         "args",
@@ -2057,7 +2056,7 @@ class Const(_base_nodes.NoChildrenNode, Instance):
 
         :param parent: The parent node in the syntax tree.
 
-        :param kind: The string prefix. "u" for u-prefixed strings and ``None`` otherwise. Python 3.8+ only.
+        :param kind: The string prefix. "u" for u-prefixed strings and ``None`` otherwise.
 
         :param end_lineno: The last line this node appears on in the source code.
 
@@ -2077,7 +2076,7 @@ class Const(_base_nodes.NoChildrenNode, Instance):
         """The value that the constant represents."""
 
         self.kind: str | None = kind  # can be None
-        """"The string prefix. "u" for u-prefixed strings and ``None`` otherwise. Python 3.8+ only."""
+        """"The string prefix. "u" for u-prefixed strings and ``None`` otherwise."""
 
         super().__init__(
             lineno=lineno,
@@ -4239,7 +4238,7 @@ UNARY_OP_METHOD = {
     "+": "__pos__",
     "-": "__neg__",
     "~": "__invert__",
-    "not": None,  # XXX not '__nonzero__'
+    "not": None,  # 'not' delegates to __bool__, there is no dedicated method
 }
 
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -58,14 +58,11 @@ class NodeNG:
 
     is_statement: ClassVar[bool] = False
     """Whether this node indicates a statement."""
-    optional_assign: ClassVar[bool] = (
-        False  # True for For (and for Comprehension if py <3.0)
-    )
+    optional_assign: ClassVar[bool] = False  # True for For
     """Whether this node optionally assigns a variable.
 
     This is for loop assignments because loop won't necessarily perform an
     assignment if the loop has no iterations.
-    This is also the case from comprehensions in Python 2.
     """
     is_function: ClassVar[bool] = False  # True for FunctionDef nodes
     """Whether this node indicates a function."""

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2641,11 +2641,8 @@ class ClassDef(
     ) -> SuccessfulInferenceResult | None:
         """Return the explicit declared metaclass for the current class.
 
-        An explicit declared metaclass is defined
-        either by passing the ``metaclass`` keyword argument
-        in the class definition line (Python 3) or (Python 2) by
-        having a ``__metaclass__`` class attribute, or if there are
-        no explicit bases but there is a global ``__metaclass__`` variable.
+        An explicit declared metaclass is defined by passing the
+        ``metaclass`` keyword argument in the class definition line.
 
         :returns: The metaclass of this class,
             or None if one could not be found.
@@ -2661,7 +2658,6 @@ class ClassDef(
                 pass
 
         if self._metaclass:
-            # Expects this from Py3k TreeRebuilder
             try:
                 return next(
                     node

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -205,11 +205,7 @@ class Module(LocalsDictNodeNG):
     """The string/bytes that this ast was built from."""
 
     file_encoding: str | None = None
-    """The encoding of the source file.
-
-    This is used to get unicode out of a source file.
-    Python 2 only.
-    """
+    """The encoding of the source file."""
 
     special_attributes = ModuleModel()
     """The names of special attributes that this module has."""

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -261,9 +261,8 @@ class DictInstance(bases.Instance):
     special_attributes = objectmodel.DictModel()
 
 
-# Custom objects tailored for dictionaries, which are used to
-# disambiguate between the types of Python 2 dict's method returns
-# and Python 3 (where they return set like objects).
+# Custom objects tailored for dictionary views
+# returned by dict.items(), dict.keys() and dict.values().
 class DictItems(bases.Proxy):
     __str__ = node_classes.NodeNG.__str__
     __repr__ = node_classes.NodeNG.__repr__

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -363,7 +363,6 @@ def _base_class_object_build(
     name = getattr(member, "__name__", "<no-name>")
     doc = member.__doc__ if isinstance(member.__doc__, str) else None
     klass = build_class(name, node, basenames, doc)
-    klass._newstyle = isinstance(member, type)
     try:
         # limit the instantiation trick since it's too dangerous
         # (such as infinite test execution...)

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -397,8 +397,7 @@ def _build_from_function(
     try:
         code = member.__code__  # type: ignore[union-attr]
     except AttributeError:
-        # Some implementations don't provide the code object,
-        # such as Jython.
+        # Some implementations don't provide the code object
         code = None
     filename = getattr(code, "co_filename", None)
     if filename is None:
@@ -522,8 +521,8 @@ class InspectBuilder:
                     continue
                 child = nodes.const_factory(member)
             elif inspect.isroutine(member):
-                # This should be called for Jython, where some builtin
-                # methods aren't caught by isbuiltin branch.
+                # Callables not caught by the isfunction/isbuiltin branches
+                # above, e.g. some method descriptors.
                 child = _build_from_function(node, member, self._module)
             elif _safe_has_attribute(member, "__all__"):
                 child: nodes.NodeNG = build_module(alias)
@@ -547,9 +546,7 @@ class InspectBuilder:
             modname = None
         if modname is None:
             if name in {"__new__", "__subclasshook__"}:
-                # Python 2.5.1 (r251:54863, Sep  1 2010, 22:03:14)
-                # >>> print object.__new__.__module__
-                # None
+                # Some builtins have no __module__, e.g. object.__new__
                 modname = builtins.__name__
             else:
                 attach_dummy_node(node, name, member)

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -962,7 +962,6 @@ class TreeRebuilder:
         # /!\ node is actually an _ast.FunctionDef node while
         # parent is an astroid.nodes.FunctionDef node
 
-        # Set the line number of the first decorator for Python 3.8+.
         lineno = node.decorator_list[0].lineno
         end_lineno = node.decorator_list[-1].end_lineno
         end_col_offset = node.decorator_list[-1].end_col_offset
@@ -1169,9 +1168,8 @@ class TreeRebuilder:
 
         lineno = node.lineno
         if node.decorator_list:
-            # Python 3.8 sets the line number of a decorated function
-            # to be the actual line number of the function, but the
-            # previous versions expected the decorator's line number instead.
+            # The ast parser of python < 3.8 incorrectly set the line number of
+            # a decorated function to the line of its first decorator.
             # We reset the function's line number to that of the
             # first decorator to maintain backward compatibility.
             # It's not ideal but this discrepancy was baked into

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -18,7 +18,14 @@ from tokenize import TokenError, TokenInfo, generate_tokens
 from typing import TYPE_CHECKING, Final, TypeVar, cast, overload
 
 from astroid import nodes
-from astroid._ast import ParserModule, get_parser_module, parse_function_type_comment
+from astroid._ast import (
+    BIN_OP_CLASSES,
+    BOOL_OP_CLASSES,
+    CMP_OP_CLASSES,
+    CONTEXT_CLASSES,
+    UNARY_OP_CLASSES,
+    parse_function_type_comment,
+)
 from astroid.const import PY312_PLUS, PY313_PLUS, Context
 from astroid.nodes.utils import Position
 from astroid.typing import InferenceResult
@@ -56,7 +63,6 @@ class TreeRebuilder:
     def __init__(
         self,
         manager: AstroidManager,
-        parser_module: ParserModule | None = None,
         data: str | None = None,
     ) -> None:
         self._manager = manager
@@ -67,11 +73,6 @@ class TreeRebuilder:
         self._visit_meths: dict[
             type[ast.AST], Callable[[ast.AST, nodes.NodeNG], nodes.NodeNG]
         ] = {}
-
-        if parser_module is None:
-            self._parser_module = get_parser_module()
-        else:
-            self._parser_module = parser_module
 
     def _get_doc(self, node: T_Doc) -> tuple[T_Doc, ast.Constant | None]:
         """Return the doc ast node."""
@@ -99,7 +100,7 @@ class TreeRebuilder:
             | ast.Tuple
         ),
     ) -> Context:
-        return self._parser_module.context_classes.get(type(node.ctx), Context.Load)
+        return CONTEXT_CLASSES.get(type(node.ctx), Context.Load)
 
     def _get_position_info(
         self,
@@ -646,7 +647,7 @@ class TreeRebuilder:
             return None
 
         try:
-            type_comment_ast = self._parser_module.parse(node.type_comment)
+            type_comment_ast = ast.parse(node.type_comment, type_comments=True)
         except (SyntaxError, ValueError, MemoryError, RecursionError):
             # Invalid type comment, just skip it. ``ast.parse`` may raise
             # ``MemoryError``/``RecursionError``/``ValueError`` on pathological
@@ -787,7 +788,7 @@ class TreeRebuilder:
     ) -> nodes.AugAssign:
         """Visit a AugAssign node by returning a fresh instance of it."""
         newnode = nodes.AugAssign(
-            op=self._parser_module.bin_op_classes[type(node.op)] + "=",
+            op=BIN_OP_CLASSES[type(node.op)] + "=",
             lineno=node.lineno,
             col_offset=node.col_offset,
             end_lineno=node.end_lineno,
@@ -802,7 +803,7 @@ class TreeRebuilder:
     def visit_binop(self, node: ast.BinOp, parent: nodes.NodeNG) -> nodes.BinOp:
         """Visit a BinOp node by returning a fresh instance of it."""
         newnode = nodes.BinOp(
-            op=self._parser_module.bin_op_classes[type(node.op)],
+            op=BIN_OP_CLASSES[type(node.op)],
             lineno=node.lineno,
             col_offset=node.col_offset,
             end_lineno=node.end_lineno,
@@ -817,7 +818,7 @@ class TreeRebuilder:
     def visit_boolop(self, node: ast.BoolOp, parent: nodes.NodeNG) -> nodes.BoolOp:
         """Visit a BoolOp node by returning a fresh instance of it."""
         newnode = nodes.BoolOp(
-            op=self._parser_module.bool_op_classes[type(node.op)],
+            op=BOOL_OP_CLASSES[type(node.op)],
             lineno=node.lineno,
             col_offset=node.col_offset,
             end_lineno=node.end_lineno,
@@ -919,7 +920,7 @@ class TreeRebuilder:
             self.visit(node.left, newnode),
             [
                 (
-                    self._parser_module.cmp_op_classes[op.__class__],
+                    CMP_OP_CLASSES[op.__class__],
                     self.visit(expr, newnode),
                 )
                 for (op, expr) in zip(node.ops, node.comparators)
@@ -1760,7 +1761,7 @@ class TreeRebuilder:
     def visit_unaryop(self, node: ast.UnaryOp, parent: nodes.NodeNG) -> nodes.UnaryOp:
         """Visit a UnaryOp node by returning a fresh instance of it."""
         newnode = nodes.UnaryOp(
-            op=self._parser_module.unary_op_classes[node.op.__class__],
+            op=UNARY_OP_CLASSES[node.op.__class__],
             lineno=node.lineno,
             col_offset=node.col_offset,
             end_lineno=node.end_lineno,

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -855,7 +855,7 @@ class TreeRebuilder:
         return newnode
 
     def visit_classdef(
-        self, node: ast.ClassDef, parent: nodes.NodeNG, newstyle: bool = True
+        self, node: ast.ClassDef, parent: nodes.NodeNG
     ) -> nodes.ClassDef:
         """Visit a ClassDef node to become astroid."""
         node, doc_ast_node = self._get_doc(node)
@@ -877,9 +877,8 @@ class TreeRebuilder:
             [self.visit(child, newnode) for child in node.bases],
             [self.visit(child, newnode) for child in node.body],
             decorators,
-            newstyle,
-            metaclass,
-            [
+            metaclass=metaclass,
+            keywords=[
                 self.visit(kwd, newnode)
                 for kwd in node.keywords
                 if kwd.arg != "metaclass"

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1397,11 +1397,10 @@ class TreeRebuilder:
         """Visit a Keyword node by returning a fresh instance of it."""
         newnode = nodes.Keyword(
             arg=node.arg,
-            # position attributes added in 3.9
-            lineno=getattr(node, "lineno", None),
-            col_offset=getattr(node, "col_offset", None),
-            end_lineno=getattr(node, "end_lineno", None),
-            end_col_offset=getattr(node, "end_col_offset", None),
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            end_lineno=node.end_lineno,
+            end_col_offset=node.end_col_offset,
             parent=parent,
         )
         newnode.postinit(self.visit(node.value, newnode))
@@ -1603,11 +1602,10 @@ class TreeRebuilder:
     def visit_slice(self, node: ast.Slice, parent: nodes.Subscript) -> nodes.Slice:
         """Visit a Slice node by returning a fresh instance of it."""
         newnode = nodes.Slice(
-            # position attributes added in 3.9
-            lineno=getattr(node, "lineno", None),
-            col_offset=getattr(node, "col_offset", None),
-            end_lineno=getattr(node, "end_lineno", None),
-            end_col_offset=getattr(node, "end_col_offset", None),
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            end_lineno=node.end_lineno,
+            end_col_offset=node.end_col_offset,
             parent=parent,
         )
         newnode.postinit(

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -43,8 +43,6 @@ class UninferableBase:
     def __bool__(self) -> Literal[False]:
         return False
 
-    __nonzero__ = __bool__
-
     def accept(self, visitor):
         return visitor.visit_uninferable(self)
 


### PR DESCRIPTION
## Type of Changes

| ✓ | Type |
| --- | --- |
| ✓ | :scissors: Refactoring |

## Description

Astroid lived through Python 2.4 to 3.15; with the minimum interpreter now at Python 3.10, several remnants of the Python 2 / `typed_ast` era are dead code:

- **`astroid/_ast.py`**: drop the unused `ast.Param` context mapping — the Python 3 parser never emits the `Param` expression context (it was the Python 2 context for function parameters). Collapse the `ParserModule`/`get_parser_module` indirection into module-level constants: this machinery existed to select between `ast` and `typed_ast` (pre-3.8 type comment support) and ended up rebuilding the same five static dicts on every single parse. `get_parser_module`'s `type_comments` parameter wasn't even used.
- **`astroid/rebuilder.py`**: `TreeRebuilder` no longer takes a `parser_module` argument; `visit_classdef` no longer threads the ignored `newstyle` argument into `ClassDef.postinit` (which never stored it).
- **`astroid/builder.py`**: `_parse_string` calls `ast.parse` directly and returns just the parsed module.
- **`astroid/util.py`**: remove `__nonzero__ = __bool__` on `UninferableBase` (Python 2 truth protocol).
- **`astroid/brain/brain_collections.py`**: remove `__nonzero__` from the `deque` stub — Python 3 `deque` has no such method, so astroid was inferring an attribute that doesn't exist.
- **`astroid/raw_building.py`**: remove the write-only `_newstyle` attribute (nothing reads it; all Python 3 classes are new-style).
- Comment/docstring cleanups: `Module.file_encoding` is not "Python 2 only" (pylint reads it), `declared_metaclass` no longer claims to look up Python 2 `__metaclass__`, drop mentions of Jython, "Py3k TreeRebuilder", the Python 2.5.1 interpreter transcript, Python 3.3/3.4/3.8 version narratives, and the `# XXX not '__nonzero__'` note.

No behavior change intended: the removed code paths were unreachable or write-only on Python 3. `ClassDef.postinit(newstyle=...)` keeps accepting the parameter for compatibility; only internal callers stopped passing it.

Net: -54 lines.