### PR TITLE
Fix regex.Pattern and regex.Match subscriptable inference

### DIFF
--- a/astroid/brain/brain_regex.py
+++ b/astroid/brain/brain_regex.py
@@ -56,9 +56,11 @@ def _looks_like_pattern_or_match(node: nodes.Call) -> bool:
     Pattern = type(...)
     Match = type(...)
     ```
+    Older versions of regex define these in ``regex.regex``, newer versions
+    define them in ``regex._main``.
     """
     return (
-        node.root().name == "regex.regex"
+        node.root().name in {"regex.regex", "regex._main"}
         and isinstance(node.func, nodes.Name)
         and node.func.name == "type"
         and isinstance(node.parent, nodes.Assign)

--- a/tests/brain/test_regex.py
+++ b/tests/brain/test_regex.py
@@ -24,9 +24,6 @@ class TestRegexBrain:
             assert name in re_ast
             assert next(re_ast[name].infer()).value == getattr(regex, name)
 
-    @pytest.mark.xfail(
-        reason="Started failing on main, but no one reproduced locally yet"
-    )
     def test_regex_pattern_and_match_subscriptable(self):
         """Test regex.Pattern and regex.Match are subscriptable in PY39+."""
         node1 = builder.extract_node("""


### PR DESCRIPTION
Fixes #2052

The regex library moved the `Pattern = type(...)` and `Match = type(...)` definitions from `regex.regex` to `regex._main` in newer versions. Update the guard in `_looks_like_pattern_or_match` to match both module names and remove the xfail marker from the test.