### PR TITLE
Run the documentation examples in CI

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,10 +10,15 @@ build:
   # Read the Docs builds every pull request and is a required check, so this is
   # what enforces `fail_on_warning` above. Keep the interpreter recent enough to
   # parse the syntax the documentation shows: the examples for PEP 695 type
-  # parameters need 3.12.
+  # parameters need 3.12, and those for template strings need 3.14.
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.14"
+  jobs:
+    post_build:
+      # Run the `>>>` examples too, so the same required check covers both a
+      # reference that does not resolve and an example that is no longer true.
+      - python -m sphinx -E -W -b doctest doc doc/build/doctest
 
 python:
   install:

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,12 @@ Release date: TBA
   are documented as part of the public API, and a number of docstrings that
   Sphinx could not parse were repaired.
 
+* The ``>>>`` examples in the documentation are run when the documentation is
+  built, so one that stops being true is noticed. Most of them could not run
+  before: they printed node addresses recorded in 2018, and the multi-line ones
+  were missing the ``...`` continuation prompt. The example for ``Decorators``
+  reported the wrong line numbers.
+
 * Fix the example in the docstring of ``BoolOp``, which showed the node it was
   copied from: ``astroid.extract_node("a and b")`` gives a ``BoolOp``, not a
   ``BinOp``.

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -392,18 +392,21 @@ def extract_node(code: str, module_name: str = "") -> nodes.NodeNG | list[nodes.
     Statements:
      To extract one or more statement nodes, append #@ to the end of the line
 
-     Examples:
-       >>> def x():
-       >>>   def y():
-       >>>     return 1 #@
+     Examples::
 
-       The return statement will be extracted.
+       def x():
+         def y():
+           return 1 #@
 
-       >>> class X(object):
-       >>>   def meth(self): #@
-       >>>     pass
+     The return statement will be extracted.
 
-      The function object 'meth' will be extracted.
+     ::
+
+       class X(object):
+         def meth(self): #@
+           pass
+
+     The function object 'meth' will be extracted.
 
     Expressions:
      To extract arbitrary expressions, surround them with the fake
@@ -412,19 +415,24 @@ def extract_node(code: str, module_name: str = "") -> nodes.NodeNG | list[nodes.
      node's parent attribute) will look like the function call was
      never there in the first place.
 
-     Examples:
-       >>> a = __(1)
+     Examples::
 
-       The const node will be extracted.
+       a = __(1)
 
-       >>> def x(d=__(foo.bar)): pass
+     The const node will be extracted.
 
-       The node containing the default argument will be extracted.
+     ::
 
-       >>> def foo(a, b):
-       >>>   return 0 < __(len(a)) < b
+       def x(d=__(foo.bar)): pass
 
-       The node containing the function call 'len' will be extracted.
+     The node containing the default argument will be extracted.
+
+     ::
+
+       def foo(a, b):
+         return 0 < __(len(a)) < b
+
+     The node containing the function call 'len' will be extracted.
 
     If no statements or expressions are selected, the last toplevel
     statement will be returned.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -404,9 +404,9 @@ class AssignName(
     >>> import astroid
     >>> node = astroid.extract_node('variable = range(10)')
     >>> node
-    <Assign l.1 at 0x7effe1db8550>
+    <Assign l.1 at 0x...>
     >>> list(node.get_children())
-    [<AssignName.variable l.1 at 0x7effe1db8748>, <Call l.1 at 0x7effe1db8630>]
+    [<AssignName.variable l.1 at 0x...>, <Call l.1 at 0x...>]
     >>> list(node.get_children())[0].as_string()
     'variable'
     """
@@ -493,7 +493,7 @@ class DelName(
     >>> import astroid
     >>> node = astroid.extract_node("del variable #@")
     >>> list(node.get_children())
-    [<DelName.variable l.1 at 0x7effe1da4d30>]
+    [<DelName.variable l.1 at 0x...>]
     >>> list(node.get_children())[0].as_string()
     'variable'
     """
@@ -531,9 +531,9 @@ class Name(_base_nodes.LookupMixIn, _base_nodes.NoChildrenNode):
     >>> import astroid
     >>> node = astroid.extract_node('range(10)')
     >>> node
-    <Call l.1 at 0x7effe1db8710>
+    <Call l.1 at 0x...>
     >>> list(node.get_children())
-    [<Name.range l.1 at 0x7effe1db86a0>, <Const.int l.1 at 0x7effe1db8518>]
+    [<Name.range l.1 at 0x...>, <Const.int l.1 at 0x...>]
     >>> list(node.get_children())[0].as_string()
     'range'
     """
@@ -609,9 +609,9 @@ class Arguments(
     >>> import astroid
     >>> node = astroid.extract_node('def foo(bar): pass')
     >>> node
-    <FunctionDef.foo l.1 at 0x7effe1db8198>
+    <FunctionDef.foo l.1 at 0x...>
     >>> node.args
-    <Arguments l.1 at 0x7effe1db82e8>
+    <Arguments l.1 at 0x...>
     """
 
     # In the ast module, each argument is a new class, _ast.arg, which
@@ -1126,9 +1126,9 @@ class AssignAttr(_base_nodes.LookupMixIn, _base_nodes.ParentAssignNode):
     >>> import astroid
     >>> node = astroid.extract_node('self.attribute = range(10)')
     >>> node
-    <Assign l.1 at 0x7effe1d521d0>
+    <Assign l.1 at 0x...>
     >>> list(node.get_children())
-    [<AssignAttr.attribute l.1 at 0x7effe1d52320>, <Call l.1 at 0x7effe1d522e8>]
+    [<AssignAttr.attribute l.1 at 0x...>, <Call l.1 at 0x...>]
     >>> list(node.get_children())[0].as_string()
     'self.attribute'
     """
@@ -1200,7 +1200,7 @@ class Assert(_base_nodes.Statement):
     >>> import astroid
     >>> node = astroid.extract_node('assert len(things) == 10, "Not enough things"')
     >>> node
-    <Assert l.1 at 0x7effe1d527b8>
+    <Assert l.1 at 0x...>
     """
 
     _astroid_fields = ("test", "fail")
@@ -1231,7 +1231,7 @@ class Assign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
     >>> import astroid
     >>> node = astroid.extract_node('variable = range(10)')
     >>> node
-    <Assign l.1 at 0x7effe1db8550>
+    <Assign l.1 at 0x...>
     """
 
     targets: list[NodeNG]
@@ -1285,7 +1285,7 @@ class AnnAssign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
     >>> import astroid
     >>> node = astroid.extract_node('variable: List[int] = range(10)')
     >>> node
-    <AnnAssign l.1 at 0x7effe1d4c630>
+    <AnnAssign l.1 at 0x...>
     """
 
     _astroid_fields = ("target", "annotation", "value")
@@ -1338,7 +1338,7 @@ class AugAssign(
     >>> import astroid
     >>> node = astroid.extract_node('variable += 1')
     >>> node
-    <AugAssign l.1 at 0x7effe1db4d68>
+    <AugAssign l.1 at 0x...>
     """
 
     _astroid_fields = ("target", "value")
@@ -1464,7 +1464,7 @@ class BinOp(_base_nodes.OperatorNode):
     >>> import astroid
     >>> node = astroid.extract_node('a + b')
     >>> node
-    <BinOp l.1 at 0x7f23b2e8cfd0>
+    <BinOp l.1 at 0x...>
     """
 
     _astroid_fields = ("left", "right")
@@ -1579,7 +1579,7 @@ class BoolOp(NodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('a and b')
     >>> node
-    <BoolOp l.1 at 0x7f23b2e71c50>
+    <BoolOp l.1 at 0x...>
     """
 
     _astroid_fields = ("values",)
@@ -1699,7 +1699,7 @@ class Break(_base_nodes.NoChildrenNode, _base_nodes.Statement):
     >>> import astroid
     >>> node = astroid.extract_node('break')
     >>> node
-    <Break l.1 at 0x7f23b2e9e5c0>
+    <Break l.1 at 0x...>
     """
 
 
@@ -1711,7 +1711,7 @@ class Call(NodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('function()')
     >>> node
-    <Call l.1 at 0x7f23b2e71eb8>
+    <Call l.1 at 0x...>
     """
 
     _astroid_fields = ("func", "args", "keywords")
@@ -1816,9 +1816,9 @@ class Compare(NodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('a <= b <= c')
     >>> node
-    <Compare l.1 at 0x7f23b2e9e6d8>
+    <Compare l.1 at 0x...>
     >>> node.ops
-    [('<=', <Name.b l.1 at 0x7f23b2e9e2b0>), ('<=', <Name.c l.1 at 0x7f23b2e9e390>)]
+    [('<=', <Name.b l.1 at 0x...>), ('<=', <Name.c l.1 at 0x...>)]
     """
 
     _astroid_fields = ("left", "ops")
@@ -1948,7 +1948,7 @@ class Comprehension(NodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('[x for x in some_values]')
     >>> list(node.get_children())
-    [<Name.x l.1 at 0x7f23b2e352b0>, <Comprehension l.1 at 0x7f23b2e35320>]
+    [<Name.x l.1 at 0x...>, <Comprehension l.1 at 0x...>]
     >>> list(node.get_children())[1].as_string()
     'for x in some_values'
     """
@@ -2025,13 +2025,13 @@ class Const(_base_nodes.NoChildrenNode, Instance):
     >>> import astroid
     >>> node = astroid.extract_node('(5, "This is a string.", True, None, b"bytes")')
     >>> node
-    <Tuple.tuple l.1 at 0x7f23b2e358d0>
+    <Tuple.tuple l.1 at 0x...>
     >>> list(node.get_children())
-    [<Const.int l.1 at 0x7f23b2e35940>,
-    <Const.str l.1 at 0x7f23b2e35978>,
-    <Const.bool l.1 at 0x7f23b2e359b0>,
-    <Const.NoneType l.1 at 0x7f23b2e359e8>,
-    <Const.bytes l.1 at 0x7f23b2e35a20>]
+    [<Const.int l.1 at 0x...>,
+    <Const.str l.1 at 0x...>,
+    <Const.bool l.1 at 0x...>,
+    <Const.NoneType l.1 at 0x...>,
+    <Const.bytes l.1 at 0x...>]
     """
 
     _other_fields = ("value", "kind")
@@ -2196,7 +2196,7 @@ class Continue(_base_nodes.NoChildrenNode, _base_nodes.Statement):
     >>> import astroid
     >>> node = astroid.extract_node('continue')
     >>> node
-    <Continue l.1 at 0x7f23b2e35588>
+    <Continue l.1 at 0x...>
     """
 
 
@@ -2208,14 +2208,14 @@ class Decorators(NodeNG):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    @property
-    def my_property(self):
-        return 3
-    ''')
+    ... @property
+    ... def my_property(self):
+    ...     return 3
+    ... ''')
     >>> node
-    <FunctionDef.my_property l.2 at 0x7f23b2e35d30>
+    <FunctionDef.my_property l.3 at 0x...>
     >>> list(node.get_children())[0]
-    <Decorators l.1 at 0x7f23b2e35d68>
+    <Decorators l.2 at 0x...>
     """
 
     _astroid_fields = ("nodes",)
@@ -2258,9 +2258,9 @@ class DelAttr(_base_nodes.ParentAssignNode):
     >>> import astroid
     >>> node = astroid.extract_node('del self.attr')
     >>> node
-    <Delete l.1 at 0x7f23b2e35f60>
+    <Delete l.1 at 0x...>
     >>> list(node.get_children())[0]
-    <DelAttr.attr l.1 at 0x7f23b2e411d0>
+    <DelAttr.attr l.1 at 0x...>
     """
 
     _astroid_fields = ("expr",)
@@ -2305,7 +2305,7 @@ class Delete(_base_nodes.AssignTypeNode, _base_nodes.Statement):
     >>> import astroid
     >>> node = astroid.extract_node('del self.attr')
     >>> node
-    <Delete l.1 at 0x7f23b2e35f60>
+    <Delete l.1 at 0x...>
     """
 
     _astroid_fields = ("targets",)
@@ -2345,7 +2345,7 @@ class Dict(NodeNG, Instance):
     >>> import astroid
     >>> node = astroid.extract_node('{1: "1"}')
     >>> node
-    <Dict.dict l.1 at 0x7f23b2e35cc0>
+    <Dict.dict l.1 at 0x...>
     """
 
     _astroid_fields = ("items",)
@@ -2532,9 +2532,9 @@ class Expr(_base_nodes.Statement):
     >>> import astroid
     >>> node = astroid.extract_node('method()')
     >>> node
-    <Call l.1 at 0x7f23b2e352b0>
+    <Call l.1 at 0x...>
     >>> node.parent
-    <Expr l.1 at 0x7f23b2e35278>
+    <Expr l.1 at 0x...>
     """
 
     _astroid_fields = ("value",)
@@ -2607,15 +2607,15 @@ class ExceptHandler(
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-        try:
-            do_something()
-        except Exception as error:
-            print("Error!")
-        ''')
+    ...     try:
+    ...         do_something()
+    ...     except Exception as error:
+    ...         print("Error!")
+    ...     ''')
     >>> node
-    <Try l.2 at 0x7f23b2e9d908>
+    <Try l.2 at 0x...>
     >>> node.handlers
-    [<ExceptHandler l.4 at 0x7f23b2e9e860>]
+    [<ExceptHandler l.4 at 0x...>]
     """
 
     _astroid_fields = ("type", "name", "body")
@@ -2686,7 +2686,7 @@ class For(
     >>> import astroid
     >>> node = astroid.extract_node('for thing in things: print(thing)')
     >>> node
-    <For l.1 at 0x7f23b2e8cf28>
+    <For l.1 at 0x...>
     """
 
     _astroid_fields = ("target", "iter", "body", "orelse")
@@ -2757,14 +2757,14 @@ class AsyncFor(For):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    async def func(things):
-        async for thing in things:
-            print(thing)
-    ''')
+    ... async def func(things):
+    ...     async for thing in things:
+    ...         print(thing)
+    ... ''')
     >>> node
-    <AsyncFunctionDef.func l.2 at 0x7f23b2e416d8>
+    <AsyncFunctionDef.func l.2 at 0x...>
     >>> node.body[0]
-    <AsyncFor l.3 at 0x7f23b2e417b8>
+    <AsyncFor l.3 at 0x...>
     """
 
 
@@ -2775,15 +2775,15 @@ class Await(NodeNG):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    async def func(things):
-        await other_func()
-    ''')
+    ... async def func(things):
+    ...     await other_func()
+    ... ''')
     >>> node
-    <AsyncFunctionDef.func l.2 at 0x7f23b2e41748>
+    <AsyncFunctionDef.func l.2 at 0x...>
     >>> node.body[0]
-    <Expr l.3 at 0x7f23b2e419e8>
+    <Expr l.3 at 0x...>
     >>> list(node.body[0].get_children())[0]
-    <Await l.3 at 0x7f23b2e41a20>
+    <Await l.3 at 0x...>
     """
 
     _astroid_fields = ("value",)
@@ -2804,7 +2804,7 @@ class ImportFrom(_base_nodes.ImportNode):
     >>> import astroid
     >>> node = astroid.extract_node('from my_package import my_module')
     >>> node
-    <ImportFrom l.1 at 0x7f23b2e415c0>
+    <ImportFrom l.1 at 0x...>
     """
 
     _other_fields = ("modname", "names", "level", "is_lazy")
@@ -2952,7 +2952,7 @@ class Global(_base_nodes.NoChildrenNode, _base_nodes.Statement):
     >>> import astroid
     >>> node = astroid.extract_node('global a_global')
     >>> node
-    <Global l.1 at 0x7f23b2e9de10>
+    <Global l.1 at 0x...>
     """
 
     _other_fields = ("names",)
@@ -3018,7 +3018,7 @@ class If(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
     >>> import astroid
     >>> node = astroid.extract_node('if condition: print(True)')
     >>> node
-    <If l.1 at 0x7f23b2e9dd30>
+    <If l.1 at 0x...>
     """
 
     _astroid_fields = ("test", "body", "orelse")
@@ -3071,7 +3071,7 @@ class IfExp(NodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('value if condition else other')
     >>> node
-    <IfExp l.1 at 0x7f23b2e9dbe0>
+    <IfExp l.1 at 0x...>
     """
 
     _astroid_fields = ("test", "body", "orelse")
@@ -3149,7 +3149,7 @@ class Import(_base_nodes.ImportNode):
     >>> import astroid
     >>> node = astroid.extract_node('import astroid')
     >>> node
-    <Import l.1 at 0x7f23b2e4e5c0>
+    <Import l.1 at 0x...>
     """
 
     _other_fields = ("names", "is_lazy")
@@ -3227,9 +3227,9 @@ class Keyword(NodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('function(a_kwarg=True)')
     >>> node
-    <Call l.1 at 0x7f23b2e9e320>
+    <Call l.1 at 0x...>
     >>> node.keywords
-    [<Keyword l.1 at 0x7f23b2e9e9b0>]
+    [<Keyword l.1 at 0x...>]
     """
 
     _astroid_fields = ("value",)
@@ -3272,7 +3272,7 @@ class List(BaseContainer):
     >>> import astroid
     >>> node = astroid.extract_node('[1, 2, 3]')
     >>> node
-    <List.list l.1 at 0x7f23b2e9e128>
+    <List.list l.1 at 0x...>
     """
 
     _other_fields = ("ctx",)
@@ -3342,13 +3342,13 @@ class Nonlocal(_base_nodes.NoChildrenNode, _base_nodes.Statement):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    def function():
-        nonlocal var
-    ''')
+    ... def function():
+    ...     nonlocal var
+    ... ''')
     >>> node
-    <FunctionDef.function l.2 at 0x7f23b2e9e208>
+    <FunctionDef.function l.2 at 0x...>
     >>> node.body[0]
-    <Nonlocal l.3 at 0x7f23b2e9e908>
+    <Nonlocal l.3 at 0x...>
     """
 
     _other_fields = ("names",)
@@ -3399,7 +3399,7 @@ class ParamSpec(_base_nodes.AssignTypeNode):
     >>> import astroid
     >>> node = astroid.extract_node('type Alias[**P] = Callable[P, int]')
     >>> node.type_params[0]
-    <ParamSpec l.1 at 0x7f23b2e4e198>
+    <ParamSpec l.1 at 0x...>
     """
 
     _astroid_fields = ("name", "default_value")
@@ -3456,7 +3456,7 @@ class Pass(_base_nodes.NoChildrenNode, _base_nodes.Statement):
     >>> import astroid
     >>> node = astroid.extract_node('pass')
     >>> node
-    <Pass l.1 at 0x7f23b2e9e748>
+    <Pass l.1 at 0x...>
     """
 
 
@@ -3466,7 +3466,7 @@ class Raise(_base_nodes.Statement):
     >>> import astroid
     >>> node = astroid.extract_node('raise RuntimeError("Something bad happened!")')
     >>> node
-    <Raise l.1 at 0x7f23b2e9e828>
+    <Raise l.1 at 0x...>
     """
 
     _astroid_fields = ("exc", "cause")
@@ -3510,7 +3510,7 @@ class Return(_base_nodes.Statement):
     >>> import astroid
     >>> node = astroid.extract_node('return True')
     >>> node
-    <Return l.1 at 0x7f23b8211908>
+    <Return l.1 at 0x...>
     """
 
     _astroid_fields = ("value",)
@@ -3538,7 +3538,7 @@ class Set(BaseContainer):
     >>> import astroid
     >>> node = astroid.extract_node('{1, 2, 3}')
     >>> node
-    <Set.set l.1 at 0x7f23b2e71d68>
+    <Set.set l.1 at 0x...>
     """
 
     infer_unary_op = protocols.set_infer_unary_op
@@ -3557,9 +3557,9 @@ class Slice(NodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('things[1:3]')
     >>> node
-    <Subscript l.1 at 0x7f23b2e71f60>
+    <Subscript l.1 at 0x...>
     >>> node.slice
-    <Slice l.1 at 0x7f23b2e71e80>
+    <Slice l.1 at 0x...>
     """
 
     _astroid_fields = ("lower", "upper", "step")
@@ -3658,7 +3658,7 @@ class Starred(_base_nodes.ParentAssignNode):
     >>> import astroid
     >>> node = astroid.extract_node('*args')
     >>> node
-    <Starred l.1 at 0x7f23b2e41978>
+    <Starred l.1 at 0x...>
     """
 
     _astroid_fields = ("value",)
@@ -3706,7 +3706,7 @@ class Subscript(NodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('things[1:3]')
     >>> node
-    <Subscript l.1 at 0x7f23b2e71f60>
+    <Subscript l.1 at 0x...>
     """
 
     _SUBSCRIPT_SENTINEL = object()
@@ -3823,15 +3823,15 @@ class Try(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-        try:
-            do_something()
-        except Exception as error:
-            print("Error!")
-        finally:
-            print("Cleanup!")
-        ''')
+    ...     try:
+    ...         do_something()
+    ...     except Exception as error:
+    ...         print("Error!")
+    ...     finally:
+    ...         print("Cleanup!")
+    ...     ''')
     >>> node
-    <Try l.2 at 0x7f23b2e41d68>
+    <Try l.2 at 0x...>
     """
 
     _astroid_fields = ("body", "handlers", "orelse", "finalbody")
@@ -4029,7 +4029,7 @@ class Tuple(BaseContainer):
     >>> import astroid
     >>> node = astroid.extract_node('(1, 2, 3)')
     >>> node
-    <Tuple.tuple l.1 at 0x7f23b2e41780>
+    <Tuple.tuple l.1 at 0x...>
     """
 
     _other_fields = ("ctx",)
@@ -4100,7 +4100,7 @@ class TypeAlias(_base_nodes.AssignTypeNode, _base_nodes.Statement):
     >>> import astroid
     >>> node = astroid.extract_node('type Point = tuple[float, float]')
     >>> node
-    <TypeAlias l.1 at 0x7f23b2e4e198>
+    <TypeAlias l.1 at 0x...>
     """
 
     _astroid_fields = ("name", "type_params", "value")
@@ -4173,7 +4173,7 @@ class TypeVar(_base_nodes.AssignTypeNode):
     >>> import astroid
     >>> node = astroid.extract_node('type Point[T] = tuple[float, float]')
     >>> node.type_params[0]
-    <TypeVar l.1 at 0x7f23b2e4e198>
+    <TypeVar l.1 at 0x...>
     """
 
     _astroid_fields = ("name", "bound", "default_value")
@@ -4238,7 +4238,7 @@ class TypeVarTuple(_base_nodes.AssignTypeNode):
     >>> import astroid
     >>> node = astroid.extract_node('type Alias[*Ts] = tuple[*Ts]')
     >>> node.type_params[0]
-    <TypeVarTuple l.1 at 0x7f23b2e4e198>
+    <TypeVarTuple l.1 at 0x...>
     """
 
     _astroid_fields = ("name", "default_value")
@@ -4305,7 +4305,7 @@ class UnaryOp(_base_nodes.OperatorNode):
     >>> import astroid
     >>> node = astroid.extract_node('-5')
     >>> node
-    <UnaryOp l.1 at 0x7f23b2e4e198>
+    <UnaryOp l.1 at 0x...>
     """
 
     _astroid_fields = ("operand",)
@@ -4449,11 +4449,11 @@ class While(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    while condition():
-        print("True")
-    ''')
+    ... while condition():
+    ...     print("True")
+    ... ''')
     >>> node
-    <While l.2 at 0x7f23b2e4e390>
+    <While l.2 at 0x...>
     """
 
     _astroid_fields = ("test", "body", "orelse")
@@ -4512,11 +4512,11 @@ class With(
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    with open(file_path) as file_:
-        print(file_.read())
-    ''')
+    ... with open(file_path) as file_:
+    ...     print(file_.read())
+    ... ''')
     >>> node
-    <With l.2 at 0x7f23b2e4e710>
+    <With l.2 at 0x...>
     """
 
     _astroid_fields = ("items", "body")
@@ -4617,7 +4617,7 @@ class Yield(NodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('yield True')
     >>> node
-    <Yield l.1 at 0x7f23b2e4e5f8>
+    <Yield l.1 at 0x...>
     """
 
     _astroid_fields = ("value",)
@@ -4655,9 +4655,9 @@ class FormattedValue(NodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('f"Format {type_}"')
     >>> node
-    <JoinedStr l.1 at 0x7f23b2e4ed30>
+    <JoinedStr l.1 at 0x...>
     >>> node.values
-    [<Const.str l.1 at 0x7f23b2e4eda0>, <FormattedValue l.1 at 0x7f23b2e4edd8>]
+    [<Const.str l.1 at 0x...>, <FormattedValue l.1 at 0x...>]
     """
 
     _astroid_fields = ("value", "format_spec")
@@ -4787,7 +4787,7 @@ class JoinedStr(NodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('f"Format {type_}"')
     >>> node
-    <JoinedStr l.1 at 0x7f23b2e4ed30>
+    <JoinedStr l.1 at 0x...>
     """
 
     _astroid_fields = ("values",)
@@ -4903,7 +4903,7 @@ class NamedExpr(_base_nodes.AssignTypeNode):
     >>> import astroid
     >>> module = astroid.parse('if a := 1: pass')
     >>> module.body[0].test
-    <NamedExpr l.1 at 0x7f23b2e4ed30>
+    <NamedExpr l.1 at 0x...>
     """
 
     _astroid_fields = ("target", "value")
@@ -5095,14 +5095,14 @@ class Match(_base_nodes.Statement, _base_nodes.MultiLineBlockNode):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    match x:
-        case 200:
-            ...
-        case _:
-            ...
-    ''')
+    ... match x:
+    ...     case 200:
+    ...         ...
+    ...     case _:
+    ...         ...
+    ... ''')
     >>> node
-    <Match l.2 at 0x10c24e170>
+    <Match l.2 at 0x...>
     """
 
     _astroid_fields = ("subject", "cases")
@@ -5146,12 +5146,12 @@ class MatchCase(_base_nodes.MultiLineBlockNode):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    match x:
-        case 200:
-            ...
-    ''')
+    ... match x:
+    ...     case 200:
+    ...         ...
+    ... ''')
     >>> node.cases[0]
-    <MatchCase l.3 at 0x10c24e590>
+    <MatchCase l.3 at 0x...>
     """
 
     _astroid_fields = ("pattern", "guard", "body")
@@ -5191,12 +5191,12 @@ class MatchValue(Pattern):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    match x:
-        case 200:
-            ...
-    ''')
+    ... match x:
+    ...     case 200:
+    ...         ...
+    ... ''')
     >>> node.cases[0].pattern
-    <MatchValue l.3 at 0x10c24e200>
+    <MatchValue l.3 at 0x...>
     """
 
     _astroid_fields = ("value",)
@@ -5228,20 +5228,20 @@ class MatchSingleton(Pattern):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    match x:
-        case True:
-            ...
-        case False:
-            ...
-        case None:
-            ...
-    ''')
+    ... match x:
+    ...     case True:
+    ...         ...
+    ...     case False:
+    ...         ...
+    ...     case None:
+    ...         ...
+    ... ''')
     >>> node.cases[0].pattern
-    <MatchSingleton l.3 at 0x10c2282e0>
+    <MatchSingleton l.3 at 0x...>
     >>> node.cases[1].pattern
-    <MatchSingleton l.5 at 0x10c228af0>
+    <MatchSingleton l.5 at 0x...>
     >>> node.cases[2].pattern
-    <MatchSingleton l.7 at 0x10c229f90>
+    <MatchSingleton l.7 at 0x...>
     """
 
     _other_fields = ("value",)
@@ -5271,16 +5271,16 @@ class MatchSequence(Pattern):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    match x:
-        case [1, 2]:
-            ...
-        case (1, 2, *_):
-            ...
-    ''')
+    ... match x:
+    ...     case [1, 2]:
+    ...         ...
+    ...     case (1, 2, *_):
+    ...         ...
+    ... ''')
     >>> node.cases[0].pattern
-    <MatchSequence l.3 at 0x10ca80d00>
+    <MatchSequence l.3 at 0x...>
     >>> node.cases[1].pattern
-    <MatchSequence l.5 at 0x10ca80b20>
+    <MatchSequence l.5 at 0x...>
     """
 
     _astroid_fields = ("patterns",)
@@ -5312,12 +5312,12 @@ class MatchMapping(_base_nodes.AssignTypeNode, Pattern):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    match x:
-        case {1: "Hello", 2: "World", 3: _, **rest}:
-            ...
-    ''')
+    ... match x:
+    ...     case {1: "Hello", 2: "World", 3: _, **rest}:
+    ...         ...
+    ... ''')
     >>> node.cases[0].pattern
-    <MatchMapping l.3 at 0x10c8a8850>
+    <MatchMapping l.3 at 0x...>
     """
 
     _astroid_fields = ("keys", "patterns", "rest")
@@ -5364,16 +5364,16 @@ class MatchClass(Pattern):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    match x:
-        case Point2D(0, 0):
-            ...
-        case Point3D(x=0, y=0, z=0):
-            ...
-    ''')
+    ... match x:
+    ...     case Point2D(0, 0):
+    ...         ...
+    ...     case Point3D(x=0, y=0, z=0):
+    ...         ...
+    ... ''')
     >>> node.cases[0].pattern
-    <MatchClass l.3 at 0x10ca83940>
+    <MatchClass l.3 at 0x...>
     >>> node.cases[1].pattern
-    <MatchClass l.5 at 0x10ca80880>
+    <MatchClass l.5 at 0x...>
     """
 
     _astroid_fields = ("cls", "patterns", "kwd_patterns")
@@ -5419,12 +5419,12 @@ class MatchStar(_base_nodes.AssignTypeNode, Pattern):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    match x:
-        case [1, *_]:
-            ...
-    ''')
+    ... match x:
+    ...     case [1, *_]:
+    ...         ...
+    ... ''')
     >>> node.cases[0].pattern.patterns[1]
-    <MatchStar l.3 at 0x10ca809a0>
+    <MatchStar l.3 at 0x...>
     """
 
     _astroid_fields = ("name",)
@@ -5461,24 +5461,24 @@ class MatchAs(_base_nodes.AssignTypeNode, Pattern):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    match x:
-        case [1, a]:
-            ...
-        case {'key': b}:
-            ...
-        case Point2D(0, 0) as c:
-            ...
-        case d:
-            ...
-    ''')
+    ... match x:
+    ...     case [1, a]:
+    ...         ...
+    ...     case {'key': b}:
+    ...         ...
+    ...     case Point2D(0, 0) as c:
+    ...         ...
+    ...     case d:
+    ...         ...
+    ... ''')
     >>> node.cases[0].pattern.patterns[1]
-    <MatchAs l.3 at 0x10d0b2da0>
+    <MatchAs l.3 at 0x...>
     >>> node.cases[1].pattern.patterns[0]
-    <MatchAs l.5 at 0x10d0b2920>
+    <MatchAs l.5 at 0x...>
     >>> node.cases[2].pattern
-    <MatchAs l.7 at 0x10d0b06a0>
+    <MatchAs l.7 at 0x...>
     >>> node.cases[3].pattern
-    <MatchAs l.9 at 0x10d09b880>
+    <MatchAs l.9 at 0x...>
     """
 
     _astroid_fields = ("pattern", "name")
@@ -5522,12 +5522,12 @@ class MatchOr(Pattern):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    match x:
-        case 400 | 401 | 402:
-            ...
-    ''')
+    ... match x:
+    ...     case 400 | 401 | 402:
+    ...         ...
+    ... ''')
     >>> node.cases[0].pattern
-    <MatchOr l.3 at 0x10d0b0b50>
+    <MatchOr l.3 at 0x...>
     """
 
     _astroid_fields = ("patterns",)
@@ -5560,7 +5560,7 @@ class TemplateStr(NodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('t"{name} finished {place!s}"')
     >>> node
-    <TemplateStr l.1 at 0x103b7aa50>
+    <TemplateStr l.1 at 0x...>
     """
 
     _astroid_fields = ("values",)
@@ -5596,11 +5596,11 @@ class Interpolation(NodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('t"{name} finished {place!s}"')
     >>> node
-    <TemplateStr l.1 at 0x103b7aa50>
+    <TemplateStr l.1 at 0x...>
     >>> node.values[0]
-    <Interpolation l.1 at 0x103b7acf0>
+    <Interpolation l.1 at 0x...>
     >>> node.values[2]
-    <Interpolation l.1 at 0x10411e5d0>
+    <Interpolation l.1 at 0x...>
     """
 
     _astroid_fields = ("value", "format_spec")

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -189,9 +189,9 @@ class Module(LocalsDictNodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('import astroid')
     >>> node
-    <Import l.1 at 0x7f23b2e4e5c0>
+    <Import l.1 at 0x...>
     >>> node.parent
-    <Module l.0 at 0x7f23b2e4eda0>
+    <Module l.0 at 0x...>
     """
 
     _astroid_fields = ("doc_node", "body")
@@ -615,7 +615,7 @@ class GeneratorExp(ComprehensionScope):
     >>> import astroid
     >>> node = astroid.extract_node('(thing for thing in things if thing)')
     >>> node
-    <GeneratorExp l.1 at 0x7f23b2e4e400>
+    <GeneratorExp l.1 at 0x...>
     """
 
     _astroid_fields = ("elt", "generators")
@@ -670,7 +670,7 @@ class DictComp(ComprehensionScope):
     >>> import astroid
     >>> node = astroid.extract_node('{k:v for k, v in things if k > v}')
     >>> node
-    <DictComp l.1 at 0x7f23b2e41d68>
+    <DictComp l.1 at 0x...>
     """
 
     _astroid_fields = ("key", "value", "generators")
@@ -730,7 +730,7 @@ class SetComp(ComprehensionScope):
     >>> import astroid
     >>> node = astroid.extract_node('{thing for thing in things if thing}')
     >>> node
-    <SetComp l.1 at 0x7f23b2e41898>
+    <SetComp l.1 at 0x...>
     """
 
     _astroid_fields = ("elt", "generators")
@@ -786,7 +786,7 @@ class ListComp(ComprehensionScope):
     >>> import astroid
     >>> node = astroid.extract_node('[thing for thing in things if thing]')
     >>> node
-    <ListComp l.1 at 0x7f23b2e418d0>
+    <ListComp l.1 at 0x...>
     """
 
     _astroid_fields = ("elt", "generators")
@@ -880,7 +880,7 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
     >>> import astroid
     >>> node = astroid.extract_node('lambda arg: arg + 1')
     >>> node
-    <Lambda.<lambda> l.1 at 0x7f23b2e41518>
+    <Lambda.<lambda> l.1 at 0x...>
     """
 
     _astroid_fields: ClassVar[tuple[str, ...]] = ("args", "body")
@@ -1075,7 +1075,7 @@ class FunctionDef(
     ...     return arg + 1
     ... ''')
     >>> node
-    <FunctionDef.my_func l.2 at 0x7f23b2e71e10>
+    <FunctionDef.my_func l.2 at 0x...>
     """
 
     _astroid_fields = (
@@ -1705,14 +1705,14 @@ class AsyncFunctionDef(FunctionDef):
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    async def func(things):
-        async for thing in things:
-            print(thing)
-    ''')
+    ... async def func(things):
+    ...     async for thing in things:
+    ...         print(thing)
+    ... ''')
     >>> node
-    <AsyncFunctionDef.func l.2 at 0x7f23b2e416d8>
+    <AsyncFunctionDef.func l.2 at 0x...>
     >>> node.body[0]
-    <AsyncFor l.3 at 0x7f23b2e417b8>
+    <AsyncFor l.3 at 0x...>
     """
 
 
@@ -1816,12 +1816,12 @@ class ClassDef(
 
     >>> import astroid
     >>> node = astroid.extract_node('''
-    class Thing:
-        def my_meth(self, arg):
-            return arg + self.offset
-    ''')
+    ... class Thing:
+    ...     def my_meth(self, arg):
+    ...         return arg + self.offset
+    ... ''')
     >>> node
-    <ClassDef.Thing l.2 at 0x7f23b2e9e748>
+    <ClassDef.Thing l.2 at 0x...>
     """
 
     # some of the attributes below are set by the builder module or

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,6 +2,7 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
+import doctest
 import os
 import sys
 from datetime import datetime, timezone
@@ -18,6 +19,7 @@ sys.path.insert(0, os.path.abspath(".."))
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
@@ -84,6 +86,18 @@ intersphinx_mapping = {
     # upcoming Python versions.
     "python": ("https://docs.python.org/dev", None),
 }
+
+# -- Options for the doctest builder -------------------------------------------
+
+# Run the ``>>>`` examples with ``tox -e doctest``, so that one that stops being
+# true is noticed. The examples print nodes, whose repr ends in the address the
+# node happens to live at, so they are written ``at 0x...`` and matched loosely.
+doctest_default_flags = (
+    doctest.DONT_ACCEPT_TRUE_FOR_1
+    | doctest.ELLIPSIS
+    | doctest.IGNORE_EXCEPTION_DETAIL
+    | doctest.NORMALIZE_WHITESPACE
+)
 
 # -- Options for cross-reference checking --------------------------------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -29,10 +29,10 @@ Python constructs, as seen in the following example::
    func(arg_1, arg_2)
    ''')
    >>> module.body[-1]
-   <Expr l.3 at 0x10ab46f28>
+   <Expr l.3 at 0x...>
    >>> inferred = next(module.body[-1].value.infer())
    >>> inferred
-   <Const.int l.None at 0x10ab00588>
+   <Const.int l.None at 0x...>
    >>> inferred.value
    5
 

--- a/doc/inference.rst
+++ b/doc/inference.rst
@@ -44,7 +44,7 @@ string::
 
     >>> tree = astroid.parse('a + b')
     >>> tree
-    >>> <Module l.0 at 0x10d8a68d0>
+    >>> <Module l.0 at 0x...>
 
     >>> print(tree.repr_tree())
     Module(
@@ -73,7 +73,7 @@ which given a string, tries to extract one or more nodes from the given string::
    ... a = 1
    ... b = 2
    ... c
-   ''')
+   ... ''')
 
 In that example, the node that is going to be returned is the last node
 from the tree, so it will be the ``Name(c)`` node.
@@ -83,7 +83,7 @@ You can also use :func:`astroid.extract_node` to extract multiple nodes::
    ... a = 1 #@
    ... b = 2 #@
    ... c
-   ''')
+   ... ''')
 
 You can use ``#@`` comment to annotate the lines for which you want the
 corresponding nodes to be extracted. In that example, what we're going to
@@ -100,10 +100,10 @@ with all the potential values that ``astroid`` can extract for a piece of code::
     ... b = 2
     ... c = a + b
     ... c
-    ''')
+    ... ''')
     >>> inferred = next(name_node.infer())
     >>> inferred
-    <Const.int l.None at 0x10d913128>
+    <Const.int l.None at 0x...>
     >>> inferred.value
     3
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,18 @@ deps =
 commands =
     sphinx-build -E -W -j auto -b html . build
 
+[testenv:doctest]
+skipsdist = True
+usedevelop = True
+changedir = doc/
+# Same interpreter as Read the Docs, for the reason given in .readthedocs.yaml.
+# On an older one the template string examples fail instead of being checked.
+basepython = python3.14
+deps =
+    -r doc/requirements.txt
+commands =
+    sphinx-build -E -W -b doctest . build/doctest
+
 [testenv:linkcheck]
 skipsdist = True
 usedevelop = True


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

The docstrings carry 252 `>>>` examples that nothing ever ran. Running them found that almost none could pass: they print nodes, and the printed address was whatever the machine that wrote the example happened to give, recorded once in 2018. The multi-line ones were also missing the `...` continuation prompt, so doctest read each line of the code being parsed as a statement of its own and every one raised a SyntaxError.

The template string examples need Python 3.14, this is why we must always use the latest python interpreter for that.
