### PR TITLE
Fix AttributeError on TypeVar in is_abstract

### DIFF
--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1481,10 +1481,15 @@ class FunctionDef(
                     inferred = next(node.infer())
                 except (InferenceError, StopIteration):
                     continue
-                if inferred and hasattr(inferred, "qname") and inferred.qname() in {
-                    "abc.abstractproperty",
-                    "abc.abstractmethod",
-                }:
+                if (
+                    inferred
+                    and hasattr(inferred, "qname")
+                    and inferred.qname()
+                    in {
+                        "abc.abstractproperty",
+                        "abc.abstractmethod",
+                    }
+                ):
                     return True
 
         for child_node in self.body:

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1481,7 +1481,7 @@ class FunctionDef(
                     inferred = next(node.infer())
                 except (InferenceError, StopIteration):
                     continue
-                if inferred and inferred.qname() in {
+                if inferred and hasattr(inferred, "qname") and inferred.qname() in {
                     "abc.abstractproperty",
                     "abc.abstractmethod",
                 }:


### PR DESCRIPTION
Fixes #3086

When a method is decorated with a TypeVar (e.g., `class C[T]: @T def m(): ...`), `inferred` may be a `TypeVar` object that doesn't have a `qname()` method. Add a `hasattr` guard to prevent the `AttributeError`.

```python
class C[T]:
    @T
    def m():
        pass
```

This previously crashed with:
```
AttributeError: 'TypeVar' object has no attribute 'qname'
```