### PR TITLE
Add __required_keys__ and __optional_keys__ to TypedDict brain

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,13 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+
+* Add ``__required_keys__`` and ``__optional_keys__`` to the inferred
+  ``TypedDict`` base class, so subclasses no longer raise a ``no-member``
+  false positive in pylint when accessing those attributes at runtime.
+
+  Closes pylint-dev/pylint#10158
+
 * Comprehension conditions now constrain the inference of names used in the
   comprehension, like ``if`` statement conditions already did:
   ``[x for x in lst if x is not None]`` no longer infers ``None`` for ``x``

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -229,6 +229,12 @@ def infer_typedDict(  # pylint: disable=invalid-name
     class_def.postinit(bases=[extract_node("dict")], body=[], decorators=None)
     func_to_add = _extract_single_node("dict")
     class_def.locals["__call__"] = [func_to_add]
+    # TypedDict subclasses have ``__required_keys__`` and ``__optional_keys__``
+    # class attributes at runtime (e.g. ``MyDict.__required_keys__``), even
+    # though the annotation-only body never declares them.
+    for attr in ("__required_keys__", "__optional_keys__"):
+        func_to_add = _extract_single_node("dict")
+        class_def.locals[attr] = [func_to_add]
     return iter([class_def])
 
 

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -655,6 +655,22 @@ class TypingBrain(unittest.TestCase):
         # Test TypedDict instance is callable
         assert next(code[1].infer()).callable() is True
 
+    def test_typed_dict_required_and_optional_keys(self):
+        """TypedDict subclasses expose ``__required_keys__`` and ``__optional_keys__``."""
+        code = builder.extract_node("""
+        from typing import TypedDict
+        from typing_extensions import TypedDict as ETD
+
+        class CustomTD(TypedDict):  #@
+            var: int
+
+        class CustomTD2(ETD):  #@
+            var: int
+        """)
+        for cls in code:
+            for attr in ("__required_keys__", "__optional_keys__"):
+                assert cls.getattr(attr), f"{cls.name}.{attr} not found"
+
     def test_typing_alias_type(self):
         """
         Test that the type aliased thanks to typing._alias function are


### PR DESCRIPTION
## Description

Closes pylint-dev/pylint#10158

TypedDict subclasses expose `__required_keys__` and `__optional_keys__` class attributes at runtime (e.g. `MyDict.__required_keys__`), but the annotation-only body never declares them, so pylint reported a `no-member` false positive — same class of issue as the previously fixed `__annotations__` (pylint-dev/pylint#7126, astroid#2431).

The inferred `TypedDict` base class in `brain_typing.py` now declares both attributes (as `dict` nodes, mirroring how `__call__` is injected), so any subclass resolves them through the base chain.

## Verification

- `MyDict.__required_keys__` / `__optional_keys__` resolve for both `typing.TypedDict` and `typing_extensions.TypedDict` subclasses
- `pylint --disable=all --enable=no-member` on the issue repro is clean (10/10)
- New test `test_typed_dict_required_and_optional_keys` added to `tests/brain/test_brain.py`

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |