### PR TITLE
Fix crash on a namedtuple field name that changes under NFKC normalization

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,14 @@ What's New in astroid 4.2.0?
 ============================
 Release date: TBA
 
+* Fix a crash on a functional ``namedtuple`` whose field name changes under NFKC
+  normalization, such as ``namedtuple("mu", ["µ"])``. Python normalizes
+  identifiers, so the parsed class stores the field under ``"μ"`` while the
+  brain looked it up as written, raising ``KeyError`` on a definition that
+  ``namedtuple`` itself accepts.
+
+  Closes pylint-dev/pylint#8746
+
 * Fix inference of a method's first argument (``self`` or ``cls``) when the
   method's return value is stored on an unrelated object. This avoids inferring
   ``cls`` as the caller's class when indexing a tuple returned by a

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import functools
 import keyword
+import unicodedata
 from collections.abc import Iterator
 from textwrap import dedent
 from typing import Final
@@ -257,7 +258,12 @@ class {name}(tuple):
     class_node.locals["_replace"] = fake.body[0].locals["_replace"]
     class_node.locals["_fields"] = fake.body[0].locals["_fields"]
     for attr in attributes:
-        class_node.locals[attr] = fake.body[0].locals[attr]
+        # Python normalises identifiers to NFKC, so a field named "\u00b5" (MICRO SIGN)
+        # is stored by the parser as "\u03bc" (GREEK SMALL LETTER MU). Looking the
+        # attribute up under the name as written raises KeyError on a definition
+        # namedtuple itself accepts, so use the name the parser actually used.
+        normalized = unicodedata.normalize("NFKC", attr)
+        class_node.locals[normalized] = fake.body[0].locals[normalized]
     # we use UseInferenceDefault, we can't be a generator so return an iterator
     return iter([class_node])
 

--- a/tests/test_regrtest.py
+++ b/tests/test_regrtest.py
@@ -551,6 +551,23 @@ def test_regression_infer_namedtuple_invalid_fieldname_error() -> None:
     assert inferred.value == Uninferable
 
 
+def test_regression_infer_namedtuple_nfkc_normalized_fieldname() -> None:
+    """Regression test for pylint-dev/pylint#8746.
+
+    ``namedtuple`` accepts any identifier as a field name, but the parser stores
+    identifiers in their NFKC-normalized form, so a field written as "\u00b5"
+    (MICRO SIGN) ends up under "\u03bc" (GREEK SMALL LETTER MU).
+    """
+    code = """
+    from collections import namedtuple
+    namedtuple('mu', ['\u00b5'])
+    """
+    node = extract_node(code)
+    inferred = next(node.infer())
+    assert isinstance(inferred, nodes.ClassDef)
+    assert "\u03bc" in inferred.locals
+
+
 # On Python 3.15+ the parser emits a regular SyntaxError instead of a MemoryError for deeply nested
 # parentheses, so the special-case test here is no longer needed.
 @pytest.mark.skipif(PY315_PLUS, reason="No longer a MemoryError on Python 3.15+")


### PR DESCRIPTION
Refs pylint-dev/pylint#8746.

Python normalizes identifiers to NFKC, so a `namedtuple` field written as `µ` (U+00B5 MICRO SIGN) is stored by the parser as `μ` (U+03BC GREEK SMALL LETTER MU). The namedtuple brain builds a fake class from generated source and then copies each attribute across by the name as written, which misses:

```python
from collections import namedtuple

names = ["µ"]
mu = namedtuple("mu", names)
```

```
KeyError: 'µ'
  astroid/brain/brain_namedtuple_enum.py:260 in infer_named_tuple
```

The definition is valid — `namedtuple` accepts any identifier, and at runtime `mu._fields` is `('µ',)` with the attribute reachable — so pylint reports `astroid-error` on working code. Reproduced on current `main` (8666418) and on released astroid 4.0.4 / pylint 4.0.6.

The attribute is now copied under the name the parser used. Storing it normalized also keeps it findable: an attribute access written as `instance.µ` in user code is normalized the same way, so a lookup would otherwise miss the entry.

Verified: the new regression test fails with the same `KeyError` on the unpatched tree and passes with the change; `tests/test_regrtest.py` is green (35 passed). `tests/brain/` has one failure, `TypingBrain::test_typed_dict_required_and_optional_keys`, which is present on a clean tree as well. `ruff check` and `black` both clean.
