### PR TITLE
Do not infer factory-decorated functions as properties

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,15 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+
+* Fix ``@decorate()`` style decorators being wrongly inferred as properties
+  when the decorator call can infer to multiple values (e.g. a factory
+  function returning a property in one branch). A decorator is now only
+  considered a property when all of its inferred results are properties.
+  This fixes an ``assignment-from-no-return`` false positive in pylint.
+
+  Closes #2632
+
 * Comprehension conditions now constrain the inference of names used in the
   comprehension, like ``if`` statement conditions already did:
   ``[x for x in lst if x is not None]`` no longer infers ``None`` for ``x``

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -98,8 +98,7 @@ def _is_property(
         # to different values (e.g. a factory function) should not turn
         # the decorated function into a property.
         if all(
-            isinstance(inf, (nodes.ClassDef, Instance))
-            and inf.qname() in PROPERTIES
+            isinstance(inf, (nodes.ClassDef, Instance)) and inf.qname() in PROPERTIES
             for inf in inferred_decorators
         ):
             return True

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -71,8 +71,6 @@ def _is_property(
     meth: nodes.FunctionDef | UnboundMethod, context: InferenceContext | None = None
 ) -> bool:
     decoratornames = meth.decoratornames(context=context)
-    if PROPERTIES.intersection(decoratornames):
-        return True
     stripped = {
         name.split(".")[-1]
         for name in decoratornames
@@ -83,12 +81,31 @@ def _is_property(
 
     if not meth.decorators:
         return False
-    # Lookup for subclasses of *property*
-    for decorator in meth.decorators.nodes or ():
-        inferred = safe_infer(decorator, context=context)
-        if inferred is None or isinstance(inferred, UninferableBase):
+    # Lookup for standard properties and subclasses of *property*
+    for decorator in meth.decorators.nodes + meth.extra_decorators:
+        try:
+            inferred_decorators = [
+                inf
+                for inf in decorator.infer(context=context)
+                if not isinstance(inf, UninferableBase)
+            ]
+        except InferenceError:
             continue
-        if isinstance(inferred, nodes.ClassDef):
+        if not inferred_decorators:
+            continue
+        # A decorator is only considered a standard property when all of
+        # its inferred results are properties; a decorator that can infer
+        # to different values (e.g. a factory function) should not turn
+        # the decorated function into a property.
+        if all(
+            isinstance(inf, (nodes.ClassDef, Instance))
+            and inf.qname() in PROPERTIES
+            for inf in inferred_decorators
+        ):
+            return True
+        for inferred in inferred_decorators:
+            if not isinstance(inferred, nodes.ClassDef):
+                continue
             # Check for a class which inherits from a standard property type
             if any(inferred.is_subtype_of(pclass) for pclass in PROPERTIES):
                 return True

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1898,6 +1898,30 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         node = ast["do_a_thing"]
         self.assertEqual(node.type, "function")
 
+    def test_decorator_inferring_to_multiple_values_is_not_property(self) -> None:
+        # Regression test for https://github.com/pylint-dev/astroid/issues/2632
+        # A decorator that can infer to multiple values (e.g. a factory
+        # function) should not turn the decorated function into a property,
+        # even if one of the possible inferred values is a property.
+        code = """
+            def decorate(obj=None):
+                if obj is None:
+                    return lambda x: decorate(x)
+                if isinstance(obj, property):
+                    return property()
+                return obj
+
+            @decorate()
+            def func() -> str:
+                return 'foo'
+        """
+        ast = parse(code, __name__)
+        node = ast["func"]
+        inferred = list(node.inferred())
+        self.assertEqual(len(inferred), 1)
+        self.assertIsInstance(inferred[0], nodes.FunctionDef)
+        self.assertIs(inferred[0], node)
+
     @pytest.mark.skipif(
         IS_PYPY,
         reason="Persistent recursion error that we ignore and never fix",


### PR DESCRIPTION
## Description

Fixes #2632

A function decorated with a decorator *call* that can infer to multiple values — e.g. a factory:

```python
def decorate(obj=None):
    if obj is None:
        return lambda x: decorate(x)
    if isinstance(obj, property):
        return property()
    return obj

@decorate()
def func() -> str:
    return "foo"
```

...was being inferred as a `Property` node, because `decoratornames()` returns `{'.decorate.<lambda>', 'builtins.NoneType', 'builtins.property'}` and `_is_property` returned `True` on the mere *intersection* with `PROPERTIES`. The `isinstance` branch cannot be pruned, so the union-of-names approach cannot distinguish a true `@property` from a factory that returns one in some branch.

`_is_property` is rewritten to inspect each decorator individually: a decorator is only treated as a standard property when **all** of its inferred results are `ClassDef`/`Instance` whose qname is in `PROPERTIES`. The `extra_decorators` are included in the loop (they already feed into `decoratornames()`), and the existing `POSSIBLE_PROPERTIES` stripped-name check is preserved.

## Verification

- `@property`, `@property()`, `@cached_property` and `@functools.cached_property` are still detected (existing `test_property`, `test_infer_property_setter`, `test_property_inference`, etc. pass).
- New regression test `test_decorator_inferring_to_multiple_values_is_not_property` added to `tests/test_inference.py`.
- Full test suite (excluding brain): 1641 passed, 2 pre-existing environment failures (`test_symlink_resolution`, `test_identify_old_namespace_package_protocol`), 113 pre-existing brain failures unchanged.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |