### PR TITLE
Add brain for wave.open to infer Wave_read vs Wave_write

### DIFF
--- a/astroid/brain/brain_wave.py
+++ b/astroid/brain/brain_wave.py
@@ -1,0 +1,83 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
+
+"""Astroid hooks for the wave module."""
+
+from __future__ import annotations
+
+from astroid import context, nodes, util
+from astroid.exceptions import InferenceError
+from astroid.inference_tip import inference_tip
+from astroid.manager import AstroidManager
+
+
+def _looks_like_wave_open(node: nodes.Call) -> bool:
+    """Check if the call is to ``wave.open``."""
+    func = node.func
+    return (
+        isinstance(func, nodes.Attribute)
+        and func.attrname == "open"
+        and isinstance(func.expr, nodes.Name)
+        and func.expr.name == "wave"
+    )
+
+
+def _infer_wave_open(
+    node: nodes.Call, context: context.InferenceContext | None = None
+) -> util.Generator[util.InferenceResult, None, None]:
+    """Infer ``wave.open`` based on the mode argument.
+
+    ``wave.open`` returns a :class:`wave.Wave_read` instance for modes
+    ``'r'``/``'rb'`` and a :class:`wave.Wave_write` instance for modes
+    ``'w'``/``'wb'``.
+    """
+    if not _looks_like_wave_open(node):
+        raise util.UseInferenceDefault
+
+    mode = None
+    mode_arg = None
+    if len(node.args) > 1:
+        mode_arg = node.args[1]
+    else:
+        for keyword in node.keywords or []:
+            if keyword.arg == "mode":
+                mode_arg = keyword.value
+                break
+    if mode_arg is not None:
+        modes: set[str] = set()
+        try:
+            for inferred in mode_arg.infer(context):
+                if isinstance(inferred, nodes.Const) and isinstance(
+                    inferred.value, str
+                ):
+                    modes.add(inferred.value)
+        except (InferenceError, StopIteration):
+            pass
+        if modes and all(m in ("r", "rb") for m in modes):
+            mode = "r"
+        elif modes and all(m in ("w", "wb") for m in modes):
+            mode = "w"
+
+    try:
+        wave_module = AstroidManager().ast_from_module_name("wave")
+        read_class = next(wave_module.igetattr("Wave_read"))
+        write_class = next(wave_module.igetattr("Wave_write"))
+    except (InferenceError, StopIteration) as exc:
+        raise util.UseInferenceDefault from exc
+
+    if mode == "r":
+        return iter([read_class.instantiate_class()])
+    if mode == "w":
+        return iter([write_class.instantiate_class()])
+    # Unknown mode (or defaulting to the mode of a file-like object):
+    # return both possibilities to avoid false positives.
+    return iter(
+        [read_class.instantiate_class(), write_class.instantiate_class()]
+    )
+
+
+def register(manager: AstroidManager) -> None:
+    manager.register_transform(
+        nodes.Call, inference_tip(_infer_wave_open), _looks_like_wave_open
+    )

--- a/astroid/brain/brain_wave.py
+++ b/astroid/brain/brain_wave.py
@@ -72,9 +72,7 @@ def _infer_wave_open(
         return iter([write_class.instantiate_class()])
     # Unknown mode (or defaulting to the mode of a file-like object):
     # return both possibilities to avoid false positives.
-    return iter(
-        [read_class.instantiate_class(), write_class.instantiate_class()]
-    )
+    return iter([read_class.instantiate_class(), write_class.instantiate_class()])
 
 
 def register(manager: AstroidManager) -> None:

--- a/astroid/brain/helpers.py
+++ b/astroid/brain/helpers.py
@@ -83,6 +83,7 @@ def register_all_brains(manager: AstroidManager) -> None:
         brain_typing,
         brain_unittest,
         brain_uuid,
+        brain_wave,
     )
 
     brain_argparse.register(manager)
@@ -136,6 +137,7 @@ def register_all_brains(manager: AstroidManager) -> None:
     brain_typing.register(manager)
     brain_unittest.register(manager)
     brain_uuid.register(manager)
+    brain_wave.register(manager)
 
 
 def is_class_var(node: NodeNG) -> bool:

--- a/tests/brain/test_wave.py
+++ b/tests/brain/test_wave.py
@@ -1,0 +1,68 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
+
+"""Tests for the wave module brain."""
+
+from astroid import builder, nodes
+from astroid.bases import Instance
+
+
+class TestWaveBrain:
+    def test_wave_open_write_mode(self) -> None:
+        """wave.open with a write mode returns a Wave_write instance."""
+        node = builder.extract_node("""
+        import wave
+        f = wave.open("blank.wav", "wb")
+        f #@
+        """)
+        inferred = next(node.infer())
+        assert isinstance(inferred, Instance)
+        assert inferred.qname() == "wave.Wave_write"
+        assert "writeframes" in inferred.locals
+
+    def test_wave_open_read_mode(self) -> None:
+        """wave.open with a read mode returns a Wave_read instance."""
+        node = builder.extract_node("""
+        import wave
+        f = wave.open("blank.wav", "rb")
+        f #@
+        """)
+        inferred = next(node.infer())
+        assert isinstance(inferred, Instance)
+        assert inferred.qname() == "wave.Wave_read"
+
+    def test_wave_open_mode_keyword(self) -> None:
+        """wave.open accepts the mode as a keyword argument."""
+        node = builder.extract_node("""
+        import wave
+        f = wave.open("blank.wav", mode="w")
+        f #@
+        """)
+        inferred = next(node.infer())
+        assert isinstance(inferred, Instance)
+        assert inferred.qname() == "wave.Wave_write"
+
+    def test_wave_open_write_attributes(self) -> None:
+        """Wave_write methods are available on the inferred instance."""
+        node = builder.extract_node("""
+        import wave
+        f = wave.open("blank.wav", "wb")
+        f.setnchannels(1)
+        f.writeframes(b"data") #@
+        """)
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.Const)
+
+    def test_wave_open_inferred_mode(self) -> None:
+        """The mode is propagated through function arguments."""
+        node = builder.extract_node("""
+        import wave
+        def write(mode):
+            f = wave.open("blank.wav", mode)
+            return f
+        write("wb") #@
+        """)
+        inferred = next(node.infer())
+        assert isinstance(inferred, Instance)
+        assert inferred.qname() == "wave.Wave_write"


### PR DESCRIPTION
## Description

The `wave` module's `open` function returns either a `Wave_read` or a `Wave_write` instance depending on the mode argument:

```python
import wave
with wave.open(blank_audio.wav, wb) as wav_file:
    wav_file.setnchannels(1)   # no-member false positive
    wav_file.writeframes(...)  # no-member false positive
```

Without a brain, `wave.open("file.wav", "wb")` was inferred as `Wave_read` (and `rb` as *both* classes), so pylint reported `no-member` on all `Wave_write` methods (pylint-dev/pylint#10316).

## Changes

- New `brain_wave.py` with an inference tip for `wave.open` calls:
  - mode `'r'`/`'rb'` (positional or keyword) → `Wave_read`
  - mode `'w'`/`'wb'` → `Wave_write`
  - mode not statically known → both classes (conservative, avoids false positives)
  - mode propagated through function arguments (e.g. `def f(mode): wave.open(..., mode)` called with a literal)
- Registered in `brain/helpers.py`
- New `tests/brain/test_wave.py` with 5 tests