### PR TITLE
Document the maintenance branch protection and backport label steps

### DIFF
--- a/doc/release.md
+++ b/doc/release.md
@@ -38,10 +38,17 @@ Check the commit and then push to a release branch:
 - Push the tag.
 - Release the version on GitHub with the same name as the tag and copy and paste the
   appropriate changelog in the description. This triggers the PyPI release.
-- Delete the `maintenance/X.Y-1.x` branch. (For example: `maintenance/2.3.x`)
 - Create a `maintenance/X.Y.x` (For example: `maintenance/2.4.x` from the `v2.4.0` tag.)
   based on the tag from the release. The maintenance branch are protected you won't be
   able to fix it after the fact if you create it from main.
+- Update the branch protection rule so it covers the new maintenance branch: in
+  `Settings` → `Branches`, change the pattern of the `maintenance/X.Y-1.*` rule to
+  `maintenance/X.Y.*`. (For example: `maintenance/2.3.*` becomes `maintenance/2.4.*`.)
+  This also unprotects the old branch so it can be deleted.
+- Delete the `maintenance/X.Y-1.x` branch. (For example: `maintenance/2.3.x`)
+- Rename the `backport maintenance/X.Y-1.x` label to `backport maintenance/X.Y.x`. (For
+  example: `backport maintenance/2.3.x` becomes `backport maintenance/2.4.x`.) Renaming
+  keeps the label attached to the issues and pull requests that already carry it.
 
 ## Backporting a fix from `main` to the maintenance branch
 


### PR DESCRIPTION
Two steps discovered during the 4.3.0 release were missing from `doc/release.md`:

- the branch protection rule pattern has to move from `maintenance/X.Y-1.*` to `maintenance/X.Y.*`, otherwise deleting the old maintenance branch is rejected with `GH006: Protected branch update failed`;
- the `backport maintenance/X.Y-1.x` label has to be renamed for the new maintenance branch (renaming keeps it attached to already-labelled issues and PRs).

Also reorders the steps so the new maintenance branch exists before the old one is deleted.