### PR TITLE
Fail the documentation build on Sphinx warnings

### DIFF
--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -1,0 +1,31 @@
+name: Documentation links
+
+# Checking external links needs the network, so it is not part of CI: a link
+# that is briefly unreachable would fail unrelated pull requests. Run it on a
+# schedule instead, and let it be started by hand when needed.
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linkcheck:
+    name: Check external links
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v7.0.1
+      - name: Set up Python
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.13"
+          check-latest: true
+      - name: Install tox
+        run: python -m pip install -U pip tox
+      - name: Check that every external link still resolves
+        run: tox -e linkcheck

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,12 @@ astroid.egg-info/
 .mypy_cache/
 venv
 doc/_build/
+doc/api/bases/
 doc/api/base_nodes/
+doc/api/context/
+doc/api/manager/
 doc/api/nodes/
+doc/api/objectmodel/
+doc/api/objects/
+doc/api/typing/
 doc/api/util/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ venv
 doc/_build/
 doc/api/base_nodes/
 doc/api/nodes/
+doc/api/util/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,11 +4,16 @@ version: 2
 
 sphinx:
   configuration: doc/conf.py
+  fail_on_warning: true
 
 build:
-  os: ubuntu-22.04
+  # Read the Docs builds every pull request and is a required check, so this is
+  # what enforces `fail_on_warning` above. Keep the interpreter recent enough to
+  # parse the syntax the documentation shows: the examples for PEP 695 type
+  # parameters need 3.12.
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.13"
 
 python:
   install:

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,12 @@ Release date: TBA
   are documented as part of the public API, and a number of docstrings that
   Sphinx could not parse were repaired.
 
+* The API documentation now covers the proxies, the objects with no node of
+  their own, the inference context, the manager, the object models and the
+  extension call signatures. The ``EvaluatedObject``, ``Interpolation``,
+  ``NamedExpr`` and ``TemplateStr`` nodes were missing from the list of nodes
+  and are listed now.
+
 * Comprehension conditions now constrain the inference of names used in the
   comprehension, like ``if`` statement conditions already did:
   ``[x for x in lst if x is not None]`` no longer infers ``None`` for ``x``

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,13 @@ Release date: TBA
   are documented as part of the public API, and a number of docstrings that
   Sphinx could not parse were repaired.
 
+* Fix the example in the docstring of ``BoolOp``, which showed the node it was
+  copied from: ``astroid.extract_node("a and b")`` gives a ``BoolOp``, not a
+  ``BinOp``.
+
+* Names written between single backticks in the ChangeLog render as code again,
+  rather than as italics.
+
 * The API documentation now covers the proxies, the objects with no node of
   their own, the inference context, the manager, the object models and the
   extension call signatures. The ``EvaluatedObject``, ``Interpolation``,

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,12 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* The documentation build now fails on any Sphinx warning, so a cross-reference
+  that does not resolve is caught by CI instead of quietly rendering as plain
+  text. ``Uninferable``, ``Position`` and the ``BadOperationMessage`` classes
+  are documented as part of the public API, and a number of docstrings that
+  Sphinx could not parse were repaired.
+
 * Comprehension conditions now constrain the inference of names used in the
   comprehension, like ``if`` statement conditions already did:
   ``[x for x in lst if x is not None]`` no longer infers ``None`` for ``x``
@@ -371,8 +377,9 @@ Release date: 2026-02-08
   Closes #2870
 
 * Fix ability to detect .py modules inside PATH directories on Windows
-  described by a UNC path with a trailing backslash (`\`)
-    - Example: modutils.modpath_from_file(filename=r"\\Mac\Code\tests\test_resources.py", path=["\\mac\code\"]) == ['tests', 'test_resources']
+  described by a UNC path with a trailing backslash (``\``)
+
+  - Example: ``modutils.modpath_from_file(filename=r"\\Mac\Code\tests\test_resources.py", path=["\\mac\code\"]) == ['tests', 'test_resources']``
 
 * Fix ``random.sample`` inference crash when sequence contains uninferable elements.
 
@@ -595,8 +602,8 @@ What's New in astroid 3.3.6?
 ============================
 Release date: 2024-12-08
 
-* Fix inability to import `collections.abc` in python 3.13.1.
-  _It was later found that this did not resolve the linked issue. It was fixed in astroid 3.3.7_
+* Fix inability to import ``collections.abc`` in python 3.13.1.
+  *It was later found that this did not resolve the linked issue. It was fixed in astroid 3.3.7*
 
   Closes pylint-dev/pylint#10112
 
@@ -912,14 +919,13 @@ Release date: 2023-09-26
   We have tried to minimize the amount of breaking changes caused by this change
   but some are unavoidable.
 
-* ``infer_call_result`` now shares the same interface across all implementations. Namely:
-  ```python
-  def infer_call_result(
-                self,
-                caller: SuccessfulInferenceResult | None,
-                context: InferenceContext | None = None,
-            ) -> Iterator[InferenceResult]:
-  ```
+* ``infer_call_result`` now shares the same interface across all implementations. Namely::
+
+      def infer_call_result(
+          self,
+          caller: SuccessfulInferenceResult | None,
+          context: InferenceContext | None = None,
+      ) -> Iterator[InferenceResult]:
 
   This is a breaking change for ``nodes.FunctionDef`` where previously ``caller`` had a default of
   ``None``. Passing ``None`` again will not create a behaviour change.

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -435,7 +435,7 @@ def extract_node(code: str, module_name: str = "") -> nodes.NodeNG | list[nodes.
     For convenience, singleton lists are unpacked.
 
     :param str code: A piece of Python code that is parsed as
-    a module. Will be passed through textwrap.dedent first.
+        a module. Will be passed through textwrap.dedent first.
     :param str module_name: The name of the module.
     :returns: The designated node from the parse tree, or a list of nodes.
     """

--- a/astroid/nodes/_base_nodes.py
+++ b/astroid/nodes/_base_nodes.py
@@ -315,7 +315,7 @@ class LookupMixIn(NodeNG):
 
         :returns: The inferred values of the statements returned from
             :meth:`lookup`.
-        :rtype: iterable
+        :rtype: Iterator
         """
         frame, stmts = self.lookup(name)
         context = InferenceContext()

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1579,7 +1579,7 @@ class BoolOp(NodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('a and b')
     >>> node
-    <BinOp l.1 at 0x7f23b2e71c50>
+    <BoolOp l.1 at 0x7f23b2e71c50>
     """
 
     _astroid_fields = ("values",)

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -317,7 +317,7 @@ class BaseContainer(_base_nodes.ParentAssignNode, Instance, metaclass=abc.ABCMet
         """An iterator over the elements this node contains.
 
         :returns: The contents of this node.
-        :rtype: iterable(NodeNG)
+        :rtype: Iterator[NodeNG]
         """
         return self.elts
 
@@ -791,11 +791,12 @@ class Arguments(
     @cached_property
     def arguments(self):
         """Get all the arguments for this node. This includes:
+
         * Positional only arguments
         * Positional arguments
         * Keyword arguments
-        * Variable arguments (.e.g *args)
-        * Variable keyword arguments (e.g **kwargs)
+        * Variable arguments (e.g. ``*args``)
+        * Variable keyword arguments (e.g. ``**kwargs``)
         """
         retval = list(itertools.chain((self.posonlyargs or ()), (self.args or ())))
         if self.vararg_node:
@@ -1387,7 +1388,7 @@ class AugAssign(
     ) -> list[util.BadBinaryOperationMessage]:
         """Get a list of type errors which can occur during inference.
 
-        Each TypeError is represented by a :class:`BadBinaryOperationMessage` ,
+        Each TypeError is represented by a :class:`~astroid.util.BadBinaryOperationMessage`,
         which holds the original exception.
 
         If any inferred result is uninferable, an empty list is returned.
@@ -1505,7 +1506,7 @@ class BinOp(_base_nodes.OperatorNode):
     ) -> list[util.BadBinaryOperationMessage]:
         """Get a list of type errors which can occur during inference.
 
-        Each TypeError is represented by a :class:`BadBinaryOperationMessage`,
+        Each TypeError is represented by a :class:`~astroid.util.BadBinaryOperationMessage`,
         which holds the original exception.
 
         If any inferred result is uninferable, an empty list is returned.
@@ -1839,7 +1840,7 @@ class Compare(NodeNG):
         strings.
 
         :returns: The children.
-        :rtype: iterable(NodeNG)
+        :rtype: Iterator[NodeNG]
         """
         yield self.left
         for _, comparator in self.ops:
@@ -2158,7 +2159,7 @@ class Const(_base_nodes.NoChildrenNode, Instance):
         """An iterator over the elements this node contains.
 
         :returns: The contents of this node.
-        :rtype: iterable(Const)
+        :rtype: Iterator[Const]
 
         :raises TypeError: If this node does not represent something that is iterable.
         """
@@ -2392,7 +2393,7 @@ class Dict(NodeNG, Instance):
         code, key first then the value.
 
         :returns: The children.
-        :rtype: iterable(NodeNG)
+        :rtype: Iterator[NodeNG]
         """
         for key, value in self.items:
             yield key
@@ -2412,7 +2413,7 @@ class Dict(NodeNG, Instance):
         """An iterator over the keys this node contains.
 
         :returns: The keys of this node.
-        :rtype: iterable(NodeNG)
+        :rtype: Iterator[NodeNG]
         """
         return [key for (key, _) in self.items]
 
@@ -2557,7 +2558,7 @@ class Expr(_base_nodes.Statement):
 
 
 class EmptyNode(_base_nodes.NoChildrenNode):
-    """Holds an arbitrary object in the :attr:`LocalsDictNodeNG.locals`."""
+    """Holds an arbitrary object in the :attr:`~astroid.nodes.LocalsDictNodeNG.locals`."""
 
     object = None
 
@@ -4342,7 +4343,7 @@ class UnaryOp(_base_nodes.OperatorNode):
     ) -> list[util.BadUnaryOperationMessage]:
         """Get a list of type errors which can occur during inference.
 
-        Each TypeError is represented by a :class:`BadUnaryOperationMessage`,
+        Each TypeError is represented by a :class:`~astroid.util.BadUnaryOperationMessage`,
         which holds the original exception.
 
         If any inferred result is uninferable, an empty list is returned.
@@ -4597,7 +4598,7 @@ class With(
         """Get the child nodes below this node.
 
         :returns: The children.
-        :rtype: iterable(NodeNG)
+        :rtype: Iterator[NodeNG]
         """
         for expr, var in self.items:
             yield expr

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -128,7 +128,7 @@ class NodeNG:
         called instead of the default interface.
 
         :returns: The inferred values.
-        :rtype: iterable
+        :rtype: Iterator
         """
         if context is None:
             context = InferenceContext()
@@ -174,7 +174,7 @@ class NodeNG:
     def repr_name(self) -> str:
         """Get a name for nice representation.
 
-        This is either :attr:`name`, :attr:`attrname`, or the empty string.
+        This is either ``name``, ``attrname``, or the empty string.
         """
         if all(name not in self._astroid_fields for name in ("name", "attrname")):
             return getattr(self, "name", "") or getattr(self, "attrname", "")
@@ -330,7 +330,7 @@ class NodeNG:
         :type child: NodeNG
 
         :returns: The sequence containing the given child node.
-        :rtype: iterable(NodeNG)
+        :rtype: Iterator[NodeNG]
 
         :raises AstroidError: If no sequence could be found that contains
             the given child.
@@ -357,7 +357,7 @@ class NodeNG:
 
         :returns: A tuple of the name of the field that contains the child,
             and the sequence or node that contains the child node.
-        :rtype: tuple(str, iterable(NodeNG) or NodeNG)
+        :rtype: tuple[str, Iterator[NodeNG] or NodeNG]
 
         :raises AstroidError: If no field could be found that contains
             the given child.
@@ -510,7 +510,7 @@ class NodeNG:
         :param klass: The types of node to search for.
 
         :param skip_klass: The types of node to ignore. This is useful to ignore
-            subclasses of :attr:`klass`.
+            subclasses of ``klass``.
 
         :returns: The node of the given types.
         """

--- a/astroid/nodes/scoped_nodes/mixin.py
+++ b/astroid/nodes/scoped_nodes/mixin.py
@@ -53,7 +53,7 @@ class LocalsDictNodeNG(_base_nodes.LookupMixIn):
         """The first parent node defining a new scope.
 
         :returns: The first parent scope node.
-        :rtype: Module or FunctionDef or ClassDef or Lambda or GenExpr
+        :rtype: Module or FunctionDef or ClassDef or Lambda or GeneratorExp
         """
         return self
 
@@ -154,7 +154,7 @@ class LocalsDictNodeNG(_base_nodes.LookupMixIn):
         """Iterate over the names of locals defined in this scoped node.
 
         :returns: The names of the defined locals.
-        :rtype: iterable(str)
+        :rtype: Iterator[str]
         """
         return iter(self.keys())
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -292,7 +292,7 @@ class Module(LocalsDictNodeNG):
     def stream(self):
         """Get a stream to the underlying file or bytes.
 
-        :type: file or io.BytesIO or None
+        :type: io.IOBase or io.BytesIO or None
         """
         return self._get_stream()
 
@@ -712,7 +712,7 @@ class DictComp(ComprehensionScope):
         """Determine the boolean value of this node.
 
         :returns: The boolean value of this node.
-            For a :class:`DictComp` this is always :class:`Uninferable`.
+            For a :class:`DictComp` this is always :obj:`~astroid.Uninferable`.
         :rtype: Uninferable
         """
         return util.Uninferable
@@ -769,7 +769,7 @@ class SetComp(ComprehensionScope):
         """Determine the boolean value of this node.
 
         :returns: The boolean value of this node.
-            For a :class:`SetComp` this is always :class:`Uninferable`.
+            For a :class:`SetComp` this is always :obj:`~astroid.Uninferable`.
         :rtype: Uninferable
         """
         return util.Uninferable
@@ -826,7 +826,7 @@ class ListComp(ComprehensionScope):
         """Determine the boolean value of this node.
 
         :returns: The boolean value of this node.
-            For a :class:`ListComp` this is always :class:`Uninferable`.
+            For a :class:`ListComp` this is always :obj:`~astroid.Uninferable`.
         :rtype: Uninferable
         """
         return util.Uninferable
@@ -1154,7 +1154,10 @@ class FunctionDef(
         self.type_params: list[nodes.TypeVar | nodes.ParamSpec | nodes.TypeVarTuple] = (
             []
         )
-        """PEP 695 (Python 3.12+) type params, e.g. first 'T' in def func[T]() -> T: ..."""
+        """The type parameters introduced by :pep:`695`, new in Python 3.12.
+
+        For example, the ``T`` in ``def func[T]() -> T: ...``.
+        """
 
         self.instance_attrs: dict[str, list[NodeNG]] = {}
 
@@ -1536,7 +1539,7 @@ class FunctionDef(
         """Infer what the function yields when called
 
         :returns: What the function yields
-        :rtype: iterable(NodeNG or Uninferable) or None
+        :rtype: Iterator[NodeNG or Uninferable] or None
         """
         for yield_ in self.nodes_of_class(node_classes.Yield):
             if yield_.value is None:
@@ -1901,7 +1904,10 @@ class ClassDef(
         self.type_params: list[nodes.TypeVar | nodes.ParamSpec | nodes.TypeVarTuple] = (
             []
         )
-        """PEP 695 (Python 3.12+) type params, e.g. class MyClass[T]: ..."""
+        """The type parameters introduced by :pep:`695`, new in Python 3.12.
+
+        For example, the ``T`` in ``class MyClass[T]: ...``.
+        """
 
         super().__init__(
             lineno=lineno,
@@ -2223,7 +2229,7 @@ class ClassDef(
         :type name: str
 
         :returns: The parents that define the given name.
-        :rtype: iterable(NodeNG)
+        :rtype: Iterator[NodeNG]
         """
         # Look up in the mro if we can. This will result in the
         # attribute being looked up just as Python does it.
@@ -2245,7 +2251,7 @@ class ClassDef(
 
         :returns: The parents that define the given name as
             an instance attribute.
-        :rtype: iterable(NodeNG)
+        :rtype: Iterator[NodeNG]
         """
         for astroid in self.ancestors(context=context):
             if name in astroid.instance_attrs:
@@ -2307,9 +2313,9 @@ class ClassDef(
         raise AttributeInferenceError(target=self, attribute=name, context=context)
 
     def instantiate_class(self) -> bases.Instance:
-        """Get an :class:`Instance` of the :class:`ClassDef` node.
+        """Get an :class:`~astroid.Instance` of the :class:`ClassDef` node.
 
-        :returns: An :class:`Instance` of the :class:`ClassDef` node
+        :returns: An :class:`~astroid.Instance` of the :class:`ClassDef` node
         """
         from astroid import objects  # pylint: disable=import-outside-toplevel
 
@@ -2329,9 +2335,9 @@ class ClassDef(
     ) -> list[InferenceResult]:
         """Get an attribute from this class, using Python's attribute semantic.
 
-        This method doesn't look in the :attr:`instance_attrs` dictionary
-        since it is done by an :class:`Instance` proxy at inference time.
-        It may return an :class:`Uninferable` object if
+        This method doesn't look in the ``instance_attrs`` dictionary
+        since it is done by an :class:`~astroid.Instance` proxy at inference time.
+        It may return an :obj:`~astroid.Uninferable` object if
         the attribute has not been
         found, but a ``__getattr__`` or ``__getattribute__`` method is defined.
         If ``class_context`` is given, then it is considered that the
@@ -2606,7 +2612,7 @@ class ClassDef(
         """Iterate over all of the method defined in this class and its parents.
 
         :returns: The methods defined on the class.
-        :rtype: iterable(FunctionDef)
+        :rtype: Iterator[FunctionDef]
         """
         done = {}
         for astroid in itertools.chain(iter((self,)), self.ancestors()):
@@ -2620,7 +2626,7 @@ class ClassDef(
         """Iterate over all of the method defined in this class only.
 
         :returns: The methods defined on the class.
-        :rtype: iterable(FunctionDef)
+        :rtype: Iterator[FunctionDef]
         """
         for member in self.values():
             if isinstance(member, FunctionDef):
@@ -2632,7 +2638,7 @@ class ClassDef(
         This will return an instance of builtins.type.
 
         :returns: The metaclass.
-        :rtype: builtins.type
+        :rtype: type
         """
         return builtin_lookup("type")[1][0]
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,8 +6,9 @@ SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build
 
-# Internal variables.
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) -n .
+# Internal variables. Nitpicky mode lives in conf.py so that every build gets
+# it; -W turns the warnings it produces into a build failure, like CI does.
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) -W .
 
 .PHONY: help clean html linkcheck
 

--- a/doc/api/astroid.bases.rst
+++ b/doc/api/astroid.bases.rst
@@ -1,0 +1,19 @@
+Proxies
+=======
+
+Inference does not only yield nodes. When a value has no node of its own — an
+instance of a class, a bound method, a running generator — it is represented by
+a proxy that forwards attribute lookups to the node it wraps.
+
+:class:`~astroid.Instance`, :class:`~astroid.BoundMethod` and
+:class:`~astroid.UnboundMethod` are the ones you meet most often, and are part
+of the :doc:`general API <general>`.
+
+.. autosummary::
+   :toctree: bases
+   :template: autosummary_class.rst
+
+   astroid.bases.Proxy
+   astroid.bases.Generator
+   astroid.bases.AsyncGenerator
+   astroid.bases.UnionType

--- a/doc/api/astroid.context.rst
+++ b/doc/api/astroid.context.rst
@@ -1,0 +1,13 @@
+Inference context
+=================
+
+Inferring a value can require inferring others, and the same name can be
+reached by more than one path. The context carries what is already known down
+that chain, so that inference terminates and does not repeat work.
+
+.. autosummary::
+   :toctree: context
+   :template: autosummary_class.rst
+
+   astroid.context.InferenceContext
+   astroid.context.CallContext

--- a/doc/api/astroid.interpreter.objectmodel.rst
+++ b/doc/api/astroid.interpreter.objectmodel.rst
@@ -1,0 +1,27 @@
+Object models
+=============
+
+Every Python object carries attributes that no source code declares: a module
+has ``__name__``, a function has ``__defaults__``, a class has ``__mro__``. An
+object model supplies those attributes for one kind of object, so that looking
+them up infers a value instead of failing.
+
+.. autosummary::
+   :toctree: objectmodel
+   :template: autosummary_class.rst
+
+   astroid.interpreter.objectmodel.ObjectModel
+   astroid.interpreter.objectmodel.ModuleModel
+   astroid.interpreter.objectmodel.FunctionModel
+   astroid.interpreter.objectmodel.ClassModel
+   astroid.interpreter.objectmodel.SuperModel
+   astroid.interpreter.objectmodel.UnboundMethodModel
+   astroid.interpreter.objectmodel.BoundMethodModel
+   astroid.interpreter.objectmodel.ContextManagerModel
+   astroid.interpreter.objectmodel.GeneratorBaseModel
+   astroid.interpreter.objectmodel.GeneratorModel
+   astroid.interpreter.objectmodel.AsyncGeneratorModel
+   astroid.interpreter.objectmodel.InstanceModel
+   astroid.interpreter.objectmodel.ExceptionInstanceModel
+   astroid.interpreter.objectmodel.DictModel
+   astroid.interpreter.objectmodel.PropertyModel

--- a/doc/api/astroid.manager.rst
+++ b/doc/api/astroid.manager.rst
@@ -1,0 +1,11 @@
+Manager
+=======
+
+The manager finds modules, builds them, and keeps the result so that a module
+reached from several places is only built once.
+
+.. autosummary::
+   :toctree: manager
+   :template: autosummary_class.rst
+
+   astroid.manager.AstroidManager

--- a/doc/api/astroid.nodes.rst
+++ b/doc/api/astroid.nodes.rst
@@ -38,6 +38,7 @@ Nodes
    astroid.nodes.DictComp
    astroid.nodes.DictUnpack
    astroid.nodes.EmptyNode
+   astroid.nodes.EvaluatedObject
    astroid.nodes.ExceptHandler
    astroid.nodes.Expr
    astroid.nodes.For
@@ -49,6 +50,7 @@ Nodes
    astroid.nodes.IfExp
    astroid.nodes.Import
    astroid.nodes.ImportFrom
+   astroid.nodes.Interpolation
    astroid.nodes.JoinedStr
    astroid.nodes.Keyword
    astroid.nodes.Lambda
@@ -66,6 +68,7 @@ Nodes
    astroid.nodes.MatchValue
    astroid.nodes.Module
    astroid.nodes.Name
+   astroid.nodes.NamedExpr
    astroid.nodes.Nonlocal
    astroid.nodes.ParamSpec
    astroid.nodes.Pass
@@ -76,6 +79,7 @@ Nodes
    astroid.nodes.Slice
    astroid.nodes.Starred
    astroid.nodes.Subscript
+   astroid.nodes.TemplateStr
    astroid.nodes.Try
    astroid.nodes.TryStar
    astroid.nodes.Tuple
@@ -99,3 +103,12 @@ Extra information attached to some nodes, rather than nodes themselves.
    :template: autosummary_class.rst
 
    astroid.nodes.utils.Position
+
+Turning nodes back into code
+----------------------------
+
+.. autosummary::
+   :toctree: nodes
+   :template: autosummary_class.rst
+
+   astroid.nodes.as_string.AsStringVisitor

--- a/doc/api/astroid.nodes.rst
+++ b/doc/api/astroid.nodes.rst
@@ -88,3 +88,14 @@ Nodes
    astroid.nodes.With
    astroid.nodes.Yield
    astroid.nodes.YieldFrom
+
+Node metadata
+-------------
+
+Extra information attached to some nodes, rather than nodes themselves.
+
+.. autosummary::
+   :toctree: nodes
+   :template: autosummary_class.rst
+
+   astroid.nodes.utils.Position

--- a/doc/api/astroid.objects.rst
+++ b/doc/api/astroid.objects.rst
@@ -1,0 +1,18 @@
+Objects
+=======
+
+Objects that exist while Python runs but have no node of their own, so astroid
+cannot represent them with the nodes it built from the source.
+
+.. autosummary::
+   :toctree: objects
+   :template: autosummary_class.rst
+
+   astroid.objects.FrozenSet
+   astroid.objects.Super
+   astroid.objects.DictInstance
+   astroid.objects.DictItems
+   astroid.objects.DictKeys
+   astroid.objects.DictValues
+   astroid.objects.PartialFunction
+   astroid.objects.Property

--- a/doc/api/astroid.typing.rst
+++ b/doc/api/astroid.typing.rst
@@ -1,0 +1,13 @@
+Typing
+======
+
+The call signatures that extensions are expected to match.
+
+.. autosummary::
+   :toctree: typing
+   :template: autosummary_class.rst
+
+   astroid.typing.InferFn
+   astroid.typing.TransformFn
+   astroid.typing.InferenceErrorInfo
+   astroid.typing.AstroidManagerBrain

--- a/doc/api/astroid.util.rst
+++ b/doc/api/astroid.util.rst
@@ -1,0 +1,16 @@
+Inference results
+=================
+
+Inference does not always end on a node. These are the other values it can
+yield, and the messages it produces for operations that cannot work.
+
+The singleton itself is :obj:`astroid.Uninferable`.
+
+.. autosummary::
+   :toctree: util
+   :template: autosummary_class.rst
+
+   astroid.util.UninferableBase
+   astroid.util.BadOperationMessage
+   astroid.util.BadUnaryOperationMessage
+   astroid.util.BadBinaryOperationMessage

--- a/doc/api/general.rst
+++ b/doc/api/general.rst
@@ -1,4 +1,20 @@
 General API
 ------------
 
+.. Exceptions are re-exported by ``astroid`` but documented on their own page.
+   Listing them here as well would give every exception two pages, and Sphinx
+   would then not know which one ``:exc:`AstroidError``` points at.
+
 .. automodule:: astroid
+   :exclude-members: AstroidBuildingError, AstroidError, AstroidImportError,
+      AstroidIndexError, AstroidSyntaxError, AstroidTypeError,
+      AstroidValueError, AttributeInferenceError, DuplicateBasesError,
+      InconsistentMroError, InferenceError, InferenceOverwriteError, MroError,
+      NameInferenceError, NoDefault, NotFoundError, ParentMissingError,
+      ResolveError, StatementMissing, SuperArgumentTypeError, SuperError,
+      TooManyLevelsError, UnresolvableName, UseInferenceDefault
+
+.. Autodoc skips module-level data, so the singleton needs its own directive.
+
+.. autodata:: astroid.Uninferable
+   :no-value:

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -9,5 +9,11 @@ API
    general
    astroid.nodes
    base_nodes
+   astroid.bases
+   astroid.objects
    astroid.util
    astroid.exceptions
+   astroid.context
+   astroid.manager
+   astroid.interpreter.objectmodel
+   astroid.typing

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -9,4 +9,5 @@ API
    general
    astroid.nodes
    base_nodes
+   astroid.util
    astroid.exceptions

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -103,7 +103,7 @@ nitpick_ignore_regex = [
     (r"py:.*", r"(?:\w+\.)*_\w+(?:\.\w+)*"),
     # Same reason, for annotations written relative to their own module, e.g.
     # ``node_classes.NodeNG``. The name Sphinx sees has no module path in it.
-    (r"py:class", r"(?:arguments|node_classes|objectmodel|objects)\.\w+"),
+    (r"py:class", r"(?:arguments|constraint|node_classes|objectmodel|objects)\.\w+"),
     # ``Uninferable`` is a singleton object, not a class, so it can never be a
     # ``:class:`` target. Prose should link to :obj:`~astroid.Uninferable`.
     (r"py:class", r"Uninferable"),
@@ -111,15 +111,6 @@ nitpick_ignore_regex = [
     # only to spell out signatures, and have no page of their own.
     (r"py:class", r"FrameType|InferenceContext|InferenceResult"),
     (r"py:class", r"LookupMixIn|SuccessfulInferenceResult"),
-    # Public modules the API documentation does not cover yet. Deleting a line
-    # here turns that module's references back on, so this doubles as a to-do.
-    (r"py:class", r"astroid\.bases\.Proxy"),
-    (r"py:class", r"astroid\.context\.InferenceContext"),
-    (r"py:class", r"astroid\.interpreter\.objectmodel\.\w+"),
-    (r"py:class", r"astroid\.manager\.AstroidManager"),
-    (r"py:class", r"astroid\.nodes\.as_string\.AsStringVisitor"),
-    (r"py:class", r"astroid\.objects\.DictInstance"),
-    (r"py:class", r"astroid\.typing\.\w+"),
 ]
 
 # -- Options for the linkcheck builder -----------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,7 +4,7 @@
 
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -33,12 +33,17 @@ source_suffix = ".rst"
 # the locale of the machine running the build happens to be.
 language = "en"
 
+# Single backticks mean code. Without this they mean "title reference", which
+# renders as italics, and the ChangeLog is full of `infer` and `**kwargs` that
+# were plainly meant to be code.
+default_role = "code"
+
 # The master toctree document.
 root_doc = "index"
 
 # General information about the project.
 project = "Astroid"
-current_year = datetime.utcnow().year
+current_year = datetime.now(timezone.utc).year
 contributors = "Logilab, and astroid contributors"
 copyright = f"2003-{current_year}, {contributors}"
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,6 +29,10 @@ templates_path = ["_templates"]
 # The suffix of source filenames.
 source_suffix = ".rst"
 
+# Pin the language so warning messages are identical for everyone, whatever
+# the locale of the machine running the build happens to be.
+language = "en"
+
 # The master toctree document.
 root_doc = "index"
 
@@ -75,3 +79,56 @@ intersphinx_mapping = {
     # upcoming Python versions.
     "python": ("https://docs.python.org/dev", None),
 }
+
+# -- Options for cross-reference checking --------------------------------------
+
+# Warn about every cross-reference that does not resolve. Combined with the
+# ``-W`` passed by ``tox -e docs`` and by ``fail_on_warning`` in
+# ``.readthedocs.yaml``, a reference to something that does not exist (or that
+# is written without its module path) breaks the build instead of silently
+# rendering as plain text.
+nitpicky = True
+
+# Targets that can never resolve, so that ``nitpicky`` only reports mistakes we
+# can actually act on. Both halves of each pair are regexes matched in full.
+#
+# Keep this list short. Every entry hides a category of broken link, so add one
+# only when the target genuinely cannot be documented; a public class or method
+# that is merely written without its module path belongs in the docs, not here.
+nitpick_ignore_regex = [
+    # Private modules, private helpers and TypeVars, e.g.
+    # ``astroid.nodes._base_nodes.Statement``. Autodoc prints the annotations
+    # of public functions as they are written in the source, and these are not
+    # part of the public API, so they have no page to link to.
+    (r"py:.*", r"(?:\w+\.)*_\w+(?:\.\w+)*"),
+    # Same reason, for annotations written relative to their own module, e.g.
+    # ``node_classes.NodeNG``. The name Sphinx sees has no module path in it.
+    (r"py:class", r"(?:arguments|node_classes|objectmodel|objects)\.\w+"),
+    # ``Uninferable`` is a singleton object, not a class, so it can never be a
+    # ``:class:`` target. Prose should link to :obj:`~astroid.Uninferable`.
+    (r"py:class", r"Uninferable"),
+    # Type aliases and base classes used unqualified in annotations. They exist
+    # only to spell out signatures, and have no page of their own.
+    (r"py:class", r"FrameType|InferenceContext|InferenceResult"),
+    (r"py:class", r"LookupMixIn|SuccessfulInferenceResult"),
+    # Public modules the API documentation does not cover yet. Deleting a line
+    # here turns that module's references back on, so this doubles as a to-do.
+    (r"py:class", r"astroid\.bases\.Proxy"),
+    (r"py:class", r"astroid\.context\.InferenceContext"),
+    (r"py:class", r"astroid\.interpreter\.objectmodel\.\w+"),
+    (r"py:class", r"astroid\.manager\.AstroidManager"),
+    (r"py:class", r"astroid\.nodes\.as_string\.AsStringVisitor"),
+    (r"py:class", r"astroid\.objects\.DictInstance"),
+    (r"py:class", r"astroid\.typing\.\w+"),
+]
+
+# -- Options for the linkcheck builder -----------------------------------------
+
+# Checked by a scheduled workflow rather than on every pull request, because it
+# needs the network and so fails for reasons that have nothing to do with a
+# change.
+linkcheck_ignore = [
+    # Bitbucket dropped Mercurial hosting in 2020 and these two changelog
+    # entries point at repositories that went with it.
+    r"https://bitbucket\.org/.*",
+]

--- a/tox.ini
+++ b/tox.ini
@@ -22,4 +22,13 @@ changedir = doc/
 deps =
     -r doc/requirements.txt
 commands =
-    sphinx-build -E -b html . build
+    sphinx-build -E -W -j auto -b html . build
+
+[testenv:linkcheck]
+skipsdist = True
+usedevelop = True
+changedir = doc/
+deps =
+    -r doc/requirements.txt
+commands =
+    sphinx-build -E -W -b linkcheck . build/linkcheck


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Follow-up to #3171 

Turn `nitpicky` on in `conf.py`, pass `-W` from `tox -e docs`, set `fail_on_warning` for Read the Docs, and add a `documentation` job to CI. External links are checked by a separate weekly workflow, since they need the network and would otherwise fail unrelated pull requests. Also fix most existing issues.