### PR TITLE
Fix crash on a dataclass base that annotates __init__

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,13 @@ Release date: TBA
 
   Closes #3191
 
+* Fix a crash when a dataclass inherits from a dataclass that annotates
+  ``__init__`` as a field, as in ``__init__: int``. Such a base binds
+  ``__init__`` to a name instead of a function, so it no longer contributes
+  arguments to the generated ``__init__``.
+
+  Closes #3200
+
 * The documentation build now fails on any Sphinx warning, so a cross-reference
   that does not resolve is caught by CI instead of quietly rendering as plain
   text. ``Uninferable``, ``Position`` and the ``BadOperationMessage`` classes

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -188,8 +188,14 @@ def _find_arguments_from_base_classes(
         if not base.is_dataclass:
             continue
         try:
-            base_init: nodes.FunctionDef = base.locals["__init__"][0]
+            base_init = base.locals["__init__"][0]
         except KeyError:
+            continue
+
+        # A base can bind "__init__" to something that is not a function, for
+        # example by annotating it as a field: "__init__: int". There are no
+        # arguments to inherit from such a base.
+        if not isinstance(base_init, nodes.FunctionDef):
             continue
 
         pos_only, kw_only = base_init.args._get_arguments_data()

--- a/tests/brain/test_dataclasses.py
+++ b/tests/brain/test_dataclasses.py
@@ -1368,8 +1368,7 @@ def test_dataclass_base_with_annotated_init_no_crash():
     by annotating it as a field. Collecting the arguments of such a base should
     not crash with an AttributeError.
     """
-    node = astroid.extract_node(
-        """
+    node = astroid.extract_node("""
     from dataclasses import dataclass
 
     @dataclass
@@ -1381,8 +1380,7 @@ def test_dataclass_base_with_annotated_init_no_crash():
         pass
 
     B.__init__  #@
-    """
-    )
+    """)
 
     inferred = next(node.infer())
     assert isinstance(inferred, bases.UnboundMethod)

--- a/tests/brain/test_dataclasses.py
+++ b/tests/brain/test_dataclasses.py
@@ -1359,3 +1359,31 @@ def test_dataclass_with_duplicate_bases_field_default():
     # Should not raise DuplicateBasesError in _get_previous_field_default
     inferred = next(node.infer())
     assert inferred is not None
+
+
+def test_dataclass_base_with_annotated_init_no_crash():
+    """Regression test for https://github.com/pylint-dev/astroid/issues/3200.
+
+    A base dataclass can bind ``__init__`` to something that is not a function
+    by annotating it as a field. Collecting the arguments of such a base should
+    not crash with an AttributeError.
+    """
+    node = astroid.extract_node(
+        """
+    from dataclasses import dataclass
+
+    @dataclass
+    class A:
+        __init__: int
+
+    @dataclass
+    class B(A):
+        pass
+
+    B.__init__  #@
+    """
+    )
+
+    inferred = next(node.infer())
+    assert isinstance(inferred, bases.UnboundMethod)
+    assert [a.name for a in inferred.args.args] == ["self"]


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

A class body can bind `__init__` to a name instead of a function by annotating
it as a dataclass field:

```python
from dataclasses import dataclass

@dataclass
class A:
    __init__: int

@dataclass
class B(A):
    pass
```

`_check_generate_dataclass_init` sees `__init__` in `A`'s locals and skips
generating one, so `A.locals["__init__"][0]` stays the `AssignName` bound by the
annotation. When `B` is transformed, `_find_arguments_from_base_classes` reads
`.args` off that node for every dataclass base, which crashes the whole
transform:

```
AttributeError: 'AssignName' object has no attribute 'args'
```

Parsing the snippet above with astroid on `main` raises it, and so does running
pylint over the file.

A base that binds `__init__` to something other than a function contributes no
arguments to the generated `__init__`, so this skips it. `B.__init__` then
infers as `__init__(self)`, and `A` keeps behaving as before.

Verified with `pytest tests` on Python 3.13: the four failures on my machine
(`test_typed_dict_required_and_optional_keys`, `test_symlink_resolution`,
`test_identify_old_namespace_package_protocol`, `test_module_is_not_namespace`)
reproduce unchanged on an untouched `main`, so they are unrelated to this diff.

Closes #3200
