### PR TITLE
Avoid enum transform crash for extension classes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,11 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Prevent crashes while processing extension-module classes whose bases cannot
+  be resolved when applying enum inference transformations.
+
+  Closes pylint-dev/pylint#11179
+
 * Comprehension conditions now constrain the inference of names used in the
   comprehension, like ``if`` statement conditions already did:
   ``[x for x in lst if x is not None]`` no longer infers ``None`` for ``x``

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -16,6 +16,7 @@ from astroid import arguments, bases, nodes, util
 from astroid.builder import AstroidBuilder, _extract_single_node, extract_node
 from astroid.context import InferenceContext
 from astroid.exceptions import (
+    AstroidError,
     AstroidTypeError,
     AstroidValueError,
     InferenceError,
@@ -654,7 +655,10 @@ def _get_namedtuple_fields(node: nodes.Call) -> str:
 
 def _is_enum_subclass(cls: nodes.ClassDef) -> bool:
     """Return whether cls is a subclass of an Enum."""
-    return cls.is_subtype_of("enum.Enum")
+    try:
+        return cls.is_subtype_of("enum.Enum")
+    except AstroidError:
+        return False
 
 
 def register(manager: AstroidManager) -> None:

--- a/tests/brain/test_enum.py
+++ b/tests/brain/test_enum.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import datetime
+import types
 import unittest
 
 import pytest
@@ -11,9 +13,23 @@ import pytest
 import astroid
 from astroid import bases, builder, nodes, objects, util
 from astroid.exceptions import InferenceError
+from astroid.manager import AstroidManager
 
 
 class EnumBrainTest(unittest.TestCase):
+    def test_enum_predicate_does_not_raise_for_extension_class(self) -> None:
+        """Classes introspected from extensions can have an unresolvable base.
+
+        Regression test for pylint-dev/pylint#11179.
+        """
+        module = types.ModuleType("extension_module")
+        module.datetime = datetime
+        extension_class = type("ExtensionClass", (datetime.datetime,), {})
+        extension_class.__module__ = module.__name__
+        module.ExtensionClass = extension_class
+
+        builder.AstroidBuilder(AstroidManager()).module_build(module, module.__name__)
+
     def test_simple_enum(self) -> None:
         module = builder.parse("""
         import enum


### PR DESCRIPTION
## Type of Changes

|     | Type |
| --- | ---- |
| ✓ | :bug: Bug fix |

## Description

Closes pylint-dev/pylint#11179.

The Enum transform predicate calls `ClassDef.is_subtype_of()` while Astroid is introspecting extension modules. A class whose base cannot be resolved through a complete source AST can raise `StatementMissing` from that predicate, aborting module construction and subsequently crashing Pylint.

Treat an `AstroidError` while checking Enum ancestry as an unsuccessful match, so the class is left untransformed.

The regression builds an introspected extension-like module containing a class derived from `datetime.datetime`; it reproduces the incomplete-parent path without requiring a third-party package.

## Validation

- `python -m pytest tests/brain/test_enum.py -q` — 33 passed
- `python -m pytest tests/brain -q` — 374 passed, 64 skipped, 3 xfailed
- Reproduced the original `pymssql==2.3.13` extension-whitelist inference path before the change; it completes without `StatementMissing` after the change.
- `ruff check astroid/brain/brain_namedtuple_enum.py tests/brain/test_enum.py`
- `git diff --check`
- Full suite: 1977 passed, 95 skipped, 15 xfailed, 35 subtests passed; six failures are unchanged on a clean current `main` checkout and require Windows symlink privileges or `pkg_resources` in the test environment.
