### PR TITLE
Fix pathlib.Path.parents inference when assigned to variable

### DIFF
--- a/astroid/brain/brain_pathlib.py
+++ b/astroid/brain/brain_pathlib.py
@@ -19,22 +19,34 @@ Path
 """
 
 
-def _looks_like_parents_subscript(node: nodes.Subscript) -> bool:
-    if not (
-        isinstance(node.value, nodes.Attribute) and node.value.attrname == "parents"
-    ):
-        return False
-
-    try:
-        value = next(node.value.infer())
-    except (InferenceError, StopIteration):
-        return False
+def _is_parents_type(value: bases.Instance) -> bool:
+    """Check if a value is a pathlib._PathParents or builtins.tuple from .parents."""
     parents = "builtins.tuple" if PY313 else "pathlib._PathParents"
     return (
         isinstance(value, bases.Instance)
         and isinstance(value._proxied, nodes.ClassDef)
         and value.qname() == parents
     )
+
+
+def _looks_like_parents_subscript(node: nodes.Subscript) -> bool:
+    if isinstance(node.value, nodes.Attribute) and node.value.attrname == "parents":
+        try:
+            value = next(node.value.infer())
+        except (InferenceError, StopIteration):
+            return False
+        return _is_parents_type(value)
+
+    # Handle the case where parents is assigned to a variable first:
+    # parents = cwd.parents; parents[0]
+    if isinstance(node.value, nodes.Name):
+        try:
+            value = next(node.value.infer())
+        except (InferenceError, StopIteration):
+            return False
+        return _is_parents_type(value)
+
+    return False
 
 
 def infer_parents_subscript(

--- a/tests/brain/test_pathlib.py
+++ b/tests/brain/test_pathlib.py
@@ -73,3 +73,24 @@ def test_inference_parents_subscript_not_path() -> None:
     inferred = name_node.inferred()
     assert len(inferred) == 1
     assert inferred[0] is Uninferable
+
+
+def test_inference_parents_assigned_to_variable() -> None:
+    """Test inference of ``pathlib.Path.parents`` when assigned to a variable.
+
+    Regression test for https://github.com/pylint-dev/astroid/issues/2864
+    """
+    node = astroid.extract_node("""
+    from pathlib import Path
+
+    cwd = Path.cwd()
+    parents = cwd.parents
+    parents[0]  #@
+    """)
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], bases.Instance)
+    if PY313:
+        assert inferred[0].qname() == "pathlib._local.Path"
+    else:
+        assert inferred[0].qname() == "pathlib.Path"


### PR DESCRIPTION
Fixes #2864

When `parents` was assigned to a variable first (e.g. `parents = cwd.parents; parents[0]`), the brain plugin didn't recognize the subscript because the value was a `Name` node instead of an `Attribute` node.

Extend the transform to also check `Name` nodes that infer to `pathlib._PathParents` (or `builtins.tuple` on PY313).

```python
from pathlib import Path

cwd = Path.cwd()
parents = cwd.parents
print(parents[0].name)  # no longer reports no-member
```