### PR TITLE
Fix the no-member false positive breaking the Checks job on main

### DIFF
--- a/tests/brain/test_enum.py
+++ b/tests/brain/test_enum.py
@@ -22,13 +22,14 @@ class EnumBrainTest(unittest.TestCase):
 
         Regression test for pylint-dev/pylint#11179.
         """
-        module = types.ModuleType("extension_module")
+        module_name = "extension_module"
+        module = types.ModuleType(module_name)
         module.datetime = datetime
         extension_class = type("ExtensionClass", (datetime.datetime,), {})
-        extension_class.__module__ = module.__name__
+        extension_class.__module__ = module_name
         module.ExtensionClass = extension_class
 
-        builder.AstroidBuilder(AstroidManager()).module_build(module, module.__name__)
+        builder.AstroidBuilder(AstroidManager()).module_build(module, module_name)
 
     def test_simple_enum(self) -> None:
         module = builder.parse("""


### PR DESCRIPTION
The `Checks` job has been failing on `main` since #3163 was merged:

```
************* Module tests.brain.test_enum
tests/brain/test_enum.py:28:37: E1101: Instance of 'module' has no '__name__' member (no-member)
tests/brain/test_enum.py:31:70: E1101: Instance of 'module' has no '__name__' member (no-member)
```

`types.ModuleType(...)` infers as an instance of `module`, and that object model has no `__name__`, so reading the name back off the module trips our own pylint run. Every open pull request inherits the failure, because pull request CI lints the merge commit.

The name is already known where it is used, so this holds it in a local instead of reading it back.

Verified with the same command CI runs, on `main` plus this commit:

```
$ pylint -rn -sn --rcfile=pylintrc $(git ls-files '*.py')
$ echo $?
0
```

`pytest tests/brain/test_enum.py` still passes, 33 tests.

The false positive itself is real astroid behaviour rather than a pylint quirk: an instance of `module` exposes none of `__name__`, `__file__` or `__doc__`. That deserves its own issue, and is not what this pull request is about.

Refs #3163