### PR TITLE
Support typing.NamedTuple fields passed as keyword arguments

### DIFF
--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -70,6 +70,15 @@ def _find_func_form_arguments(node, context):
     if name and names:
         return name.value, names
 
+    # typing.NamedTuple also accepts the fields as keyword arguments,
+    # e.g. Point = NamedTuple("Point", x=float, y=float)
+    if name and any(
+        keyword.arg
+        and keyword.arg not in ("typename", "field_names")
+        for keyword in (keywords or [])
+    ):
+        return name.value, None
+
     raise UseInferenceDefault()
 
 
@@ -104,6 +113,8 @@ def infer_func_form(
 
             # Handle attributes of Enums
             else:
+                if names is None:
+                    raise UseInferenceDefault
                 # Enums supports either iterator of (name, value) pairs
                 # or mappings.
                 if hasattr(names, "items") and isinstance(names.items, list):
@@ -601,10 +612,10 @@ def infer_typing_namedtuple(
     if func.qname() not in TYPING_NAMEDTUPLE_QUALIFIED:
         raise UseInferenceDefault
 
-    if len(node.args) != 2:
-        raise UseInferenceDefault
-
-    if not isinstance(node.args[1], (nodes.List, nodes.Tuple)):
+    if len(node.args) == 2:
+        if not isinstance(node.args[1], (nodes.List, nodes.Tuple)):
+            raise UseInferenceDefault
+    elif not node.keywords:
         raise UseInferenceDefault
 
     return infer_named_tuple(node, context)
@@ -634,16 +645,25 @@ def _get_namedtuple_fields(node: nodes.Call) -> str:
                     raise UseInferenceDefault from exc
                 break
     if not isinstance(container, nodes.BaseContainer):
-        raise UseInferenceDefault
-    for elt in container.elts:
-        if isinstance(elt, nodes.Const):
-            names.append(elt.as_string())
-            continue
-        if not isinstance(elt, (nodes.List, nodes.Tuple)):
+        # typing.NamedTuple also accepts the fields as keyword arguments,
+        # e.g. Point = NamedTuple("Point", x=float, y=float)
+        names = [
+            f"'{keyword_node.arg}'"
+            for keyword_node in node.keywords
+            if keyword_node.arg and keyword_node.arg != "field_names"
+        ]
+        if not names:
             raise UseInferenceDefault
-        if len(elt.elts) != 2:
-            raise UseInferenceDefault
-        names.append(elt.elts[0].as_string())
+    else:
+        for elt in container.elts:
+            if isinstance(elt, nodes.Const):
+                names.append(elt.as_string())
+                continue
+            if not isinstance(elt, (nodes.List, nodes.Tuple)):
+                raise UseInferenceDefault
+            if len(elt.elts) != 2:
+                raise UseInferenceDefault
+            names.append(elt.elts[0].as_string())
 
     if names:
         field_names = f"({','.join(names)},)"

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -73,8 +73,7 @@ def _find_func_form_arguments(node, context):
     # typing.NamedTuple also accepts the fields as keyword arguments,
     # e.g. Point = NamedTuple("Point", x=float, y=float)
     if name and any(
-        keyword.arg
-        and keyword.arg not in ("typename", "field_names")
+        keyword.arg and keyword.arg not in ("typename", "field_names")
         for keyword in (keywords or [])
     ):
         return name.value, None

--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -138,7 +138,9 @@ def infer_re_compile(
     node: nodes.Call, ctx: context.InferenceContext | None = None
 ) -> Iterator[bases.Instance]:
     """Infer the result of re.compile as an instance of re.Pattern."""
-    from astroid.manager import AstroidManager  # pylint: disable=import-outside-toplevel
+    from astroid.manager import (
+        AstroidManager,
+    )  # pylint: disable=import-outside-toplevel
 
     re_module = AstroidManager().ast_from_module_name("re")
     try:

--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -4,7 +4,9 @@
 
 from __future__ import annotations
 
-from astroid import context, nodes
+from collections.abc import Iterator
+
+from astroid import bases, context, nodes, util
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import _extract_single_node, parse
 from astroid.const import PY311_PLUS
@@ -47,6 +49,33 @@ CLASS_GETITEM_TEMPLATE = """
 @classmethod
 def __class_getitem__(cls, item):
     return cls
+
+def match(self, string, pos=0, endpos=-1):
+    pass
+
+def fullmatch(self, string, pos=0, endpos=-1):
+    pass
+
+def search(self, string, pos=0, endpos=-1):
+    pass
+
+def sub(self, repl, string, count=0):
+    pass
+
+def subn(self, repl, string, count=0):
+    pass
+
+def split(self, string, maxsplit=0):
+    pass
+
+def findall(self, string, pos=0, endpos=-1):
+    pass
+
+def finditer(self, string, pos=0, endpos=-1):
+    pass
+
+def scanner(self, string, pos=0, endpos=-1):
+    pass
 """
 
 
@@ -73,7 +102,7 @@ def _looks_like_pattern_or_match(node: nodes.Call) -> bool:
 def infer_pattern_match(node: nodes.Call, ctx: context.InferenceContext | None = None):
     """Infer re.Pattern and re.Match as classes.
 
-    For PY39+ add `__class_getitem__`.
+    For PY39+ add `__class_getitem__` and the regular expression methods.
     """
     class_def = nodes.ClassDef(
         name=node.parent.targets[0].name,
@@ -83,13 +112,49 @@ def infer_pattern_match(node: nodes.Call, ctx: context.InferenceContext | None =
         end_lineno=node.end_lineno,
         end_col_offset=node.end_col_offset,
     )
-    func_to_add = _extract_single_node(CLASS_GETITEM_TEMPLATE)
-    class_def.locals["__class_getitem__"] = [func_to_add]
+    template_module = parse(CLASS_GETITEM_TEMPLATE)
+    for func in template_module.body:
+        class_def.locals[func.name] = [func]
     return iter([class_def])
+
+
+def _looks_like_re_compile(node: nodes.Call) -> bool:
+    """Check for a call to re.compile."""
+    if len(node.args) == 0:
+        return False
+    func = node.func
+    if isinstance(func, nodes.Attribute):
+        return (
+            func.attrname == "compile"
+            and isinstance(func.expr, nodes.Name)
+            and func.expr.name == "re"
+        )
+    if isinstance(func, nodes.Name):
+        return func.name == "compile"
+    return False
+
+
+def infer_re_compile(
+    node: nodes.Call, ctx: context.InferenceContext | None = None
+) -> Iterator[bases.Instance]:
+    """Infer the result of re.compile as an instance of re.Pattern."""
+    from astroid.manager import AstroidManager  # pylint: disable=import-outside-toplevel
+
+    re_module = AstroidManager().ast_from_module_name("re")
+    try:
+        pattern = next(re_module.getattr("Pattern")[0].infer())
+    except (AttributeError, IndexError, StopIteration):
+        return iter([util.Uninferable])
+    if not isinstance(pattern, nodes.ClassDef):
+        return iter([util.Uninferable])
+    return iter([pattern.instantiate_class()])
 
 
 def register(manager: AstroidManager) -> None:
     register_module_extender(manager, "re", _re_transform)
     manager.register_transform(
         nodes.Call, inference_tip(infer_pattern_match), _looks_like_pattern_or_match
+    )
+    manager.register_transform(
+        nodes.Call, inference_tip(infer_re_compile), _looks_like_re_compile
     )

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -505,9 +505,7 @@ class Module(LocalsDictNodeNG):
                 # namespace package prefix so that the relative import can be
                 # resolved against it (e.g. ``pkg.main`` importing
                 # ``.subpkg`` must resolve to ``pkg.subpkg``, not ``subpkg``).
-                package_name = (
-                    self.name.rsplit(".", 1)[0] if "." in self.name else ""
-                )
+                package_name = self.name.rsplit(".", 1)[0] if "." in self.name else ""
             else:
                 package_name = self.name.rsplit(".", level)[0]
             if level and self.name.count(".") < level:

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -501,7 +501,13 @@ class Module(LocalsDictNodeNG):
                 )
             ):
                 level = level - 1
-                package_name = ""
+                # The module is part of a namespace package: keep the
+                # namespace package prefix so that the relative import can be
+                # resolved against it (e.g. ``pkg.main`` importing
+                # ``.subpkg`` must resolve to ``pkg.subpkg``, not ``subpkg``).
+                package_name = (
+                    self.name.rsplit(".", 1)[0] if "." in self.name else ""
+                )
             else:
                 package_name = self.name.rsplit(".", level)[0]
             if level and self.name.count(".") < level:

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -893,6 +893,21 @@ class ReBrainTest(unittest.TestCase):
         assert isinstance(inferred2, nodes.ClassDef)
         assert isinstance(inferred2.getattr("__class_getitem__")[0], nodes.FunctionDef)
 
+    def test_re_compile_inferred_as_pattern(self):
+        """Test re.compile is inferred as an instance of re.Pattern."""
+        node = builder.extract_node("""
+        import re
+        _ENCODING_RGX = re.compile(r"f")
+        _ENCODING_RGX
+        """)
+        inferred = next(node.infer())
+        assert isinstance(inferred, Instance)
+        assert inferred.qname() == "re.Pattern"
+        # The pattern exposes the usual regular expression methods.
+        assert "match" in inferred._proxied.locals
+        assert "search" in inferred._proxied.locals
+        assert "findall" in inferred._proxied.locals
+
 
 class BrainNamedtupleAnnAssignTest(unittest.TestCase):
     def test_no_crash_on_ann_assign_in_namedtuple(self) -> None:

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -634,6 +634,29 @@ class TypingBrain(unittest.TestCase):
         inferred = next(node.infer())
         self.assertIsInstance(inferred, astroid.Instance)
 
+    def test_typing_namedtuple_fields_as_keyword_arguments(self) -> None:
+        node = builder.extract_node("""
+        from typing import NamedTuple
+
+        Point = NamedTuple("Point", x=float, y=float)
+        Point #@
+        """)
+        inferred = next(node.infer())
+        self.assertIsInstance(inferred, nodes.ClassDef)
+        self.assertEqual(inferred.name, "Point")
+        self.assertIn("x", inferred.locals)
+        self.assertIn("y", inferred.locals)
+
+        instance = builder.extract_node("""
+        from typing import NamedTuple
+
+        Point = NamedTuple("Point", x=float, y=float)
+        p = Point(1, 2)
+        p #@
+        """)
+        inferred = next(instance.infer())
+        self.assertIsInstance(inferred, astroid.Instance)
+
     def test_typed_dict(self):
         code = builder.extract_node("""
         from typing import TypedDict

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import difflib
 import os
 import sys
+import tempfile
 import textwrap
 import unittest
 from functools import partial
@@ -213,6 +214,30 @@ class ModuleNodeTest(ModuleLoader, unittest.TestCase):
                 f"({level-1}) for module {mod.name!r}"
             )
             self.assertEqual(expected, str(cm.exception))
+
+    def test_relative_to_absolute_name_namespace_package(self) -> None:
+        """A module in a namespace package must keep the package prefix."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkg = os.path.join(tmpdir, "pkg")
+            subpkg = os.path.join(pkg, "subpkg")
+            os.makedirs(subpkg)
+            with open(os.path.join(subpkg, "mod.py"), "w", encoding="utf-8") as f:
+                f.write("x = 1\n")
+            with open(os.path.join(pkg, "main.py"), "w", encoding="utf-8") as f:
+                f.write("from .subpkg import mod\n")
+
+            sys.path.insert(0, tmpdir)
+            try:
+                mod = MANAGER.ast_from_file(os.path.join(pkg, "main.py"))
+                self.assertEqual(mod.name, "pkg.main")
+                self.assertFalse(mod.package)
+                self.assertEqual(
+                    mod.relative_to_absolute_name("subpkg", 1), "pkg.subpkg"
+                )
+                imported = mod.import_module("subpkg", level=1)
+                self.assertEqual(imported.name, "pkg.subpkg")
+            finally:
+                del sys.path[0]
 
     def test_import_1(self) -> None:
         data = """from . import subpackage"""


### PR DESCRIPTION
## Description

``typing.NamedTuple`` accepts the fields as keyword arguments (documented since Python 3.5):

```python
Point = NamedTuple(Point, x=float, y=float)
p = Point(1, 2)
```

This form was not recognized by ``infer_typing_namedtuple``: it required exactly two positional arguments with the second being a ``list``/``tuple``, so the call was not transformed. ``Point`` was inferred as a plain ``Instance`` of ``typing.NamedTuple`` and ``Point(1, 2)`` was uninferable, causing pylint to report ``not-callable`` (see PyCQA/pylint#4431).

## Changes

- Relax the argument check in ``infer_typing_namedtuple`` so the call is accepted when fields are given as keyword arguments.
- ``_find_func_form_arguments`` now returns a ``(name, None)`` pair when fields are passed as keyword arguments.
- ``_get_namedtuple_fields`` collects the field names from the keyword arguments (excluding ``typename``/``field_names``).
- Enum inference falls back to default inference when no field container is available (unchanged behavior).

Closes #1259