### PR TITLE
Fix incorrect type inference for enum.auto() in IntEnum members

### DIFF
--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -429,6 +429,15 @@ def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
                         inferred_return_value = repr(stmt.value.value)
                     else:
                         inferred_return_value = stmt.value.value
+                elif (
+                    isinstance(stmt.value, nodes.Call)
+                    and isinstance(stmt.value.func, nodes.Attribute)
+                    and stmt.value.func.attrname == "auto"
+                ):
+                    # enum.auto() is a Call node, not a Const.
+                    # Substituting 1 so the stub correctly infers int
+                    # for IntEnum members instead of the type `auto`.
+                    inferred_return_value = 1
                 else:
                     inferred_return_value = stmt.value.as_string()
 

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -429,14 +429,15 @@ def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
                         inferred_return_value = repr(stmt.value.value)
                     else:
                         inferred_return_value = stmt.value.value
-                elif (
-                    isinstance(stmt.value, nodes.Call)
-                    and isinstance(stmt.value.func, nodes.Attribute)
-                    and stmt.value.func.attrname == "auto"
+                elif isinstance(stmt.value, nodes.Call) and _looks_like(
+                    stmt.value, "auto"
                 ):
-                    # enum.auto() is a Call node, not a Const.
-                    # Substituting 1 so the stub correctly infers int
-                    # for IntEnum members instead of the type `auto`.
+                    # enum.auto() is a Call node, not a Const. Handles both
+                    # spellings: `enum.auto()` and `auto()` (after
+                    # `from enum import auto`). Substituting 1 so the stub
+                    # infers the correct type (int) for IntEnum members;
+                    # note the value itself may differ at runtime for later
+                    # members but only the type is consulted for E1101.
                     inferred_return_value = 1
                 else:
                     inferred_return_value = stmt.value.as_string()

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -907,6 +907,42 @@ class BrainNamedtupleAnnAssignTest(unittest.TestCase):
         self.assertIsInstance(inferred, nodes.ClassDef)
 
 
+class BrainEnumAutoTest(unittest.TestCase):
+    """Tests for correct type inference of enum members assigned via enum.auto()."""
+
+    def test_int_enum_auto_value_inferred_as_int(self) -> None:
+        """enum.auto() members in IntEnum should have .value inferred as int, not auto."""
+        node = builder.extract_node("""
+        import enum
+
+        class Color(enum.IntEnum):
+            RED = enum.auto()
+            GREEN = enum.auto()
+            BLUE = 10
+
+        Color.RED.value #@
+        """)
+        inferred = next(node.infer())
+        self.assertIsInstance(inferred, nodes.Const)
+        self.assertIsInstance(inferred.value, int)
+
+    def test_int_enum_mixed_auto_and_literal(self) -> None:
+        """IntEnum with both auto() and literal values should not raise false E1101."""
+        node = builder.extract_node("""
+        import enum
+
+        class Status(enum.IntEnum):
+            PENDING = enum.auto()
+            ACTIVE = 2
+            CLOSED = enum.auto()
+
+        Status.PENDING.value #@
+        """)
+        inferred = next(node.infer())
+        self.assertIsInstance(inferred, nodes.Const)
+        self.assertIsInstance(inferred.value, int)
+
+
 class BrainUUIDTest(unittest.TestCase):
     def test_uuid_has_int_member(self) -> None:
         node = builder.extract_node("""

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -907,42 +907,6 @@ class BrainNamedtupleAnnAssignTest(unittest.TestCase):
         self.assertIsInstance(inferred, nodes.ClassDef)
 
 
-class BrainEnumAutoTest(unittest.TestCase):
-    """Tests for correct type inference of enum members assigned via enum.auto()."""
-
-    def test_int_enum_auto_value_inferred_as_int(self) -> None:
-        """enum.auto() members in IntEnum should have .value inferred as int, not auto."""
-        node = builder.extract_node("""
-        import enum
-
-        class Color(enum.IntEnum):
-            RED = enum.auto()
-            GREEN = enum.auto()
-            BLUE = 10
-
-        Color.RED.value #@
-        """)
-        inferred = next(node.infer())
-        self.assertIsInstance(inferred, nodes.Const)
-        self.assertIsInstance(inferred.value, int)
-
-    def test_int_enum_mixed_auto_and_literal(self) -> None:
-        """IntEnum with both auto() and literal values should not raise false E1101."""
-        node = builder.extract_node("""
-        import enum
-
-        class Status(enum.IntEnum):
-            PENDING = enum.auto()
-            ACTIVE = 2
-            CLOSED = enum.auto()
-
-        Status.PENDING.value #@
-        """)
-        inferred = next(node.infer())
-        self.assertIsInstance(inferred, nodes.Const)
-        self.assertIsInstance(inferred.value, int)
-
-
 class BrainUUIDTest(unittest.TestCase):
     def test_uuid_has_int_member(self) -> None:
         node = builder.extract_node("""

--- a/tests/brain/test_enum.py
+++ b/tests/brain/test_enum.py
@@ -586,3 +586,35 @@ class EnumBrainTest(unittest.TestCase):
         # Inference must not raise ``DuplicateBasesError``.
         inferred = next(node.infer())
         assert isinstance(inferred, nodes.ClassDef)
+
+    def test_int_enum_auto_value_inferred_as_int(self) -> None:
+        """enum.auto() members in IntEnum should have .value inferred as int, not auto."""
+        node = builder.extract_node("""
+        import enum
+
+        class Color(enum.IntEnum):
+            RED = enum.auto()
+            GREEN = enum.auto()
+            BLUE = 10
+
+        Color.RED.value #@
+        """)
+        inferred = next(node.infer())
+        self.assertIsInstance(inferred, nodes.Const)
+        self.assertIsInstance(inferred.value, int)
+
+    def test_int_enum_auto_unqualified_inferred_as_int(self) -> None:
+        """auto() (unqualified) in IntEnum should also infer .value as int."""
+        node = builder.extract_node("""
+        from enum import IntEnum, auto
+
+        class Status(IntEnum):
+            PENDING = auto()
+            ACTIVE = 2
+            CLOSED = auto()
+
+        Status.PENDING.value #@
+        """)
+        inferred = next(node.infer())
+        self.assertIsInstance(inferred, nodes.Const)
+        self.assertIsInstance(inferred.value, int)


### PR DESCRIPTION
When an `IntEnum` member is assigned via `enum.auto()`, `stmt.value` is a `nodes.Call` node rather than `nodes.Const`. The previous code fell into the `else` branch and called `.as_string()`, returning the string `"enum.auto()"`. This caused astroid to infer `.value` as type `auto` instead of `int`, producing false-positive E1101 errors.

**Fix:** Uses the existing `_looks_like()` helper to detect both `enum.auto()` and `auto()` (unqualified, after `from enum import auto`) spellings, substituting integer `1` so the stub infers the correct type (`int`) for `IntEnum` members.

**Tests:** Added two tests to `EnumBrainTest` in `tests/brain/test_enum.py` covering both the qualified and unqualified `auto()` spellings.

Closes #1847

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |