### PR TITLE
Fix inference of loop variable unpacking with names in iterables

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,17 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+
+* Fix inference of loop variable unpacking when the iterable contains names
+  referring to sequences, e.g. ``for a, b in [some_sequence]``. The names are
+  now inferred before the assignment path is resolved into them, so ``a``
+  receives the first element of ``some_sequence`` instead of the whole
+  sequence. This fixes a ``no-member`` false positive in pylint for list
+  comprehensions like ``[sth.name for sth, _ in [lorem]]`` where ``lorem``
+  is a tuple.
+
+  Closes #10472 (pylint-dev/pylint#10472)
+
 * Comprehension conditions now constrain the inference of names used in the
   comprehension, like ``if`` statement conditions already did:
   ``[x for x in lst if x is not None]`` no longer infers ``None`` for ``x``

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -283,7 +283,7 @@ to any intermediary inference necessary.
 """
 
 
-def _resolve_looppart(parts, assign_path, context):
+def _resolve_looppart(parts, assign_path, context, resolve_names=False):
     """Recursive function to resolve multiple assignments on loops."""
     assign_path = assign_path[:]
     index = assign_path.pop(0)
@@ -297,31 +297,45 @@ def _resolve_looppart(parts, assign_path, context):
         except TypeError:
             continue
         try:
-            if isinstance(itered[index], (nodes.Const, nodes.Name)):
+            if isinstance(itered[index], nodes.Const) or (
+                not resolve_names and isinstance(itered[index], nodes.Name)
+            ):
                 itered = [part]
         except IndexError:
             pass
         for stmt in itered:
             index_node = nodes.Const(index)
-            try:
-                assigned = stmt.getitem(index_node, context)
-            except (AttributeError, AstroidTypeError, AstroidIndexError):
-                continue
-            if not assign_path:
-                # we achieved to resolved the assignment path,
-                # don't infer the last part
-                yield assigned
-            elif isinstance(assigned, util.UninferableBase):
-                break
+            if resolve_names and isinstance(stmt, nodes.Name):
+                # The elements of the iterable are references, so they have
+                # to be inferred before the assignment path can be resolved
+                # into them, e.g. ``for a, b in [some_sequence]``.
+                stmts = [
+                    inferred
+                    for inferred in stmt.infer(context)
+                    if not isinstance(inferred, util.UninferableBase)
+                ]
             else:
-                # we are not yet on the last part of the path
-                # search on each possibly inferred value
+                stmts = [stmt]
+            for value in stmts:
                 try:
-                    yield from _resolve_looppart(
-                        assigned.infer(context), assign_path, context
-                    )
-                except InferenceError:
+                    assigned = value.getitem(index_node, context)
+                except (AttributeError, AstroidTypeError, AstroidIndexError):
+                    continue
+                if not assign_path:
+                    # we achieved to resolved the assignment path,
+                    # don't infer the last part
+                    yield assigned
+                elif isinstance(assigned, util.UninferableBase):
                     break
+                else:
+                    # we are not yet on the last part of the path
+                    # search on each possibly inferred value
+                    try:
+                        yield from _resolve_looppart(
+                            assigned.infer(context), assign_path, context
+                        )
+                    except InferenceError:
+                        break
 
 
 @decorators.raise_if_nothing_inferred
@@ -344,7 +358,9 @@ def for_assigned_stmts(
             if isinstance(lst, (nodes.Tuple, nodes.List)):
                 yield from lst.elts
     else:
-        yield from _resolve_looppart(self.iter.infer(context), assign_path, context)
+        yield from _resolve_looppart(
+            self.iter.infer(context), assign_path, context, resolve_names=True
+        )
     return {
         "node": self,
         "unknown": node,

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -119,6 +119,63 @@ class ProtocolTests(unittest.TestCase):
         assigned3 = list(for3_assnode.assigned_stmts())
         self.assertNameNodesEqual(["str", "bytes"], assigned3)
 
+    def test_assigned_stmts_unpacking_names_in_iterable(self) -> None:
+        # Names in the iterable are references to the sequence elements and
+        # have to be inferred before the assignment path is resolved into
+        # them. Regression test for pylint no-member false positive, see
+        # https://github.com/pylint-dev/pylint/issues/10472
+        assign_stmts = extract_node("""
+        lorem = ("lorem", 0)
+        ipsum = ("ipsum", 1)
+        for a, b in [lorem, ipsum]:  #@
+            pass
+        """)
+        assign_nodes = assign_stmts.nodes_of_class(nodes.AssignName)
+
+        for1_assnode = next(assign_nodes)
+        assigned = list(for1_assnode.assigned_stmts())
+        self.assertConstNodesEqual(["lorem", "ipsum"], assigned)
+
+        for2_assnode = next(assign_nodes)
+        assigned2 = list(for2_assnode.assigned_stmts())
+        self.assertConstNodesEqual([0, 1], assigned2)
+
+    def test_assigned_stmts_unpacking_mixed_names_in_iterable(self) -> None:
+        assign_stmts = extract_node("""
+        lorem = (1, 2)
+        for a, b in [(3, 4), lorem]:  #@
+            pass
+        """)
+        assign_nodes = assign_stmts.nodes_of_class(nodes.AssignName)
+
+        for1_assnode = next(assign_nodes)
+        assigned = list(for1_assnode.assigned_stmts())
+        self.assertConstNodesEqual([3, 1], assigned)
+
+        for2_assnode = next(assign_nodes)
+        assigned2 = list(for2_assnode.assigned_stmts())
+        self.assertConstNodesEqual([4, 2], assigned2)
+
+    def test_assigned_stmts_unpacking_nested_names_in_iterable(self) -> None:
+        assign_stmts = extract_node("""
+        lorem = ((1, 2), 3)
+        for (a, b), c in [lorem]:  #@
+            pass
+        """)
+        assign_nodes = assign_stmts.nodes_of_class(nodes.AssignName)
+
+        for1_assnode = next(assign_nodes)
+        assigned = list(for1_assnode.assigned_stmts())
+        self.assertConstNodesEqual([1], assigned)
+
+        for2_assnode = next(assign_nodes)
+        assigned2 = list(for2_assnode.assigned_stmts())
+        self.assertConstNodesEqual([2], assigned2)
+
+        for3_assnode = next(assign_nodes)
+        assigned3 = list(for3_assnode.assigned_stmts())
+        self.assertConstNodesEqual([3], assigned3)
+
     def test_assigned_stmts_starred_for(self) -> None:
         assign_stmts = extract_node("""
         for *a, b in ((1, 2, 3), (4, 5, 6, 7)): #@


### PR DESCRIPTION
## Description

Fixes pylint-dev/pylint#10472 (a `no-member` false positive).

When the iterable of a for loop or comprehension contains names referring to sequences, e.g.

```python
lorem = (Foo(...), 0)
names = [sth.name for sth, _ in [lorem]]
```

the names were not inferred before resolving the assignment path into them: `sth` was assigned the *whole* tuple instead of its first element, so `sth.name` was a `no-member` false positive.

With this change, names in the iterable are inferred before the assignment path is resolved into them (`for a, b in [some_sequence]` -> `a` is the first element of the inferred sequence). The previous behavior is kept for the elements of literal values in deeper unpacking levels, where elements are values rather than references (e.g. `for a, (b, c) in {1: ("a", str)}.items()` still assigns `b` the raw `Name.a` node).

## Tests
- New regression tests in `tests/test_protocols.py` (names in iterable, mixed literals and names, nested unpacking of a named sequence).
- Full test suite: no new failures (baseline comparison with and without the change).