### PR TITLE
Make typing_extensions.TypeAlias infer to a single node

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,16 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+
+* Make ``typing_extensions.TypeAlias`` infer to a single value
+  (``typing.TypeAlias``) instead of two: the legacy Python 3.9 fallback
+  ``FunctionDef`` behind an ``hasattr`` check was dead code for all
+  supported Python versions and confused consumers of the inference.
+  This fixes an ``invalid-name`` false positive in pylint for type
+  aliases declared with ``typing_extensions.TypeAlias``.
+
+  Closes pylint-dev/pylint#11013
+
 * Comprehension conditions now constrain the inference of names used in the
   comprehension, like ``if`` statement conditions already did:
   ``[x for x in lst if x is not None]`` no longer infers ``None`` for ``x``

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -474,6 +474,27 @@ def _typing_transform():
     return AstroidBuilder(AstroidManager()).string_build(code)
 
 
+def _typing_extensions_typealias_transform(
+    module: nodes.Module,
+) -> nodes.Module:
+    """Remove the legacy ``TypeAlias`` FunctionDef from ``typing_extensions``.
+
+    ``typing_extensions.TypeAlias`` is an alias of ``typing.TypeAlias`` since
+    Python 3.10, but the source still contains a Python 3.9 fallback
+    implementation behind an ``hasattr`` check. Astroid cannot prune that
+    branch, so the name infers to two values and consumers (e.g. pylint's
+    name checker) see inconsistent results.
+    """
+    if "TypeAlias" not in module.locals:
+        return module
+    module.locals["TypeAlias"] = [
+        node
+        for node in module.locals["TypeAlias"]
+        if not (isinstance(node, nodes.FunctionDef) and node.name == "TypeAlias")
+    ]
+    return module
+
+
 def register(manager: AstroidManager) -> None:
     manager.register_transform(
         nodes.Call,
@@ -505,3 +526,8 @@ def register(manager: AstroidManager) -> None:
             inference_tip(infer_typing_generic_class_pep695),
             _looks_like_generic_class_pep695,
         )
+    manager.register_transform(
+        nodes.Module,
+        _typing_extensions_typealias_transform,
+        lambda module: module.name == "typing_extensions",
+    )

--- a/tests/brain/test_typing_extensions.py
+++ b/tests/brain/test_typing_extensions.py
@@ -37,3 +37,18 @@ class TestTypingExtensions:
         for node in ast_nodes:
             inferred = next(node.infer())
             assert isinstance(inferred, nodes.ClassDef)
+
+    @staticmethod
+    @pytest.mark.skipif(
+        not HAS_TYPING_EXTENSIONS_TYPEVAR,
+        reason="Need typing_extensions>=4.4.0 to test TypeVar",
+    )
+    def test_typing_extensions_typealias() -> None:
+        """TypeAlias infers to a single node, matching typing.TypeAlias."""
+        ast_nodes = builder.extract_node("""
+        from typing_extensions import TypeAlias
+        TypeAlias #@
+        """)
+        inferred = list(ast_nodes.infer())
+        assert len(inferred) == 1
+        assert inferred[0].qname() == "typing.TypeAlias"


### PR DESCRIPTION
## Description

Closes pylint-dev/pylint#11013

`typing_extensions.TypeAlias` is an alias of `typing.TypeAlias` since Python 3.10, but the module source still contains a Python 3.9 fallback implementation behind an `hasattr` check that astroid cannot prune. The name therefore inferred to two values:

```
ClassDef typing.TypeAlias          # via typing.TypeAlias (brain)
FunctionDef typing_extensions.TypeAlias  # dead 3.9 fallback
```

Consumers that only look at the first inferred value (e.g. pylint's name checker via `safe_infer`) saw the legacy `FunctionDef`, breaking type-alias detection and producing an `invalid-name` false positive for `AuthenticationType: TypeAlias = "..."` inside `TYPE_CHECKING`.

This adds a module transform that drops the dead legacy `FunctionDef` from `typing_extensions` locals — safe because astroid 4.x requires Python 3.10+, where the `hasattr(typing, 'TypeAlias')` branch is always taken.

## Verification

- `typing_extensions.TypeAlias` now infers to exactly one value: `typing.TypeAlias` (ClassDef on 3.12+, FunctionDef on 3.10/3.11 — consistent with how `typing.TypeAlias` itself infers)
- `pylint --disable=all --enable=invalid-name` on the #11013 repro is clean (was C0103 × 2)
- New test `test_typing_extensions_typealias` in `tests/brain/test_typing_extensions.py`
- Full astroid suite: only pre-existing failures unchanged (2 env, 113 brain)

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |