### PR TITLE
Fix crash when inferring `__func__` on a directly proxied bound method

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -236,12 +236,9 @@ Refs #3108
 * Fix detecting static/class methods and inspecting IntFlag types in
   GObject-based libraries (GLib, Gtk etc)
 
-* Fix ``AttributeError`` crash when inferring ``__func__`` on a bound method
-  that proxies its function directly, such as a classmethod accessed on its
-  class (``A.method.__func__``) or a lambda assigned as a class attribute
-  (``A().lam.__func__``). ``BoundMethodModel.attr___func__`` unwrapped two
-  proxy levels unconditionally, so those raised ``AttributeError: 'FunctionDef'
-  object has no attribute '_proxied'`` instead of returning the function.
+  * Fix a crash when inferring ``__func__`` on a bound method that proxies its  function directly,
+    such as ``A.method.__func__`` for a classmethod, or a lambda assigned to a class attribute 
+    such as ``A().lam.__func__``.
 
   Closes pylint-dev/pylint#11198
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -237,7 +237,7 @@ Refs #3108
   GObject-based libraries (GLib, Gtk etc)
 
   * Fix a crash when inferring ``__func__`` on a bound method that proxies its  function directly,
-    such as ``A.method.__func__`` for a classmethod, or a lambda assigned to a class attribute 
+    such as ``A.method.__func__`` for a classmethod, or a lambda assigned to a class attribute
     such as ``A().lam.__func__``.
 
   Closes pylint-dev/pylint#11198

--- a/ChangeLog
+++ b/ChangeLog
@@ -236,6 +236,15 @@ Refs #3108
 * Fix detecting static/class methods and inspecting IntFlag types in
   GObject-based libraries (GLib, Gtk etc)
 
+* Fix ``AttributeError`` crash when inferring ``__func__`` on a bound method
+  that proxies its function directly, such as a classmethod accessed on its
+  class (``A.method.__func__``) or a lambda assigned as a class attribute
+  (``A().lam.__func__``). ``BoundMethodModel.attr___func__`` unwrapped two
+  proxy levels unconditionally, so those raised ``AttributeError: 'FunctionDef'
+  object has no attribute '_proxied'`` instead of returning the function.
+
+  Closes pylint-dev/pylint#11198
+
 What's New in astroid 4.1.2?
 ============================
 Release date: 2026-03-22

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -744,11 +744,9 @@ class ContextManagerModel(ObjectModel):
 class BoundMethodModel(FunctionModel):
     @property
     def attr___func__(self):
-        # A bound method either proxies another method proxy, as when an
-        # instance method is accessed through an instance, or the function
-        # itself, as for a classmethod accessed on its class or a lambda
-        # assigned as a class attribute. Unwrap the proxies that are there
-        # instead of assuming a fixed nesting depth.
+        # Proxy depth varies: an instance method accessed through an instance
+        # proxies another method proxy, a classmethod on its class or a lambda
+        # class attribute proxies the function directly.
         proxied = self._instance._proxied
         while isinstance(proxied, bases.UnboundMethod):
             proxied = proxied._proxied

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -744,7 +744,15 @@ class ContextManagerModel(ObjectModel):
 class BoundMethodModel(FunctionModel):
     @property
     def attr___func__(self):
-        return self._instance._proxied._proxied
+        # A bound method either proxies another method proxy, as when an
+        # instance method is accessed through an instance, or the function
+        # itself, as for a classmethod accessed on its class or a lambda
+        # assigned as a class attribute. Unwrap the proxies that are there
+        # instead of assuming a fixed nesting depth.
+        proxied = self._instance._proxied
+        while isinstance(proxied, bases.UnboundMethod):
+            proxied = proxied._proxied
+        return proxied
 
     @property
     def attr___self__(self):

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -88,6 +88,44 @@ class BoundMethodModelTest(unittest.TestCase):
         self.assertIsInstance(self_, astroid.Instance)
         self.assertEqual(self_.name, "A")
 
+    def test_bound_method_model_classmethod_on_class(self) -> None:
+        """A classmethod accessed on its class proxies the function directly.
+
+        Reported in https://github.com/pylint-dev/pylint/issues/11198, where
+        ``getattr()`` on ``__func__`` aborted the whole pylint run.
+        """
+        ast_nodes = builder.extract_node("""
+        class A:
+            @classmethod
+            def test(cls): pass
+        A.test.__func__ #@
+        getattr(A.test, "__func__") #@
+        A.test.__self__ #@
+        """)
+        assert isinstance(ast_nodes, list)
+        for node in ast_nodes[:2]:
+            func = next(node.infer())
+            self.assertIsInstance(func, nodes.FunctionDef)
+            self.assertEqual(func.name, "test")
+
+        self_ = next(ast_nodes[2].infer())
+        self.assertIsInstance(self_, nodes.ClassDef)
+        self.assertEqual(self_.name, "A")
+
+    def test_bound_method_model_lambda_class_attribute(self) -> None:
+        """A lambda assigned as a class attribute is proxied directly too."""
+        ast_nodes = builder.extract_node("""
+        class A:
+            test = lambda self: 1
+        a = A()
+        a.test.__func__ #@
+        getattr(a.test, "__func__") #@
+        """)
+        assert isinstance(ast_nodes, list)
+        for node in ast_nodes:
+            func = next(node.infer())
+            self.assertIsInstance(func, nodes.Lambda)
+
 
 class UnboundMethodModelTest(unittest.TestCase):
     def test_unbound_method_model(self) -> None:


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`BoundMethodModel.attr___func__` unwraps two proxy levels unconditionally:

```python
class BoundMethodModel(FunctionModel):
    @property
    def attr___func__(self):
        return self._instance._proxied._proxied
```

A `BoundMethod` is only nested that deep when it proxies *another* method proxy.
`UnboundMethod._proxied` is annotated `nodes.FunctionDef | UnboundMethod`, and both
shapes really occur:

| expression                                          | `BoundMethod._proxied` | `._proxied._proxied` |
| --------------------------------------------------- | ---------------------- | -------------------- |
| `A().method` (instance method)                       | `UnboundMethod`        | `FunctionDef`        |
| `A().method`, where `method` is a classmethod        | `BoundMethod`          | `FunctionDef`        |
| `A.method` (classmethod accessed on the class)       | `FunctionDef`          | raises               |
| `A().lam`, where `lam = lambda self: 1`              | `Lambda`               | raises               |

For the last two the second unwrap hits a plain node, so it raises
`AttributeError: 'FunctionDef' object has no attribute '_proxied'` (or `'Lambda'`).

### Reproducer (against `main`, 4.2.0b5)

| expression                                     | before                                                              | after           |
| ---------------------------------------------- | ------------------------------------------------------------------- | --------------- |
| `A.f.__func__`, `f` a classmethod              | `InferenceError: StopIteration raised without any error information` | `FunctionDef.f` |
| `getattr(A.f, "__func__")`, `f` a classmethod  | `AttributeError: 'FunctionDef' object has no attribute '_proxied'`   | `FunctionDef.f` |
| `A().f.__func__`, `f` a classmethod            | `FunctionDef.f`                                                     | `FunctionDef.f` |
| `D().f.__func__`, `f = lambda self: 1`         | `InferenceError: StopIteration ...`                                 | `Lambda`        |
| `getattr(D().f, "__func__")`, same class       | `AttributeError: 'Lambda' object has no attribute '_proxied'`        | `Lambda`        |
| `A.f.__self__` / `D().f.__self__`              | `ClassDef.A` / `Instance of D`                                      | unchanged       |

The two ways to spell the lookup fail differently. Plain attribute access ends up as an
`InferenceError` because the `AttributeError` kills the inference generator, while
`getattr()` goes through `brain_builtin_inference.infer_getattr`, which calls `igetattr`
directly and lets the `AttributeError` escape into the caller.

### Downstream effect

The escaping variant is what pylint-dev/pylint#11198 reports: pylint re-raises it as
`AstroidError`, which becomes a fatal `F0002 astroid-error` and aborts the file. On the
snippet from that issue:

```python
class A:
    @classmethod
    def f(cls):
        return 2

    @classmethod
    def h(cls):
        return getattr(cls.f, "__func__")
```

```
before:  A.py:1:0: F0002: Fatal error while checking 'A.py' ... (astroid-error)
after:   only the usual missing-docstring conventions
```

### Fix

Unwrap the proxies that are actually present instead of assuming a fixed depth:

```python
proxied = self._instance._proxied
while isinstance(proxied, bases.UnboundMethod):
    proxied = proxied._proxied
return proxied
```

`BoundMethod` subclasses `UnboundMethod`, so one loop covers both nesting shapes and
stops at the function node, which is what `__func__` should be. `__self__` is untouched.

## Verification

- `pytest` on this branch: 2017 passed. Two tests fail on my machine
  (`tests/test_get_relative_base_path.py::TestModUtilsRelativePath::test_symlink_resolution`
  and `tests/test_manager.py::AstroidManagerTest::test_module_is_not_namespace`); both fail
  the same way on unmodified `main` here, so they look like macOS environment artifacts
  rather than anything from this change.
- Both new tests fail on `main` without the one-property change, so they do guard the fix.
- pylint's own suite run against this astroid (what the `Test pylint` job does): 2117 passed,
  0 failed, identical to the same run against unmodified `main`.

Closes pylint-dev/pylint#11198
