### PR TITLE
Infer the value of a data descriptor as unknown

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -261,6 +261,15 @@ Refs #3108
 
   Refs #3115
 
+* Infer the value of a data descriptor of a C-implemented class as unknown
+  instead of as a class named after the attribute. Reading such an attribute,
+  for instance ``exc.__traceback__.tb_frame`` or ``gen.gi_frame``, inferred a
+  class, so the attributes of the value the descriptor returns were reported as
+  missing. ``raw_building.object_build_datadescriptor()`` now returns an
+  ``EmptyNode``.
+
+  Closes pylint-dev/pylint#11218
+
 What's New in astroid 4.1.2?
 ============================
 Release date: 2026-03-22

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -335,9 +335,15 @@ def object_build_function(
 
 def object_build_datadescriptor(
     node: nodes.Module | nodes.ClassDef, member: type
-) -> nodes.ClassDef:
-    """create astroid for a living data descriptor object"""
-    return _base_class_object_build(node, member, [])
+) -> nodes.EmptyNode:
+    """create astroid for a living data descriptor object
+
+    What the descriptor returns is not statically known, so it is modelled as an
+    unknown value. Modelling it as a class named after the attribute made
+    attribute access on the descriptor's value infer that class instead, which
+    reported the value's own attributes as missing.
+    """
+    return build_dummy(_EMPTY_OBJECT_MARKER)
 
 
 def object_build_methoddescriptor(
@@ -511,7 +517,7 @@ class InspectBuilder:
             elif inspect.ismethoddescriptor(member):
                 child: nodes.NodeNG = object_build_methoddescriptor(node, member)
             elif inspect.isdatadescriptor(member):
-                child = object_build_datadescriptor(node, member)
+                child: nodes.NodeNG = object_build_datadescriptor(node, member)
             elif isinstance(member, tuple(node_classes.CONST_CLS)):
                 # Special case: __hash__ = None overrides ObjectModel for unhashable types.
                 # See https://docs.python.org/3/reference/datamodel.html#object.__hash__

--- a/tests/brain/test_ctypes.py
+++ b/tests/brain/test_ctypes.py
@@ -6,7 +6,7 @@ import sys
 
 import pytest
 
-from astroid import extract_node, nodes
+from astroid import extract_node, nodes, util
 
 pytestmark = pytest.mark.skipif(
     hasattr(sys, "pypy_version_info"),
@@ -95,9 +95,9 @@ def test_cdata_member_access() -> None:
     """
     node = extract_node(src)
     assert isinstance(node, nodes.NodeNG)
-    node_inf = node.inferred()[0]
-    assert node_inf.display_type() == "Class"
-    assert node_inf.qname() == "_ctypes._SimpleCData._objects"
+    # ``_objects`` is a data descriptor, so the attribute resolves but the value
+    # it returns is not statically known.
+    assert node.inferred() == [util.Uninferable]
 
 
 def test_other_ctypes_member_untouched() -> None:

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -666,13 +666,13 @@ class GeneratorModelTest(unittest.TestCase):
         doc = next(ast_nodes[1].infer())
         self.assertEqual(doc.value, "a")
 
+        # ``gi_code`` and ``gi_frame`` are data descriptors, so they resolve but
+        # the values they return are not statically known.
         gi_code = next(ast_nodes[2].infer())
-        self.assertIsInstance(gi_code, nodes.ClassDef)
-        self.assertEqual(gi_code.name, "gi_code")
+        self.assertIs(gi_code, util.Uninferable)
 
         gi_frame = next(ast_nodes[3].infer())
-        self.assertIsInstance(gi_frame, nodes.ClassDef)
-        self.assertEqual(gi_frame.name, "gi_frame")
+        self.assertIs(gi_frame, util.Uninferable)
 
         send = next(ast_nodes[4].infer())
         self.assertIsInstance(send, astroid.BoundMethod)
@@ -740,6 +740,21 @@ class ExceptionModelTest(unittest.TestCase):
             inferred = next(node.infer())
             assert isinstance(inferred, nodes.Const)
             assert inferred.value == value
+
+    @staticmethod
+    def test_traceback_frame_attribute() -> None:
+        """The frame a traceback exposes is a data descriptor, so its value is
+        unknown rather than a class named after the attribute.
+
+        Closes https://github.com/pylint-dev/pylint/issues/11218
+        """
+        node = builder.extract_node("""
+        try:
+            raise ValueError("a")
+        except ValueError as err:
+            err.__traceback__.tb_frame.f_locals #@
+        """)
+        assert node.inferred() == [util.Uninferable]
 
     def test_unicodedecodeerror(self) -> None:
         code = """

--- a/tests/test_raw_building.py
+++ b/tests/test_raw_building.py
@@ -24,6 +24,7 @@ import pytest
 import tests.testdata.python3.data.fake_module_with_broken_getattr as fm_getattr
 import tests.testdata.python3.data.fake_module_with_collection_getattribute as fm_collection
 import tests.testdata.python3.data.fake_module_with_warnings as fm
+from astroid import nodes, util
 from astroid.builder import AstroidBuilder
 from astroid.const import IS_PYPY, PY312_PLUS
 from astroid.manager import AstroidManager
@@ -34,6 +35,7 @@ from astroid.raw_building import (
     build_function,
     build_module,
     object_build_class,
+    object_build_datadescriptor,
 )
 
 try:
@@ -90,6 +92,15 @@ class RawBuildingTC(unittest.TestCase):
         assert len(node.args.kwonlyargs) == 2
         assert node.args.kwonlyargs[0].name == "a"
         assert node.args.kwonlyargs[1].name == "b"
+
+    def test_object_build_datadescriptor(self) -> None:
+        # Tests https://github.com/pylint-dev/pylint/issues/11218
+        # A data descriptor used to be modelled as a class named after the
+        # attribute, so the value it returns was inferred as that class and the
+        # attributes of the real value were reported as missing.
+        node = object_build_datadescriptor(DUMMY_MOD, types.TracebackType.tb_frame)
+        self.assertIsInstance(node, nodes.EmptyNode)
+        self.assertEqual(node.inferred(), [util.Uninferable])
 
     def test_build_from_import(self) -> None:
         names = ["exceptions, inference, inspector"]


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`raw_building` modelled a data descriptor of a C-implemented class as a class named
after the attribute (`object_build_datadescriptor` built a `ClassDef` through
`_base_class_object_build`). Reading such an attribute therefore inferred that class
instead of a value, and the attributes of the value the descriptor returns were
reported as missing:

```console
$ cat tbf.py
def foo():
    pass


try:
    foo()
except Exception as exn:
    last_tb = exn.__traceback__
    print(last_tb.tb_frame.f_locals)
$ pylint --rcfile=/dev/null --disable=all --enable=no-member tbf.py
tbf.py:9:10: E1101: Class 'tb_frame' has no 'f_locals' member (no-member)
```

The generator model has the same surface, since `gi_frame` and `gi_code` are data
descriptors too:

```console
$ pylint --rcfile=/dev/null --disable=all --enable=no-member gen.py
gen.py:6:6: E1101: Class 'gi_frame' has no 'f_locals' member (no-member)
```

What a data descriptor returns is not statically known, so this builds an unknown
value instead: the same `EmptyNode` that the fallback branch of
`InspectBuilder.object_build` already uses for members astroid cannot model. The
attribute itself stays resolvable (`getattr` finds it, a genuinely missing attribute
still raises `AttributeInferenceError`); only the value is now `Uninferable`. Both
snippets above are clean after the change.

Two existing tests pinned the old modelling and are updated to the new one:
`test_cdata_member_access` (it checks that `_CData` members stay reachable through the
ctypes brain, which is still asserted, `x._objects` resolving to `Uninferable` rather
than raising) and `GeneratorModelTest::test_model`.

Exception instance attributes such as `OSError().errno` are unaffected: they come from
the instantiation trick in `_base_class_object_build`, which only applies to classes.

Verification run locally on macOS with CPython 3.13: `pytest` gives 2013 passed with
the same 3 pre-existing environment failures (`test_symlink_resolution`,
`test_identify_old_namespace_package_protocol`, `test_module_is_not_namespace`) that
also fail on unmodified `main`; each of the four touched tests fails with only the
`raw_building` hunk reverted; pylint's own suite against this branch is 2122 passed,
identical to the same run against unmodified `main`; `black`, `ruff`, `mypy` and
`pylint --rcfile=pylintrc` are clean.

Closes pylint-dev/pylint#11218
