### PR TITLE
Apply comprehension conditions as inference constraints

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Fix ``isinstance()`` constraints only filtering the first inferred value of
+  a variable: checking a value made the ``isinstance`` classinfo uninferable
+  for the checks of the following values.
+
 * Fix inference of a starred target that is not last in a ``for`` loop, such as
   ``for a, *b, c in ...``. The elements following the starred one were counted
   from the target's own arity rather than from the end of the iterable, so

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,13 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Comprehension conditions now constrain the inference of names used in the
+  comprehension, like ``if`` statement conditions already did:
+  ``[x for x in lst if x is not None]`` no longer infers ``None`` for ``x``
+  in the element expression.
+
+  Refs #3094
+
 * Fix ``isinstance()`` constraints only filtering the first inferred value of
   a variable: checking a value made the ``isinstance`` classinfo uninferable
   for the checks of the following values.

--- a/astroid/constraint.py
+++ b/astroid/constraint.py
@@ -249,17 +249,18 @@ class EqualityConstraint(Constraint):
 
 def get_constraints(
     expr: _NameNodes, frame: nodes.LocalsDictNodeNG
-) -> dict[nodes.If | nodes.IfExp, set[Constraint]]:
+) -> dict[nodes.NodeNG, set[Constraint]]:
     """Returns the constraints for the given expression.
 
     The returned dictionary maps the node where the constraint was generated to the
     corresponding constraint(s).
 
     Constraints are computed statically by analysing the code surrounding expr.
-    Currently this only supports constraints generated from if conditions.
+    Currently this only supports constraints generated from if conditions and
+    comprehension conditions.
     """
     current_node: nodes.NodeNG | None = expr
-    constraints_mapping: dict[nodes.If | nodes.IfExp, set[Constraint]] = {}
+    constraints_mapping: dict[nodes.NodeNG, set[Constraint]] = {}
     while current_node is not None and current_node is not frame:
         parent = current_node.parent
         if isinstance(parent, (nodes.If, nodes.IfExp)):
@@ -272,9 +273,37 @@ def get_constraints(
 
             if constraints:
                 constraints_mapping[parent] = constraints
+        elif isinstance(parent, nodes.Comprehension) and current_node in parent.ifs:
+            # Preceding conditions of the same generator guard this condition.
+            index = parent.ifs.index(current_node)
+            _add_ifs_constraints(expr, parent.ifs[:index], constraints_mapping)
+        elif isinstance(
+            parent, (nodes.ListComp, nodes.SetComp, nodes.DictComp, nodes.GeneratorExp)
+        ):
+            branch, _ = parent.locate_child(current_node)
+            if branch == "generators":
+                # Conditions guard the iterables of all later generators.
+                index = parent.generators.index(current_node)
+                generators = parent.generators[:index]
+            else:  # elt, key or value: guarded by all conditions
+                generators = parent.generators
+            for comprehension in generators:
+                _add_ifs_constraints(expr, comprehension.ifs, constraints_mapping)
         current_node = parent
 
     return constraints_mapping
+
+
+def _add_ifs_constraints(
+    expr: _NameNodes,
+    ifs: list[nodes.NodeNG],
+    constraints_mapping: dict[nodes.NodeNG, set[Constraint]],
+) -> None:
+    """Add the constraints matching each comprehension condition in ifs."""
+    for if_expr in ifs:
+        constraints = set(_match_constraint(expr, if_expr))
+        if constraints:
+            constraints_mapping[if_expr] = constraints
 
 
 ALL_CONSTRAINT_CLASSES = frozenset(

--- a/astroid/constraint.py
+++ b/astroid/constraint.py
@@ -171,6 +171,12 @@ class TypeConstraint(Constraint):
         if inferred is util.Uninferable:
             return True
 
+        # This method is called once per inferred value, with the same context.
+        # Use a clone: inferring the classinfo pushes it onto the context's
+        # inference path but only its first value is consumed, so nothing is
+        # cached and a reused context would make the classinfo uninferable
+        # from the second call on.
+        context = context.clone()
         try:
             types = helpers.class_or_tuple_to_container(self.classinfo, context)
             matches_checked_types = helpers.object_isinstance(inferred, types, context)

--- a/astroid/constraint.py
+++ b/astroid/constraint.py
@@ -273,10 +273,14 @@ def get_constraints(
 
             if constraints:
                 constraints_mapping[parent] = constraints
-        elif isinstance(parent, nodes.Comprehension) and current_node in parent.ifs:
-            # Preceding conditions of the same generator guard this condition.
-            index = parent.ifs.index(current_node)
-            _add_ifs_constraints(expr, parent.ifs[:index], constraints_mapping)
+        elif isinstance(parent, nodes.Comprehension):
+            try:
+                index = parent.ifs.index(current_node)
+            except ValueError:
+                pass
+            else:
+                # Preceding conditions of the same generator guard this condition.
+                _add_ifs_constraints(expr, parent.ifs[:index], constraints_mapping)
         elif isinstance(
             parent, (nodes.ListComp, nodes.SetComp, nodes.DictComp, nodes.GeneratorExp)
         ):

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -77,9 +77,7 @@ class InferenceContext:
         self.extra_context: dict[SuccessfulInferenceResult, InferenceContext] = {}
         """Context that needs to be passed down through call stacks for call arguments."""
 
-        self.constraints: dict[
-            str, dict[nodes.If | nodes.IfExp, set[constraint.Constraint]]
-        ] = {}
+        self.constraints: dict[str, dict[nodes.NodeNG, set[constraint.Constraint]]] = {}
         """The constraints on nodes."""
 
     @property

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -1141,3 +1141,46 @@ def test_equality_fractions():
         assert isinstance(inferred[0], Instance), msg
         assert isinstance(inferred[0]._proxied, nodes.ClassDef), msg
         assert inferred[0]._proxied.name == "Fraction", msg
+
+
+def test_isinstance_multiple_inferred_values() -> None:
+    """Test that an isinstance() constraint filters every inferred value.
+
+    Checking a value must not pollute the inference context used to check
+    the following ones.
+    """
+    node = builder.extract_node("""
+    def f(y):
+        x = 2 if y else "a"
+        if isinstance(x, int):
+            return (
+                x  #@
+            )
+    """)
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 2
+
+
+def test_equality_multiple_inferred_values() -> None:
+    """Test that an equality constraint with a name operand filters every
+    inferred value.
+
+    Checking a value must not pollute the inference context used to check
+    the following ones.
+    """
+    node = builder.extract_node("""
+    y = 1
+
+    def f(cond):
+        x = 1 if cond else 2
+        if x == y:
+            return (
+                x  #@
+            )
+    """)
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 1

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -1143,6 +1143,103 @@ def test_equality_fractions():
         assert inferred[0]._proxied.name == "Fraction", msg
 
 
+@common_params(node="x")
+def test_comprehension_condition(
+    condition: str, satisfy_val: int | None, fail_val: int | None
+) -> None:
+    """Test constraint for a comprehension target used in the element expression."""
+    node = builder.extract_node(
+        f"[x for x in [{satisfy_val}, {fail_val}] if {condition}]"
+    )
+    inferred = node.elt.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == satisfy_val
+
+
+def test_comprehension_condition_all_comprehension_types() -> None:
+    """Test that comprehension conditions apply in every type of comprehension."""
+    list_comp, set_comp, gen_exp, dict_comp = builder.extract_node("""
+    [x for x in [None, 3] if x is not None]  #@
+    {x for x in [None, 3] if x is not None}  #@
+    (x for x in [None, 3] if x is not None)  #@
+    {x: x for x in [None, 3] if x is not None}  #@
+    """)
+    for comp in (list_comp, set_comp, gen_exp):
+        msg = node_info(comp)
+        inferred = comp.elt.inferred()
+        assert len(inferred) == 1, msg
+        assert isinstance(inferred[0], nodes.Const), msg
+        assert inferred[0].value == 3, msg
+
+    for expr in (dict_comp.key, dict_comp.value):
+        inferred = expr.inferred()
+        assert len(inferred) == 1
+        assert isinstance(inferred[0], nodes.Const)
+        assert inferred[0].value == 3
+
+
+def test_comprehension_condition_unsupported_pattern() -> None:
+    """Test that a condition matching no supported constraint doesn't filter."""
+    node = builder.extract_node("[L for L in [[1, 2], [3, 4]] if sum(L) == 3]")
+    inferred = node.elt.inferred()
+    assert [elt.as_string() for elt in inferred] == ["[1, 2]", "[3, 4]"]
+
+
+def test_comprehension_condition_multiple_conditions() -> None:
+    """Test that all conditions apply to the element expression and that earlier
+    conditions also guard later ones.
+    """
+    node = builder.extract_node("[x for x in [None, 3, 4] if x is not None if x == 3]")
+    inferred = node.elt.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 3
+
+    # ``x`` in the second condition is only guarded by the first condition.
+    second_condition = node.generators[0].ifs[1]
+    inferred = second_condition.left.inferred()
+    assert [const.value for const in inferred] == [3, 4]
+
+
+def test_comprehension_condition_guards_later_generators() -> None:
+    """Test that a generator's conditions guard the iterables of later generators."""
+    node = builder.extract_node("[y for x in [None, [3]] if x is not None for y in x]")
+    inferred = node.elt.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 3
+
+
+def test_comprehension_condition_does_not_guard_same_generator() -> None:
+    """Test that a generator's conditions don't constrain its own target, iterable
+    or the element of a preceding generator.
+    """
+    node = builder.extract_node("""
+    def f(y = None):
+        return [x for x in [y] if y is not None]  #@
+    """)
+    # ``y`` in the iterable is not constrained by the condition.
+    iter_elt = node.value.generators[0].iter.elts[0]
+    inferred = iter_elt.inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value is None
+    assert inferred[1] is Uninferable
+
+
+def test_comprehension_condition_outer_name() -> None:
+    """Test that comprehension conditions constrain names from outer scopes
+    used in the element expression.
+    """
+    node = builder.extract_node("""
+    def f(y = None):
+        return [y for x in [1, 2] if y is not None]  #@
+    """)
+    inferred = node.value.elt.inferred()
+    assert inferred == [Uninferable]
+
+
 def test_isinstance_multiple_inferred_values() -> None:
     """Test that an isinstance() constraint filters every inferred value.
 

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -1281,3 +1281,38 @@ def test_equality_multiple_inferred_values() -> None:
     assert len(inferred) == 1
     assert isinstance(inferred[0], nodes.Const)
     assert inferred[0].value == 1
+
+
+def test_comprehension_condition_nested_in_call() -> None:
+    """Test that comprehension conditions constrain a name nested inside a call."""
+    node = builder.extract_node("[f(x) for x in [None, 1] if x is not None]")
+    inferred = node.elt.args[0].inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 1
+
+    node = builder.extract_node(
+        "[y for x in [None, 1] if x is not None for y in make_iter(x)]"
+    )
+    inferred = node.generators[1].iter.args[0].inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 1
+
+
+def test_comprehension_condition_nested_comprehension() -> None:
+    """Test that comprehension conditions constrain a name used inside an inner
+    comprehension.
+    """
+    node = builder.extract_node(
+        "[[y for y in x] for x in [None, [1]] if x is not None]"
+    )
+    inner = node.elt
+
+    inferred = inner.generators[0].iter.inferred()
+    assert [iterable.as_string() for iterable in inferred] == ["[1]"]
+
+    inferred = inner.elt.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 1


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :bug: Bug fix          |

## Description

Follow-up to [the review discussion in #3094](https://github.com/pylint-dev/astroid/pull/3094#discussion_r3651237329): inference ignored comprehension conditions entirely, with or without unpacking.

Comprehension conditions now generate the same constraints as `if` statement conditions (`is None`, truthiness, `isinstance()`, `==`/`!=`). The conditions of a generator apply to the element expression, to later conditions of the same generator, and to everything in later generators — but not to the generator's own target or iterable:

```python
[x for x in [None, 1] if x is not None]  # x in the element now infers only 1
```

Conditions matching no supported constraint pattern keep the previous unfiltered behavior, so the exact example from #3094 (`if sum(L) == 3`) still infers both values — same conservative behavior as `if` statements.

Writing the tests exposed a pre-existing constraint bug, fixed in the first commit: `TypeConstraint.satisfied_by` is called once per inferred value with the same inference context, and inferring the classinfo pushed it onto the context's inference path without ever caching it (`class_or_tuple_to_container` abandons the generator after one value, so `NodeNG.infer` never reaches its cache-write). From the second value on the classinfo was uninferable and every value passed the check:

```python
def f(y):
    x = 2 if y else "a"
    if isinstance(x, int):
        x  # inferred 2 AND "a" before, now only 2
```