### PR TITLE
Use explicit version guard for PEP 810 `is_lazy` field

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -88,7 +88,8 @@ Release date: TBA
   Closes #3091
 
 * Support PEP 810 lazy imports (new in Python 3.15). ``Import`` and
-  ``ImportFrom`` nodes gain a ``lazy`` boolean attribute.
+  ``ImportFrom`` nodes gain an ``is_lazy`` integer attribute, mirroring
+  the ``ast`` field of the same name.
 
 * Support PEP 798 comprehension unpacking (``{**d for d in dicts}``,
   new in Python 3.15).

--- a/astroid/nodes/as_string.py
+++ b/astroid/nodes/as_string.py
@@ -287,7 +287,7 @@ class AsStringVisitor:
 
     def visit_importfrom(self, node: nodes.ImportFrom) -> str:
         """return an nodes.ImportFrom node as string"""
-        lazy = "lazy " if node.lazy else ""
+        lazy = "lazy " if node.is_lazy else ""
         return "{}from {} import {}".format(
             lazy, "." * (node.level or 0) + node.modname, _import_string(node.names)
         )
@@ -404,7 +404,7 @@ class AsStringVisitor:
 
     def visit_import(self, node: nodes.Import) -> str:
         """return an nodes.Import node as string"""
-        lazy = "lazy " if node.lazy else ""
+        lazy = "lazy " if node.is_lazy else ""
         return f"{lazy}import {_import_string(node.names)}"
 
     def visit_keyword(self, node: nodes.Keyword) -> str:

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2807,7 +2807,7 @@ class ImportFrom(_base_nodes.ImportNode):
     <ImportFrom l.1 at 0x7f23b2e415c0>
     """
 
-    _other_fields = ("modname", "names", "level", "lazy")
+    _other_fields = ("modname", "names", "level", "is_lazy")
 
     def __init__(
         self,
@@ -2820,7 +2820,7 @@ class ImportFrom(_base_nodes.ImportNode):
         *,
         end_lineno: int | None = None,
         end_col_offset: int | None = None,
-        lazy: bool = False,
+        is_lazy: int = 0,
     ) -> None:
         """
         :param fromname: The module that is being imported from.
@@ -2829,7 +2829,7 @@ class ImportFrom(_base_nodes.ImportNode):
 
         :param level: The level of relative import.
 
-        :param lazy: Whether this is a PEP 810 lazy import (``lazy from ...``).
+        :param is_lazy: Whether this is a PEP 810 lazy import (``lazy from ...``).
 
         :param lineno: The line that this node appears on in the source code.
 
@@ -2863,10 +2863,10 @@ class ImportFrom(_base_nodes.ImportNode):
         This is ``None`` for absolute imports.
         """
 
-        self.lazy: bool = lazy
+        self.is_lazy: int = is_lazy
         """Whether this is a PEP 810 lazy import (``lazy from ... import ...``).
 
-        Always ``False`` before Python 3.15.
+        Always ``0`` before Python 3.15.
         """
 
         super().__init__(
@@ -3152,7 +3152,7 @@ class Import(_base_nodes.ImportNode):
     <Import l.1 at 0x7f23b2e4e5c0>
     """
 
-    _other_fields = ("names", "lazy")
+    _other_fields = ("names", "is_lazy")
 
     def __init__(
         self,
@@ -3163,12 +3163,12 @@ class Import(_base_nodes.ImportNode):
         *,
         end_lineno: int | None = None,
         end_col_offset: int | None = None,
-        lazy: bool = False,
+        is_lazy: int = 0,
     ) -> None:
         """
         :param names: The names being imported.
 
-        :param lazy: Whether this is a PEP 810 lazy import (``lazy import ...``).
+        :param is_lazy: Whether this is a PEP 810 lazy import (``lazy import ...``).
 
         :param lineno: The line that this node appears on in the source code.
 
@@ -3189,10 +3189,10 @@ class Import(_base_nodes.ImportNode):
         and the alias that the name is assigned to (if any).
         """
 
-        self.lazy: bool = lazy
+        self.is_lazy: int = is_lazy
         """Whether this is a PEP 810 lazy import (``lazy import ...``).
 
-        Always ``False`` before Python 3.15.
+        Always ``0`` before Python 3.15.
         """
 
         super().__init__(

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1136,8 +1136,7 @@ class TreeRebuilder:
             end_lineno=node.end_lineno,
             end_col_offset=node.end_col_offset,
             parent=parent,
-            # ``is_lazy`` is a PEP 810 field only present on Python 3.15+.
-            lazy=bool(getattr(node, "is_lazy", False)),
+            lazy=bool(node.is_lazy) if sys.version_info >= (3, 15) else False,
         )
         # store From names to add them to locals after building
         self._import_from_nodes.append(
@@ -1340,8 +1339,7 @@ class TreeRebuilder:
             end_lineno=node.end_lineno,
             end_col_offset=node.end_col_offset,
             parent=parent,
-            # ``is_lazy`` is a PEP 810 field only present on Python 3.15+.
-            lazy=bool(getattr(node, "is_lazy", False)),
+            lazy=bool(node.is_lazy) if sys.version_info >= (3, 15) else False,
         )
         # save import names in parent's locals:
         for name, asname in newnode.names:

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1136,7 +1136,7 @@ class TreeRebuilder:
             end_lineno=node.end_lineno,
             end_col_offset=node.end_col_offset,
             parent=parent,
-            lazy=bool(node.is_lazy) if sys.version_info >= (3, 15) else False,
+            is_lazy=node.is_lazy if sys.version_info >= (3, 15) else 0,
         )
         # store From names to add them to locals after building
         self._import_from_nodes.append(
@@ -1339,7 +1339,7 @@ class TreeRebuilder:
             end_lineno=node.end_lineno,
             end_col_offset=node.end_col_offset,
             parent=parent,
-            lazy=bool(node.is_lazy) if sys.version_info >= (3, 15) else False,
+            is_lazy=node.is_lazy if sys.version_info >= (3, 15) else 0,
         )
         # save import names in parent's locals:
         for name, asname in newnode.names:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -537,20 +537,20 @@ class ImportNodeTest(resources.SysPathSetup, unittest.TestCase):
     def test_lazy_import(self) -> None:
         node = extract_node("lazy import json")
         assert isinstance(node, nodes.Import)
-        assert node.lazy is True
+        assert node.is_lazy == 1
         self.assertEqual(node.as_string(), "lazy import json")
 
     @pytest.mark.skipif(not PY315_PLUS, reason="PEP 810 lazy imports, new in 3.15")
     def test_lazy_import_from(self) -> None:
         node = extract_node("lazy from pathlib import Path")
         assert isinstance(node, nodes.ImportFrom)
-        assert node.lazy is True
+        assert node.is_lazy == 1
         self.assertEqual(node.as_string(), "lazy from pathlib import Path")
 
     def test_eager_import_is_not_lazy(self) -> None:
-        # The ``lazy`` flag defaults to False on every supported version.
-        assert extract_node("import json").lazy is False
-        assert extract_node("from pathlib import Path").lazy is False
+        # The ``is_lazy`` flag defaults to 0 on every supported version.
+        assert extract_node("import json").is_lazy == 0
+        assert extract_node("from pathlib import Path").is_lazy == 0
 
     def test_import_self_resolve(self) -> None:
         myos = next(self.module2.igetattr("myos"))


### PR DESCRIPTION
Follow-up to #3094, addressing https://github.com/pylint-dev/astroid/pull/3094#discussion_r3651238697 (and the same pattern in `visit_import`) which was merged before being resolved.

Replaces `getattr(node, "is_lazy", False)` with a `sys.version_info >= (3, 15)` guard in both `visit_import` and `visit_importfrom`, matching the existing guard style in `rebuilder.py`. The explanatory comment is no longer needed since the guard makes the version requirement explicit (and greppable when dropping 3.14 support).

No behavior change.