### PR TITLE
Fix .pyi stub files not found when .pyc exists alongside

### DIFF
--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -496,7 +496,11 @@ def get_source_file(
     filename = os.path.abspath(_path_from_filename(filename))
     base, orig_ext = os.path.splitext(filename)
     orig_ext = orig_ext.lstrip(".")
-    if orig_ext not in PY_SOURCE_EXTS and os.path.exists(f"{base}.{orig_ext}"):
+    if (
+        orig_ext not in PY_SOURCE_EXTS
+        and orig_ext not in ("pyc", "pyo")
+        and os.path.exists(f"{base}.{orig_ext}")
+    ):
         return f"{base}.{orig_ext}"
     for ext in PY_SOURCE_EXTS_STUBS_FIRST if prefer_stubs else PY_SOURCE_EXTS:
         source_path = f"{base}.{ext}"


### PR DESCRIPTION
Fixes #3087

When a `.pyc` file is passed to `_datafilename_lstrip`, the old code returned the `.pyc` path immediately without checking for `.pyi` stubs. Skip the early return for bytecode extensions (`.pyc`, `.pyo`) so the stubs-first lookup logic can find `.pyi` files.

Before this fix, projects using compiled `.pyc` files with accompanying `.pyi` stubs would fail with "wrong encoding" errors because astroid picked up the `.pyc` instead of the `.pyi`.