### PR TITLE
Infer re.compile result as re.Pattern instance

### DIFF
--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -138,7 +138,9 @@ def infer_re_compile(
     node: nodes.Call, ctx: context.InferenceContext | None = None
 ) -> Iterator[bases.Instance]:
     """Infer the result of re.compile as an instance of re.Pattern."""
-    from astroid.manager import AstroidManager  # pylint: disable=import-outside-toplevel
+    from astroid.manager import (
+        AstroidManager,
+    )  # pylint: disable=import-outside-toplevel
 
     re_module = AstroidManager().ast_from_module_name("re")
     try:

--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -4,7 +4,9 @@
 
 from __future__ import annotations
 
-from astroid import context, nodes
+from collections.abc import Iterator
+
+from astroid import bases, context, nodes, util
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import _extract_single_node, parse
 from astroid.const import PY311_PLUS
@@ -47,6 +49,33 @@ CLASS_GETITEM_TEMPLATE = """
 @classmethod
 def __class_getitem__(cls, item):
     return cls
+
+def match(self, string, pos=0, endpos=-1):
+    pass
+
+def fullmatch(self, string, pos=0, endpos=-1):
+    pass
+
+def search(self, string, pos=0, endpos=-1):
+    pass
+
+def sub(self, repl, string, count=0):
+    pass
+
+def subn(self, repl, string, count=0):
+    pass
+
+def split(self, string, maxsplit=0):
+    pass
+
+def findall(self, string, pos=0, endpos=-1):
+    pass
+
+def finditer(self, string, pos=0, endpos=-1):
+    pass
+
+def scanner(self, string, pos=0, endpos=-1):
+    pass
 """
 
 
@@ -73,7 +102,7 @@ def _looks_like_pattern_or_match(node: nodes.Call) -> bool:
 def infer_pattern_match(node: nodes.Call, ctx: context.InferenceContext | None = None):
     """Infer re.Pattern and re.Match as classes.
 
-    For PY39+ add `__class_getitem__`.
+    For PY39+ add `__class_getitem__` and the regular expression methods.
     """
     class_def = nodes.ClassDef(
         name=node.parent.targets[0].name,
@@ -83,13 +112,49 @@ def infer_pattern_match(node: nodes.Call, ctx: context.InferenceContext | None =
         end_lineno=node.end_lineno,
         end_col_offset=node.end_col_offset,
     )
-    func_to_add = _extract_single_node(CLASS_GETITEM_TEMPLATE)
-    class_def.locals["__class_getitem__"] = [func_to_add]
+    template_module = parse(CLASS_GETITEM_TEMPLATE)
+    for func in template_module.body:
+        class_def.locals[func.name] = [func]
     return iter([class_def])
+
+
+def _looks_like_re_compile(node: nodes.Call) -> bool:
+    """Check for a call to re.compile."""
+    if len(node.args) == 0:
+        return False
+    func = node.func
+    if isinstance(func, nodes.Attribute):
+        return (
+            func.attrname == "compile"
+            and isinstance(func.expr, nodes.Name)
+            and func.expr.name == "re"
+        )
+    if isinstance(func, nodes.Name):
+        return func.name == "compile"
+    return False
+
+
+def infer_re_compile(
+    node: nodes.Call, ctx: context.InferenceContext | None = None
+) -> Iterator[bases.Instance]:
+    """Infer the result of re.compile as an instance of re.Pattern."""
+    from astroid.manager import AstroidManager  # pylint: disable=import-outside-toplevel
+
+    re_module = AstroidManager().ast_from_module_name("re")
+    try:
+        pattern = next(re_module.getattr("Pattern")[0].infer())
+    except (AttributeError, IndexError, StopIteration):
+        return iter([util.Uninferable])
+    if not isinstance(pattern, nodes.ClassDef):
+        return iter([util.Uninferable])
+    return iter([pattern.instantiate_class()])
 
 
 def register(manager: AstroidManager) -> None:
     register_module_extender(manager, "re", _re_transform)
     manager.register_transform(
         nodes.Call, inference_tip(infer_pattern_match), _looks_like_pattern_or_match
+    )
+    manager.register_transform(
+        nodes.Call, inference_tip(infer_re_compile), _looks_like_re_compile
     )

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -893,6 +893,21 @@ class ReBrainTest(unittest.TestCase):
         assert isinstance(inferred2, nodes.ClassDef)
         assert isinstance(inferred2.getattr("__class_getitem__")[0], nodes.FunctionDef)
 
+    def test_re_compile_inferred_as_pattern(self):
+        """Test re.compile is inferred as an instance of re.Pattern."""
+        node = builder.extract_node("""
+        import re
+        _ENCODING_RGX = re.compile(r"f")
+        _ENCODING_RGX
+        """)
+        inferred = next(node.infer())
+        assert isinstance(inferred, Instance)
+        assert inferred.qname() == "re.Pattern"
+        # The pattern exposes the usual regular expression methods.
+        assert "match" in inferred._proxied.locals
+        assert "search" in inferred._proxied.locals
+        assert "findall" in inferred._proxied.locals
+
 
 class BrainNamedtupleAnnAssignTest(unittest.TestCase):
     def test_no_crash_on_ann_assign_in_namedtuple(self) -> None:


### PR DESCRIPTION
Fixes #520

Add an inference tip for `re.compile` that returns an instance of `re.Pattern` instead of `Uninferable`. The `Pattern`/`Match` synthetic classes now also expose the regular expression methods (`match`, `search`, `findall`, etc.) so attribute access works on compiled patterns.

```python
import re
_ENCODING_RGX = re.compile(r"f")
_ENCODING_RGX  # now infers as re.Pattern instance
```