### PR TITLE
Only define _HAS_DEFAULT_FACTORY when a default_factory is used

### DIFF
--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -103,7 +103,7 @@ def dataclass_transform(node: nodes.ClassDef) -> nodes.ClassDef | None:
         node.locals["__init__"] = [init_node]
 
         root = node.root()
-        if DEFAULT_FACTORY not in root.locals:
+        if DEFAULT_FACTORY in init_str and DEFAULT_FACTORY not in root.locals:
             new_assign = parse(f"{DEFAULT_FACTORY} = object()").body[0]
             new_assign.parent = root
             root.locals[DEFAULT_FACTORY] = [new_assign.targets[0]]

--- a/tests/brain/test_dataclasses.py
+++ b/tests/brain/test_dataclasses.py
@@ -1332,3 +1332,34 @@ def test_dataclass_with_duplicate_bases_field_default():
     # Should not raise DuplicateBasesError in _get_previous_field_default
     inferred = next(node.infer())
     assert inferred is not None
+
+
+def test_dataclass_without_default_factory_does_not_leak_name():
+    """A dataclass with no default_factory should not add _HAS_DEFAULT_FACTORY.
+
+    The name is only needed by the generated ``__init__`` when a field uses
+    ``field(default_factory=...)``; adding it unconditionally leaked a module
+    global that does not exist at runtime.
+
+    See https://github.com/pylint-dev/astroid/issues/2808.
+    """
+    module = astroid.parse("""
+    from dataclasses import dataclass
+
+    @dataclass
+    class A:
+        x: int = 1
+    """)
+    assert "_HAS_DEFAULT_FACTORY" not in module.locals
+
+
+def test_dataclass_with_default_factory_defines_name():
+    """_HAS_DEFAULT_FACTORY is still defined when a default_factory is used."""
+    module = astroid.parse("""
+    from dataclasses import dataclass, field
+
+    @dataclass
+    class A:
+        x: list = field(default_factory=list)
+    """)
+    assert "_HAS_DEFAULT_FACTORY" in module.locals


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The dataclass brain added `_HAS_DEFAULT_FACTORY` to the module's locals for every transformed dataclass, but the generated `__init__` only references that name when a field uses `field(default_factory=...)`. Dataclasses without a default factory therefore exposed a module global that does not exist at runtime, as reported in the issue.

The assignment is now guarded on the generated init actually referencing the name. Regression tests cover both the absent and the still-present case.

Closes #2808
