### PR TITLE
only load a stdlib-named C extension from the standard library

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -323,6 +323,13 @@ Refs #3108
 
   Refs #3115
 
+* Require a C extension to be located in the standard library before its
+  standard library name allows it to be imported. A name such as ``colorsys``
+  was trusted on its own, so an extension of that name sitting next to the
+  analysed sources was imported, and its module initialisation run, without
+  being on ``extension-pkg-allow-list``. Extensions shipped with the
+  interpreter are unaffected.
+
 What's New in astroid 4.1.2?
 ============================
 Release date: 2026-03-22

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -31,6 +31,7 @@ from astroid.modutils import (
     is_module_name_part_of_extension_package_whitelist,
     is_python_source,
     is_stdlib_module,
+    is_stdlib_path,
     load_module_from_name,
     modpath_from_file,
 )
@@ -183,10 +184,15 @@ class AstroidManager:
     ) -> nodes.Module:
         return build_namespace_package_module(modname, path)
 
-    def _can_load_extension(self, modname: str) -> bool:
+    def _can_load_extension(self, modname: str, location: str | None) -> bool:
         if self.always_load_extensions:
             return True
-        if is_stdlib_module(modname):
+        # Only trust a stdlib name that resolves to the stdlib itself.
+        if (
+            is_stdlib_module(modname)
+            and location is not None
+            and is_stdlib_path(location)
+        ):
             return True
         return is_module_name_part_of_extension_package_whitelist(
             modname, self.extension_package_whitelist
@@ -227,7 +233,7 @@ class AstroidManager:
             ):
                 if (
                     found_spec.type == spec.ModuleType.C_EXTENSION
-                    and not self._can_load_extension(modname)
+                    and not self._can_load_extension(modname, found_spec.location)
                 ):
                     return self._build_stub_module(modname)
                 try:

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -537,6 +537,24 @@ def is_stdlib_module(modname: str) -> bool:
     return modname.split(".")[0] in stdlib_module_names
 
 
+def is_stdlib_path(filename: str) -> bool:
+    """Return: True if the file is located in the standard library.
+
+    site-packages sits below one of the standard library directories in a
+    virtualenv, so external locations are rejected first.
+    """
+    filename = _normalize_path(filename)
+    if any(
+        filename.startswith(_cache_normalize_path(entry) + os.sep)
+        for entry in EXT_LIB_DIRS
+    ):
+        return False
+    return any(
+        filename.startswith(_cache_normalize_path(entry) + os.sep)
+        for entry in STD_LIB_DIRS
+    )
+
+
 def module_in_path(modname: str, path: str | Iterable[str]) -> bool:
     """Try to determine if a module is imported from one of the specified paths
 

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -519,6 +519,24 @@ def is_stdlib_module(modname: str) -> bool:
     return modname.split(".")[0] in stdlib_module_names
 
 
+def is_stdlib_path(filename: str) -> bool:
+    """Return: True if the file is located in the standard library.
+
+    site-packages sits below one of the standard library directories in a
+    virtualenv, so external locations are rejected first.
+    """
+    filename = _normalize_path(filename)
+    if any(
+        filename.startswith(_cache_normalize_path(entry) + os.sep)
+        for entry in EXT_LIB_DIRS
+    ):
+        return False
+    return any(
+        filename.startswith(_cache_normalize_path(entry) + os.sep)
+        for entry in STD_LIB_DIRS
+    )
+
+
 def module_in_path(modname: str, path: str | Iterable[str]) -> bool:
     """Try to determine if a module is imported from one of the specified paths
 

--- a/doc/whatsnew/fragments/3193.bugfix
+++ b/doc/whatsnew/fragments/3193.bugfix
@@ -1,0 +1,8 @@
+Require a C extension to be located in the standard library before its
+standard library name allows it to be imported. A name such as ``colorsys``
+was trusted on its own, so an extension of that name sitting next to the
+analysed sources was imported, and its module initialisation run, without
+being on ``extension-pkg-allow-list``. Extensions shipped with the
+interpreter are unaffected.
+
+Refs #3193

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -2,9 +2,11 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
+import importlib.machinery
 import os
 import re
 import sys
+import tempfile
 import time
 import types
 import unittest
@@ -145,6 +147,21 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
             self.manager.ast_from_module_name,
             "unhandledModule",
         )
+
+    def test_ast_from_module_name_extension_shadowing_stdlib(self) -> None:
+        """An extension outside the stdlib is stubbed, not imported."""
+        modname = "colorsys"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            extension = modname + importlib.machinery.EXTENSION_SUFFIXES[0]
+            with open(os.path.join(tmpdir, extension), "wb"):
+                pass
+            sys.path.insert(0, tmpdir)
+            try:
+                ast = self.manager.ast_from_module_name(modname)
+            finally:
+                sys.path.remove(tmpdir)
+        self.assertEqual(ast.name, modname)
+        self.assertEqual(ast.items(), [])
 
     def _test_ast_from_old_namespace_package_protocol(self, root: str) -> None:
         origpath = sys.path[:]

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -163,6 +163,10 @@ class AstroidManagerTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual(ast.name, modname)
         self.assertEqual(ast.items(), [])
 
+    def test_can_load_extension_stdlib_name_without_location(self) -> None:
+        """A stdlib name with no resolved location is not trusted."""
+        self.assertFalse(self.manager._can_load_extension("colorsys", None))
+
     def _test_ast_from_old_namespace_package_protocol(self, root: str) -> None:
         origpath = sys.path[:]
         paths = [resources.find(f"data/path_{root}_{index}") for index in range(1, 4)]

--- a/tests/test_modutils.py
+++ b/tests/test_modutils.py
@@ -5,6 +5,7 @@
 """Unit tests for module modutils (module manipulation utilities)."""
 
 import email
+import importlib.machinery
 import logging
 import os
 import shutil
@@ -455,6 +456,24 @@ class IsStdLibModuleTest(resources.SysPathSetup, unittest.TestCase):
         assert modutils.is_stdlib_module("_curses")
         assert modutils.is_stdlib_module("msvcrt")
         assert modutils.is_stdlib_module("termios")
+
+
+class IsStdLibPathTest(unittest.TestCase):
+    """
+    Return true if the file is located in the standard library
+    """
+
+    def test_stdlib(self) -> None:
+        assert modutils.is_stdlib_path(os.__file__)
+
+    def test_ext_lib_dirs(self) -> None:
+        # site-packages can sit below a standard library directory, so an
+        # extension there is not a standard library location.
+        for ext_lib_dir in modutils.EXT_LIB_DIRS:
+            planted = os.path.join(
+                ext_lib_dir, "colorsys" + importlib.machinery.EXTENSION_SUFFIXES[0]
+            )
+            assert not modutils.is_stdlib_path(planted)
 
 
 class ModuleInPathTest(resources.SysPathSetup, unittest.TestCase):


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`_can_load_extension` only receives the module name, and `is_stdlib_module` is a
plain name test, so any C extension whose name matches a stdlib module is
imported no matter where it came from. `ImportlibFinder.find_module` walks
`sys.path` in order and tries the extension suffixes before `.py`, and the
analysed project's directory comes first, so a `colorsys.cpython-313-x86_64-linux-gnu.so`
committed to a repository resolves ahead of the real module and
`ast_from_module_name` hands it to `load_module_from_name`, which runs its
module init. That happens with `always_load_extensions` off and an empty
`extension-pkg-allow-list`, so the opt-in that guards extension loading is
skipped entirely and linting a checkout executes code out of it. Pass the
resolved location down and require it to be inside `STD_LIB_DIRS` before the
stdlib name is trusted, excluding `EXT_LIB_DIRS` because site-packages sits
below the stdlib directory in a virtualenv. Extensions shipped with the
interpreter still load from `lib-dynload`, and an explicit allow-list entry
still wins.
