### PR TITLE
Fix three crashes found by fuzzing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,12 @@ Release date: TBA
   Closes #2852
   Closes pylint-dev/pylint#10807
 
+* Fix a crash when the field names of a functional ``Enum`` or ``namedtuple``
+  call are bytes, as in ``Enum("", b"")``. Such a definition is invalid, so
+  inference now falls back to its default instead of raising ``TypeError``.
+
+  Closes #3189
+
 * The documentation build now fails on any Sphinx warning, so a cross-reference
   that does not resolve is caught by CI instead of quietly rendering as plain
   text. ``Uninferable``, ``Position`` and the ``BadOperationMessage`` classes

--- a/ChangeLog
+++ b/ChangeLog
@@ -34,6 +34,13 @@ Release date: TBA
 
   Closes #3190
 
+* Fix a crash when a binary operation involves a class whose metaclass is not a
+  class, as in ``class C(metaclass=sum)`` followed by ``C | None``. The type of
+  such a class is a function, which has no bases, so ``has_known_bases()`` now
+  returns ``False`` for anything that is not a class.
+
+  Closes #3191
+
 * The documentation build now fails on any Sphinx warning, so a cross-reference
   that does not resolve is caught by CI instead of quietly rendering as plain
   text. ``Uninferable``, ``Position`` and the ``BadOperationMessage`` classes

--- a/ChangeLog
+++ b/ChangeLog
@@ -27,6 +27,13 @@ Release date: TBA
 
   Closes #3189
 
+* Fix a crash when the body of a ``typing.NamedTuple`` subclass contains an
+  assignment whose target is not a single name, such as ``cat.color = "black"``,
+  ``basket[0] = "apple"`` or ``apple, banana = "red", "yellow"``. The names bound
+  by unpacking are now copied to the inferred class as well.
+
+  Closes #3190
+
 * The documentation build now fails on any Sphinx warning, so a cross-reference
   that does not resolve is caught by CI instead of quietly rendering as plain
   text. ``Uninferable``, ``Position`` and the ``BadOperationMessage`` classes

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -571,8 +571,12 @@ def infer_typing_namedtuple_class(class_node, context: InferenceContext | None =
     for body_node in class_node.body:
         if isinstance(body_node, nodes.Assign):
             for target in body_node.targets:
-                attr = target.name
-                generated_class_node.locals[attr] = class_node.locals[attr]
+                # A target is not necessarily a single name: ``cat.color = ...``
+                # and ``basket[0] = ...`` define no class attribute at all, while
+                # ``apple, banana = ...`` defines one per unpacked element.
+                for assign_name in target.nodes_of_class(nodes.AssignName):
+                    attr = assign_name.name
+                    generated_class_node.locals[attr] = class_node.locals[attr]
         elif isinstance(body_node, nodes.ClassDef):
             generated_class_node.locals[body_node.name] = [body_node]
 

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -92,7 +92,11 @@ def infer_func_form(
         name, names = _find_func_form_arguments(node, context)
         try:
             attributes: list[str] = names.value.replace(",", " ").split()
-        except AttributeError as exc:
+        except (AttributeError, TypeError) as exc:
+            # ``names`` is not a whitespace-separated string: it is either a
+            # container node, which has no ``value`` (AttributeError), or a
+            # constant of another type such as bytes (TypeError).
+
             # Handle attributes of NamedTuples
             if not enum:
                 attributes = []

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -187,6 +187,11 @@ def class_or_tuple_to_container(
 
 def has_known_bases(klass, context: InferenceContext | None = None) -> bool:
     """Return whether all base classes of a class could be inferred."""
+    if not isinstance(klass, scoped_nodes.ClassDef):
+        # Not a class, so it has no bases at all. This happens for the type of a
+        # class whose metaclass is not a class either, as in
+        # ``class C(metaclass=sum)``, whose type is the ``sum`` function.
+        return False
     try:
         return klass._all_bases_known
     except AttributeError:

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -495,6 +495,36 @@ class TypingBrain(unittest.TestCase):
         attr = next(attr_def.infer())
         self.assertEqual(attr.value, "bar")
 
+    def test_namedtuple_class_form_assignment_targets(self):
+        """An assignment in the body may not bind a single plain name.
+
+        Regression test for https://github.com/pylint-dev/astroid/issues/3190
+        """
+        attribute, subscript, unpacking = builder.extract_node("""
+        from typing import NamedTuple
+
+        class Attribute(NamedTuple):
+            cat.color = "black"
+
+        class Subscript(NamedTuple):
+            basket[0] = "apple"
+
+        class Unpacking(NamedTuple):
+            apple, banana = "red", "yellow"
+
+        Attribute()  #@
+        Subscript()  #@
+        Unpacking()  #@
+        """)
+        # Inference must not raise ``AttributeError`` or ``KeyError``.
+        for node in (attribute, subscript, unpacking):
+            self.assertIsInstance(next(node.infer()), astroid.Instance)
+
+        # The names bound by unpacking are still class attributes.
+        inferred = next(unpacking.infer())
+        for name, value in (("apple", "red"), ("banana", "yellow")):
+            self.assertEqual(next(inferred.getattr(name)[0].infer()).value, value)
+
     def test_tuple_type(self):
         node = builder.extract_node("""
         from typing import Tuple

--- a/tests/brain/test_enum.py
+++ b/tests/brain/test_enum.py
@@ -195,6 +195,18 @@ class EnumBrainTest(unittest.TestCase):
         # Inference must not raise ``TypeError``; it falls back to default.
         assert next(node.infer()) is util.Uninferable
 
+    def test_enum_func_form_bytes_field_names_no_crash(self) -> None:
+        """A functional Enum whose field names are bytes is invalid.
+
+        Regression test for https://github.com/pylint-dev/astroid/issues/3189
+        """
+        node = builder.extract_node("""
+        from enum import Enum
+        Enum("", b"")  #@
+        """)
+        # Inference must not raise ``TypeError``; it falls back to default.
+        assert next(node.infer()) is util.Uninferable
+
     def test_infer_enum_value_as_the_right_type(self) -> None:
         string_value, int_value = builder.extract_node("""
         from enum import Enum

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -238,6 +238,34 @@ class TestHelpers(unittest.TestCase):
         self.assertTrue(helpers.is_supertype(builtin_type, cls_a))
         self.assertTrue(helpers.is_subtype(cls_a, builtin_type))
 
+    def test_is_subtype_supertype_function_metaclass(self) -> None:
+        """A metaclass that is a function makes the type of the class a function.
+
+        Regression test for https://github.com/pylint-dev/astroid/issues/3191
+        """
+        cls_a = builder.extract_node("""
+        class A(metaclass=sum): #@
+            pass
+        """)
+        cls_a_type = helpers.object_type(cls_a)
+        self.assertIsInstance(cls_a_type, nodes.FunctionDef)
+        builtin_type = self._extract("type")
+        # A function has no bases, so the hierarchy cannot be deduced.
+        with self.assertRaises(_NonDeducibleTypeHierarchy):
+            helpers.is_subtype(cls_a_type, builtin_type)
+        with self.assertRaises(_NonDeducibleTypeHierarchy):
+            helpers.is_supertype(cls_a_type, builtin_type)
+
+    def test_binop_with_function_metaclass_no_crash(self) -> None:
+        """Regression test for https://github.com/pylint-dev/astroid/issues/3191"""
+        node = builder.extract_node("""
+        class A(metaclass=sum):
+            pass
+        A | None  #@
+        """)
+        # Inference must not raise ``AttributeError``.
+        self.assertIs(next(node.infer()), util.Uninferable)
+
 
 def test_uninferable_for_safe_infer() -> None:
     uninfer = util.Uninferable


### PR DESCRIPTION
Fixes the three crashes @correctmost found in the last fuzzing run, one commit each, with a failing test added before the fix.

### `Enum("", b"")` — `TypeError: a bytes-like object is required, not 'str'`

`names.value.replace(",", " ")` raises `TypeError`, not `AttributeError`, when the field names argument is a bytes constant, and only `AttributeError` was caught. Inference now falls back to its default, as it already does for `Enum("e", (1,))`.

Closes #3189

### `class C(NamedTuple): t.a = None` — `AttributeError: 'AssignAttr' object has no attribute 'name'`

`infer_typing_namedtuple_class` read `target.name` for every assignment target in the class body. Two shapes beyond the reported one crash as well:

```python
class Subscript(NamedTuple):
    basket[0] = "apple"      # AttributeError: 'Subscript' object has no attribute 'name'

class Unpacking(NamedTuple):
    apple, banana = 1, 2     # KeyError: 'tuple', since Tuple.name is "tuple"
```

Collecting the `AssignName` nodes of each target handles all three, and copies the names bound by unpacking to the generated class, which never happened before.

Closes #3190

### `class C(metaclass=sum)` then `C | None` — `AttributeError: 'FunctionDef' object has no attribute 'bases'`

`sum` is a function, so the type of `C` is a function too, and `has_known_bases()` read `klass.bases` on it. A node that is not a `ClassDef` has no bases, so it returns `False` and the callers raise `_NonDeducibleTypeHierarchy` as they do for any other unknown hierarchy.

Closes #3191
