### PR TITLE
Release 4.2.0b5

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -62,6 +62,7 @@ Contributors
 - David Shea <dshea@redhat.com>
 - Daniel Harding <dharding@gmail.com>
 - Christian Clauss <cclauss@me.com>
+- Dani Alcala <112832187+clavedeluna@users.noreply.github.com>
 - Ville Skyttä <ville.skytta@iki.fi>
 - Synrom <30272537+Synrom@users.noreply.github.com>
 - Rene Zhang <rz99@cornell.edu>
@@ -74,9 +75,9 @@ Contributors
 - James Addison <55152140+jayaddison@users.noreply.github.com>
 - FELD Boris <lothiraldan@gmail.com>
 - Enji Cooper <yaneurabeya@gmail.com>
-- Dani Alcala <112832187+clavedeluna@users.noreply.github.com>
 - Adrien Di Mascio <Adrien.DiMascio@logilab.fr>
 - Vincent Gao <gaobing1230@gmail.com>
+- Sai Asish Y <say.apm35@gmail.com>
 - tristanlatr <19967168+tristanlatr@users.noreply.github.com>
 - grayjk <grayjk@gmail.com>
 - emile@crater.logilab.fr <emile@crater.logilab.fr>
@@ -112,6 +113,7 @@ Contributors
 - Anthony Truchet <anthony.truchet@logilab.fr>
 - Anthony Sottile <asottile@umich.edu>
 - Alexander Shadchin <alexandr.shadchin@gmail.com>
+- jkmnt <git@firewood.fastmail.com>
 - wgehalo <wgehalo@gmail.com>
 - tejaschauhan36912 <59693377+tejaschauhan36912@users.noreply.github.com>
 - sergiochan <yuheng9211@qq.com>
@@ -124,8 +126,6 @@ Contributors
 - nathannaveen <42319948+nathannaveen@users.noreply.github.com>
 - mathieui <mathieui@users.noreply.github.com>
 - markmcclain <markmcclain@users.noreply.github.com>
-- jkmnt <git@firewood.fastmail.com>
-- Sai Asish Y <say.apm35@gmail.com>
 - ioanatia <ioanatia@users.noreply.github.com>
 - alm <alonme@users.noreply.github.com>
 - adam-grant-hendry <59346180+adam-grant-hendry@users.noreply.github.com>
@@ -226,13 +226,17 @@ Contributors
 - Alexander Presnyakov <flagist0@gmail.com>
 - Ahmed Azzaoui <ahmed.azzaoui@engie.com>
 - nanookclaw <nanook@agentmail.to>
-- SAY-5 <say.apm35@gmail.com>
 - Omkar Kabde <omkarkabde@gmail.com>
 - MJSHANG <shangmengjiajiajia@gmail.com>
 - Kyle D Kavanagh <kkavanagh@jumptrading.com>
 - KALI 834X <kali834x@gmail.com>
 - June <kimjune01@gmail.com>
 - Jam Balaya <jambalaya.pyoncafe@outlook.jp>
+- sayed nabhan <nabhan@bugqore.com>
+- chuenchen309 <48723787+chuenchen309@users.noreply.github.com>
+- Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+- MUHAMED FAZAL PS <107547381+muhamedfazalps@users.noreply.github.com>
+- Genny-oo <156810188+Genny-oo@users.noreply.github.com>
 
 Co-Author
 ---------

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "4.2.0b4"
+__version__ = "4.2.0b5"
 version = __version__

--- a/requirements_minimal.txt
+++ b/requirements_minimal.txt
@@ -1,5 +1,5 @@
 # Tools used when releasing
-contributors-txt>=1.0.2
+contributors-txt>=1.1.0
 tbump~=6.11
 
 # Tools used to run tests

--- a/script/.contributors_aliases.json
+++ b/script/.contributors_aliases.json
@@ -189,6 +189,10 @@
     "name": "Łukasz Rogalski",
     "team": "Maintainers"
   },
+  "say.apm35@gmail.com": {
+    "mails": ["say.apm35@gmail.com"],
+    "name": "Sai Asish Y"
+  },
   "shlomme@gmail.com": {
     "mails": ["shlomme@gmail.com", "tmarek@google.com"],
     "name": "Torsten Marek",

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "4.2.0b4"
+current = "4.2.0b5"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
Used `tbump 4.2.0b5 --no-push --no-tag` but ran into some issues with `pre-commit` on Python 3.15, so committed manually.

Bumps `contributors-txt` as well, as discussed in https://github.com/pylint-dev/astroid/pull/3153