### PR TITLE
Do not infer a shadowed builtin as the builtin

### DIFF
--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -222,22 +222,65 @@ def _builtin_filter_predicate(node, builtin_name) -> bool:
     return False
 
 
-def _is_builtin_call(node: nodes.Call) -> bool:
-    """Check that the callable of *node* really resolves to a builtin.
+def _name_lookup_frame(
+    name_node: nodes.Name,
+) -> tuple[nodes.LocalsDictNodeNG, list[nodes.NodeNG]]:
+    """Resolve *name_node* the way Python would at that point.
 
-    ``_builtin_filter_predicate`` only matches on the identifier, so a name
-    shadowing a builtin (say a parameter called ``type``) selects the transform
-    too. Resolve the identifier the way Python would before trusting it, like
-    ``brain_type`` does for ``type[...]`` subscripts.
+    ``Name.lookup`` already ignores later assignments in the same scope, so
+    things like ``len(...)`` before a later ``def len`` work. Defaults are the
+    awkward bit: they run in the enclosing scope, and ``FunctionDef.scope_lookup``
+    only special-cases that when the looked-up node *is* the default, not a name
+    inside it. Detect that and look up from the parent frame instead.
+    """
+    scope = name_node.scope()
+    if isinstance(scope, (nodes.FunctionDef, nodes.Lambda)):
+        args = scope.args
+        if args is not None:
+            for default in itertools.chain(
+                args.defaults or (),
+                (d for d in (args.kw_defaults or ()) if d is not None),
+            ):
+                if default is name_node or default.parent_of(name_node):
+                    parent = scope.parent
+                    if parent is None:
+                        break
+                    # Same offset as FunctionDef.scope_lookup uses for defaults,
+                    # so ``def f(f=f)`` does not resolve the default to itself.
+                    return parent.frame()._scope_lookup(
+                        name_node, name_node.name, offset=-1
+                    )
+    return name_node.lookup(name_node.name)
+
+
+def _is_from_builtins_import(stmt: nodes.NodeNG, name: str) -> bool:
+    """True if *stmt* is ``from builtins import ...`` binding *name*."""
+    if not isinstance(stmt, nodes.ImportFrom) or stmt.modname != "builtins":
+        return False
+    for imported, alias in stmt.names:
+        if imported == "*":
+            return True
+        if (alias or imported) == name:
+            return True
+    return False
+
+
+def _is_builtin_call(node: nodes.Call) -> bool:
+    """True if the callable on *node* actually comes from builtins.
+
+    The filter only matches the name text, so a parameter called ``type`` still
+    picks the transform. Check where the name resolves before trusting it.
     """
     func = node.func
     if isinstance(func, nodes.Attribute):
-        # ``dict.fromkeys``: what matters is where ``dict`` comes from.
+        # dict.fromkeys: what matters is where ``dict`` comes from.
         func = func.expr
     if not isinstance(func, nodes.Name):
         return False
-    node_scope, _ = node.scope().lookup(func.name)
-    return isinstance(node_scope, nodes.Module) and node_scope.qname() == "builtins"
+    frame, stmts = _name_lookup_frame(func)
+    if isinstance(frame, nodes.Module) and frame.qname() == "builtins":
+        return True
+    return any(_is_from_builtins_import(stmt, func.name) for stmt in stmts)
 
 
 def register_builtin_transform(

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -222,47 +222,13 @@ def _builtin_filter_predicate(node, builtin_name) -> bool:
     return False
 
 
-def _name_lookup_frame(
-    name_node: nodes.Name,
-) -> tuple[nodes.LocalsDictNodeNG, list[nodes.NodeNG]]:
-    """Resolve *name_node* the way Python would at that point.
-
-    ``Name.lookup`` already ignores later assignments in the same scope, so
-    things like ``len(...)`` before a later ``def len`` work. Defaults are the
-    awkward bit: they run in the enclosing scope, and ``FunctionDef.scope_lookup``
-    only special-cases that when the looked-up node *is* the default, not a name
-    inside it. Detect that and look up from the parent frame instead.
-    """
-    scope = name_node.scope()
-    if isinstance(scope, (nodes.FunctionDef, nodes.Lambda)):
-        args = scope.args
-        if args is not None:
-            for default in itertools.chain(
-                args.defaults or (),
-                (d for d in (args.kw_defaults or ()) if d is not None),
-            ):
-                if default is name_node or default.parent_of(name_node):
-                    parent = scope.parent
-                    if parent is None:
-                        break
-                    # Same offset as FunctionDef.scope_lookup uses for defaults,
-                    # so ``def f(f=f)`` does not resolve the default to itself.
-                    return parent.frame()._scope_lookup(
-                        name_node, name_node.name, offset=-1
-                    )
-    return name_node.lookup(name_node.name)
-
-
 def _is_from_builtins_import(stmt: nodes.NodeNG, name: str) -> bool:
     """True if *stmt* is ``from builtins import ...`` binding *name*."""
     if not isinstance(stmt, nodes.ImportFrom) or stmt.modname != "builtins":
         return False
-    for imported, alias in stmt.names:
-        if imported == "*":
-            return True
-        if (alias or imported) == name:
-            return True
-    return False
+    return any(
+        imported == "*" or (alias or imported) == name for imported, alias in stmt.names
+    )
 
 
 def _is_builtin_call(node: nodes.Call) -> bool:
@@ -270,14 +236,18 @@ def _is_builtin_call(node: nodes.Call) -> bool:
 
     The filter only matches the name text, so a parameter called ``type`` still
     picks the transform. Check where the name resolves before trusting it.
+    ``lookup`` handles the ordering rules for us: later assignments in the same
+    scope do not count, and a name in a default value resolves in the enclosing
+    scope.
     """
     func = node.func
     if isinstance(func, nodes.Attribute):
         # dict.fromkeys: what matters is where ``dict`` comes from.
         func = func.expr
-    if not isinstance(func, nodes.Name):
+    if not isinstance(func, nodes.Name):  # pragma: no cover
+        # The predicate only lets through a Name or ``dict.fromkeys``.
         return False
-    frame, stmts = _name_lookup_frame(func)
+    frame, stmts = func.lookup(func.name)
     if isinstance(frame, nodes.Module) and frame.qname() == "builtins":
         return True
     return any(_is_from_builtins_import(stmt, func.name) for stmt in stmts)

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -223,12 +223,18 @@ def _builtin_filter_predicate(node, builtin_name) -> bool:
 
 
 def _is_from_builtins_import(stmt: nodes.NodeNG, name: str) -> bool:
-    """True if *stmt* is ``from builtins import ...`` binding *name*."""
+    """True if *stmt* is ``from builtins import ...`` binding *name* to ``builtins.name``.
+
+    The binding has to be the builtin of the same name. An alias makes it a
+    different one: ``from builtins import int as str`` leaves ``str`` calling
+    ``int``.
+    """
     if not isinstance(stmt, nodes.ImportFrom) or stmt.modname != "builtins":
         return False
-    return any(
-        imported == "*" or (alias or imported) == name for imported, alias in stmt.names
-    )
+    try:
+        return stmt.real_name(name) == name
+    except AttributeInferenceError:
+        return False
 
 
 def _is_builtin_call(node: nodes.Call) -> bool:

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -222,6 +222,24 @@ def _builtin_filter_predicate(node, builtin_name) -> bool:
     return False
 
 
+def _is_builtin_call(node: nodes.Call) -> bool:
+    """Check that the callable of *node* really resolves to a builtin.
+
+    ``_builtin_filter_predicate`` only matches on the identifier, so a name
+    shadowing a builtin (say a parameter called ``type``) selects the transform
+    too. Resolve the identifier the way Python would before trusting it, like
+    ``brain_type`` does for ``type[...]`` subscripts.
+    """
+    func = node.func
+    if isinstance(func, nodes.Attribute):
+        # ``dict.fromkeys``: what matters is where ``dict`` comes from.
+        func = func.expr
+    if not isinstance(func, nodes.Name):
+        return False
+    node_scope, _ = node.scope().lookup(func.name)
+    return isinstance(node_scope, nodes.Module) and node_scope.qname() == "builtins"
+
+
 def register_builtin_transform(
     manager: AstroidManager, transform, builtin_name
 ) -> None:
@@ -234,6 +252,8 @@ def register_builtin_transform(
     def _transform_wrapper(
         node: nodes.Call, context: InferenceContext | None = None
     ) -> Iterator:
+        if not _is_builtin_call(node):
+            raise UseInferenceDefault
         result = transform(node, context=context)
         if result:
             if not result.parent:

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -222,6 +222,17 @@ def _builtin_filter_predicate(node, builtin_name) -> bool:
     return False
 
 
+def _is_bare_annotation(stmt: nodes.NodeNG) -> bool:
+    """True if *stmt* is a name bound only by ``name: T`` with no value.
+
+    At module or class scope that is not a binding: ``len: int`` still calls
+    the builtin. Inside a function it *is* a binding and makes the name local.
+    """
+    if isinstance(stmt, nodes.AssignName):
+        stmt = stmt.parent
+    return isinstance(stmt, nodes.AnnAssign) and stmt.value is None
+
+
 def _is_from_builtins_import(stmt: nodes.NodeNG, name: str) -> bool:
     """True if *stmt* is ``from builtins import ...`` binding *name* to ``builtins.name``.
 
@@ -256,6 +267,22 @@ def _is_builtin_call(node: nodes.Call) -> bool:
     frame, stmts = func.lookup(func.name)
     if isinstance(frame, nodes.Module) and frame.qname() == "builtins":
         return True
+    # Bare annotations in modules and classes are stored in __annotations__,
+    # they do not shadow. In a function they do, so leave those stmts alone.
+    if not isinstance(frame, (nodes.FunctionDef, nodes.Lambda)):
+        stmts = [stmt for stmt in stmts if not _is_bare_annotation(stmt)]
+        if not stmts:
+            # lookup() prefers the later AnnAssign, so an earlier real
+            # binding such as ``len = 5`` then ``len: int`` is dropped.
+            # Walk locals that appear before this call for one.
+            for stmt in frame.locals.get(func.name, ()):
+                if _is_bare_annotation(stmt):
+                    continue
+                stmt_line = getattr(stmt, "fromlineno", None) or stmt.lineno or 0
+                if stmt_line > (func.lineno or 0):
+                    continue
+                return _is_from_builtins_import(stmt, func.name)
+            return True
     return any(_is_from_builtins_import(stmt, func.name) for stmt in stmts)
 
 

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -52,7 +52,7 @@ def infer_type_sub(node, context: InferenceContext | None = None):
     :return: the inferred node
     :rtype: nodes.NodeNG
     """
-    node_scope, _ = node.scope().lookup("type")
+    node_scope, _ = node.lookup("type")
     if not (isinstance(node_scope, nodes.Module) and node_scope.qname() == "builtins"):
         raise UseInferenceDefault()
     class_src = """

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -874,6 +874,36 @@ def _infer_decorator_callchain(node):
     return None
 
 
+def _is_in_default_value(args: Arguments, node: NodeNG) -> bool:
+    """Whether *node* is part of one of the default values in *args*.
+
+    Default values are evaluated in the enclosing scope, so a name inside one
+    must not resolve to the parameters it sits next to. That goes for a name
+    nested in the default too, not just the default itself, which is why this
+    cannot be a plain identity test.
+
+    Walk up from *node* rather than down from each default: the walk stops at
+    the arguments (found) or at the function they belong to (not found), so
+    this stays cheap for the common case of a name in the body.
+    """
+    child = node
+    parent = child.parent
+    while parent is not None:
+        if parent is args:
+            return any(
+                child is default
+                for default in itertools.chain(
+                    args.defaults or (), args.kw_defaults or ()
+                )
+            )
+        if parent is args.parent:
+            # Reached the function or lambda without going through its
+            # arguments, so the node lives somewhere else in it.
+            return False
+        child, parent = parent, parent.parent
+    return False
+
+
 class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
     """Class representing an :class:`ast.Lambda` node.
 
@@ -1002,9 +1032,7 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
             given name according to the scope where it has been found (locals,
             globals or builtin).
         """
-        if (self.args.defaults and node in self.args.defaults) or (
-            self.args.kw_defaults and node in self.args.kw_defaults
-        ):
+        if _is_in_default_value(self.args, node):
             if not self.parent:
                 raise ParentMissingError(target=self)
             frame = self.parent.frame()
@@ -1672,9 +1700,7 @@ class FunctionDef(
             if self.parent and isinstance(frame := self.parent.frame(), ClassDef):
                 return self, [frame]
 
-        if (self.args.defaults and node in self.args.defaults) or (
-            self.args.kw_defaults and node in self.args.kw_defaults
-        ):
+        if _is_in_default_value(self.args, node):
             if not self.parent:
                 raise ParentMissingError(target=self)
             frame = self.parent.frame()

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -874,34 +874,56 @@ def _infer_decorator_callchain(node):
     return None
 
 
-def _is_in_default_value(args: Arguments, node: NodeNG) -> bool:
-    """Whether *node* is part of one of the default values in *args*.
+def _signature_part(
+    func: Lambda | FunctionDef, node: NodeNG
+) -> Literal["default", "annotation"] | None:
+    """Which part of *func*'s signature *node* sits in, if any.
 
-    Default values are evaluated in the enclosing scope, so a name inside one
-    must not resolve to the parameters it sits next to. That goes for a name
-    nested in the default too, not just the default itself, which is why this
-    cannot be a plain identity test.
+    Defaults and annotations are evaluated where the function is defined, not
+    inside it, so a name in one must not resolve to the parameters it sits next
+    to. That goes for a name nested in the value too, not just the value
+    itself, which is why this cannot be a plain identity test.
 
-    Walk up from *node* rather than down from each default: the walk stops at
+    The two are told apart because only annotations see the type parameters:
+    ``def f[T](x: T = T)`` is fine on the annotation and a ``NameError`` on the
+    default.
+
+    Walk up from *node* rather than down from each value: the walk stops at
     the arguments (found) or at the function they belong to (not found), so
     this stays cheap for the common case of a name in the body.
     """
+    args = func.args
     child = node
     parent = child.parent
     while parent is not None:
         if parent is args:
-            return any(
+            if any(
                 child is default
                 for default in itertools.chain(
                     args.defaults or (), args.kw_defaults or ()
                 )
-            )
-        if parent is args.parent:
+            ):
+                return "default"
+            if any(
+                child is annotation
+                for annotation in itertools.chain(
+                    args.annotations or (),
+                    args.posonlyargs_annotations or (),
+                    args.kwonlyargs_annotations or (),
+                    (args.varargannotation, args.kwargannotation),
+                )
+            ):
+                return "annotation"
+            return None
+        if parent is func:
             # Reached the function or lambda without going through its
-            # arguments, so the node lives somewhere else in it.
-            return False
+            # arguments, so the only signature value left is the return
+            # annotation; anything else lives in the body.
+            if isinstance(func, FunctionDef) and child is func.returns:
+                return "annotation"
+            return None
         child, parent = parent, parent.parent
-    return False
+    return None
 
 
 class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
@@ -1032,7 +1054,7 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
             given name according to the scope where it has been found (locals,
             globals or builtin).
         """
-        if _is_in_default_value(self.args, node):
+        if _signature_part(self, node) is not None:
             if not self.parent:
                 raise ParentMissingError(target=self)
             frame = self.parent.frame()
@@ -1700,7 +1722,14 @@ class FunctionDef(
             if self.parent and isinstance(frame := self.parent.frame(), ClassDef):
                 return self, [frame]
 
-        if _is_in_default_value(self.args, node):
+        part = _signature_part(self, node)
+        # An annotation is evaluated in the scope holding the type parameters,
+        # which sits between the function and the scope it is defined in.
+        if part == "annotation" and any(
+            type_param.name.name == name for type_param in self.type_params
+        ):
+            part = None
+        if part is not None:
             if not self.parent:
                 raise ParentMissingError(target=self)
             frame = self.parent.frame()

--- a/doc/whatsnew/fragments/3211.bugfix
+++ b/doc/whatsnew/fragments/3211.bugfix
@@ -4,5 +4,10 @@ parameter named ``type`` or a function named ``len`` was still inferred as a
 call to the builtin. The identifier is now resolved with ``lookup()`` first,
 as ``brain_type`` already does for ``type[...]`` subscripts.
 
+``Lambda.scope_lookup`` and ``FunctionDef.scope_lookup`` now send any name
+nested inside a default value to the enclosing scope, not just the default
+itself. A comprehension or a lambda in a default used to resolve names against
+the parameters it sits next to.
+
 Refs #3211
 Closes pylint-dev/pylint#10994

--- a/doc/whatsnew/fragments/3211.bugfix
+++ b/doc/whatsnew/fragments/3211.bugfix
@@ -4,6 +4,13 @@ parameter named ``type`` or a function named ``len`` was still inferred as a
 call to the builtin. The identifier is now resolved with ``lookup()`` first,
 as ``brain_type`` already does for ``type[...]`` subscripts.
 
+Every kind of binding counts, not just parameters: a name bound by ``import``,
+``for``, ``with ... as``, ``global`` or ``nonlocal`` shadows the builtin too.
+Calls that used to infer a builtin result may now infer ``Uninferable`` or raise
+``InferenceError`` instead. In exchange, a rebound name resolves to what it is
+really bound to, so ``from collections import OrderedDict as dict`` followed by
+``dict(a=1)`` now infers an ``OrderedDict`` rather than a plain ``dict``.
+
 ``Lambda.scope_lookup`` and ``FunctionDef.scope_lookup`` now send any name
 nested inside a default value to the enclosing scope, not just the default
 itself. A comprehension or a lambda in a default used to resolve names against

--- a/doc/whatsnew/fragments/3211.bugfix
+++ b/doc/whatsnew/fragments/3211.bugfix
@@ -1,0 +1,8 @@
+The builtin inference tips no longer fire on a name that shadows the builtin
+they are registered for. They were selected on the identifier alone, so a
+parameter named ``type`` or a function named ``len`` was still inferred as a
+call to the builtin. The identifier is now resolved with ``lookup()`` first,
+as ``brain_type`` already does for ``type[...]`` subscripts.
+
+Refs #3211
+Closes pylint-dev/pylint#10994

--- a/doc/whatsnew/fragments/3211.bugfix
+++ b/doc/whatsnew/fragments/3211.bugfix
@@ -1,20 +1,7 @@
 The builtin inference tips no longer fire on a name that shadows the builtin
 they are registered for. They were selected on the identifier alone, so a
 parameter named ``type`` or a function named ``len`` was still inferred as a
-call to the builtin. The identifier is now resolved with ``lookup()`` first,
-as ``brain_type`` already does for ``type[...]`` subscripts.
-
-Every kind of binding counts, not just parameters: a name bound by ``import``,
-``for``, ``with ... as``, ``global`` or ``nonlocal`` shadows the builtin too.
-Calls that used to infer a builtin result may now infer ``Uninferable`` or raise
-``InferenceError`` instead. In exchange, a rebound name resolves to what it is
-really bound to, so ``from collections import OrderedDict as dict`` followed by
-``dict(a=1)`` now infers an ``OrderedDict`` rather than a plain ``dict``.
-
-``Lambda.scope_lookup`` and ``FunctionDef.scope_lookup`` now send any name
-nested inside a default value to the enclosing scope, not just the default
-itself. A comprehension or a lambda in a default used to resolve names against
-the parameters it sits next to.
+call to the builtin.
 
 Refs #3211
 Closes pylint-dev/pylint#10994

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -134,6 +134,25 @@ class TypeBrain(unittest.TestCase):
         meth_inf = val_inf.getattr("__class_getitem__")[0]
         self.assertIsInstance(meth_inf, nodes.FunctionDef)
 
+    @pytest.mark.xfail(
+        reason="infer_type_sub looks 'type' up from the scope, so a parameter hides it"
+    )
+    def test_type_subscript_next_to_a_parameter_named_type(self):
+        """A parameter called ``type`` does not reach the annotation next to it.
+
+        The annotation is evaluated where the function is defined, so ``type``
+        there is still the builtin and ``type[int]`` still works.
+        """
+        src = builder.extract_node("""
+            def feed(type: str) -> type[int]:
+                return int
+            """)
+        val_inf = src.returns.value.inferred()[0]
+        self.assertIsInstance(val_inf, nodes.ClassDef)
+        self.assertEqual(val_inf.name, "type")
+        meth_inf = val_inf.getattr("__class_getitem__")[0]
+        self.assertIsInstance(meth_inf, nodes.FunctionDef)
+
     def test_invalid_type_subscript(self):
         """
         Check that a type (str for example) that inherits

--- a/tests/brain/test_brain.py
+++ b/tests/brain/test_brain.py
@@ -134,9 +134,6 @@ class TypeBrain(unittest.TestCase):
         meth_inf = val_inf.getattr("__class_getitem__")[0]
         self.assertIsInstance(meth_inf, nodes.FunctionDef)
 
-    @pytest.mark.xfail(
-        reason="infer_type_sub looks 'type' up from the scope, so a parameter hides it"
-    )
     def test_type_subscript_next_to_a_parameter_named_type(self):
         """A parameter called ``type`` does not reach the annotation next to it.
 

--- a/tests/brain/test_builtin.py
+++ b/tests/brain/test_builtin.py
@@ -449,18 +449,56 @@ class TestShadowedBuiltins:
         assert isinstance(inferred, nodes.Const)
         assert inferred.value == "apple"
 
-    @pytest.mark.xfail(
-        reason="a bare annotation is taken for a binding, so the builtin is lost"
-    )
     def test_bare_annotation_does_not_shadow(self) -> None:
         """``len: int`` says what ``len`` should hold, it does not put anything there.
 
-        ``lookup()`` still hands back the annotated name, so the tip reads it as a
-        shadow and steps aside, where the builtin is really the one being called.
+        ``lookup()`` still hands back the annotated name, so the tip used to read
+        it as a shadow and step aside. At module scope the builtin is the one
+        being called.
         """
         node: nodes.Call = _extract_single_node("""
         len: int
         len([1, 2, 3]) #@
+        """)
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == 3
+
+    def test_assignment_then_bare_annotation_still_shadows(self) -> None:
+        """``len = 5`` is a real binding. A later ``len: int`` does not undo it."""
+        node: nodes.Call = _extract_single_node("""
+        len = 5
+        len: int
+        len([1, 2, 3]) #@
+        """)
+        inferred = next(node.infer())
+        assert inferred is util.Uninferable
+
+    def test_builtins_import_then_bare_annotation_stays_builtin(self) -> None:
+        node: nodes.Call = _extract_single_node("""
+        from builtins import str
+        str: object
+        str("apple") #@
+        """)
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == "apple"
+
+    def test_bare_annotation_in_function_body_shadows(self) -> None:
+        """A function-local ``len: int`` makes ``len`` local, so the call is not the builtin."""
+        node: nodes.Call = _extract_single_node("""
+        def f():
+            len: int
+            len([1, 2, 3]) #@
+        """)
+        inferred = next(node.infer())
+        assert inferred is util.Uninferable
+
+    def test_bare_annotation_in_class_body_does_not_shadow(self) -> None:
+        node: nodes.Call = _extract_single_node("""
+        class C:
+            len: int
+            len([1, 2, 3]) #@
         """)
         inferred = next(node.infer())
         assert isinstance(inferred, nodes.Const)

--- a/tests/brain/test_builtin.py
+++ b/tests/brain/test_builtin.py
@@ -8,7 +8,7 @@ import unittest
 
 import pytest
 
-from astroid import nodes, objects, util
+from astroid import bases, nodes, objects, util
 from astroid.builder import _extract_single_node, extract_node
 
 
@@ -156,3 +156,143 @@ class Number:
 """)
         inferit = function_def.infer_call_result(function_def, context=None)
         assert [a.name for a in inferit] == [util.Uninferable]
+
+
+class TestShadowedBuiltins:
+    """A name shadowing a builtin must not be inferred as that builtin.
+
+    The transforms registered by ``register_builtin_transform`` are selected on
+    the identifier alone, so every one of them used to fire on a shadowing name.
+    """
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            pytest.param(
+                """
+                def bool(x):
+                    return "shadowed"
+                bool(1) #@
+                """,
+                id="bool",
+            ),
+            pytest.param(
+                """
+                def int(x):
+                    return "shadowed"
+                int("1") #@
+                """,
+                id="int",
+            ),
+            pytest.param(
+                """
+                def isinstance(obj, cls):
+                    return "shadowed"
+                isinstance(1, int) #@
+                """,
+                id="isinstance",
+            ),
+            pytest.param(
+                """
+                def len(x):
+                    return "shadowed"
+                len([1, 2, 3]) #@
+                """,
+                id="len",
+            ),
+            pytest.param(
+                """
+                def list(x):
+                    return "shadowed"
+                list("ab") #@
+                """,
+                id="list",
+            ),
+            pytest.param(
+                """
+                def str(x):
+                    return "shadowed"
+                str(42) #@
+                """,
+                id="str",
+            ),
+            pytest.param(
+                """
+                def type(x):
+                    return "shadowed"
+                type(1) #@
+                """,
+                id="type",
+            ),
+            pytest.param(
+                """
+                len = lambda x: "shadowed"
+                len([1, 2, 3]) #@
+                """,
+                id="assignment-instead-of-def",
+            ),
+            pytest.param(
+                """
+                class dict:
+                    @staticmethod
+                    def fromkeys(keys):
+                        return "shadowed"
+                dict.fromkeys("ab") #@
+                """,
+                id="dict.fromkeys",
+            ),
+        ],
+    )
+    def test_shadowed_builtin_call(self, code: str) -> None:
+        node: nodes.Call = _extract_single_node(code)
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == "shadowed"
+
+    def test_shadowed_by_a_parameter_pylint10994(self) -> None:
+        """https://github.com/pylint-dev/pylint/issues/10994"""
+        node: nodes.Call = _extract_single_node("""
+        def convert_type(x, type):
+            return type(x)
+
+        convert_type(12.34, str) #@
+        """)
+        inferred = next(node.infer())
+        assert isinstance(inferred, bases.Instance)
+        assert inferred.pytype() == "builtins.str"
+
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            pytest.param("bool(0) #@", nodes.Const, id="bool"),
+            pytest.param("callable(len) #@", nodes.Const, id="callable"),
+            pytest.param("dict(a=1) #@", nodes.Dict, id="dict"),
+            pytest.param("dict.fromkeys(['a']) #@", nodes.Dict, id="dict.fromkeys"),
+            pytest.param("frozenset([1]) #@", objects.FrozenSet, id="frozenset"),
+            pytest.param("int('42') #@", nodes.Const, id="int"),
+            pytest.param("isinstance(1, int) #@", nodes.Const, id="isinstance"),
+            pytest.param("issubclass(bool, int) #@", nodes.Const, id="issubclass"),
+            pytest.param("len([1, 2, 3]) #@", nodes.Const, id="len"),
+            pytest.param("list((1, 2)) #@", nodes.List, id="list"),
+            pytest.param("set([1]) #@", nodes.Set, id="set"),
+            pytest.param("slice(1, 2) #@", nodes.Slice, id="slice"),
+            pytest.param("str(42) #@", nodes.Const, id="str"),
+            pytest.param("tuple([1, 2]) #@", nodes.Tuple, id="tuple"),
+            pytest.param("type(1) #@", nodes.ClassDef, id="type"),
+        ],
+    )
+    def test_unshadowed_builtin_call(self, code: str, expected: type) -> None:
+        """The brains must keep firing when the builtin is not shadowed."""
+        node: nodes.Call = _extract_single_node(code)
+        assert isinstance(next(node.infer()), expected)
+
+    def test_shadowing_in_another_scope_is_ignored(self) -> None:
+        node: nodes.Call = _extract_single_node("""
+        def takes_a_len(len):
+            return len
+
+        len([1, 2, 3]) #@
+        """)
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == 3

--- a/tests/brain/test_builtin.py
+++ b/tests/brain/test_builtin.py
@@ -282,9 +282,7 @@ class TestShadowedBuiltins:
             pytest.param(
                 'getattr("apple", "upper") #@', bases.BoundMethod, id="getattr"
             ),
-            pytest.param(
-                'hasattr("apple", "upper") #@', nodes.Const, id="hasattr"
-            ),
+            pytest.param('hasattr("apple", "upper") #@', nodes.Const, id="hasattr"),
             pytest.param(
                 "property(lambda self: 1) #@", objects.Property, id="property"
             ),
@@ -349,24 +347,20 @@ class TestShadowedBuiltins:
 
     def test_default_arg_uses_enclosing_builtin(self) -> None:
         """Defaults are evaluated in the enclosing scope, not the function body."""
-        func: nodes.FunctionDef = extract_node(
-            """
+        func: nodes.FunctionDef = extract_node("""
             def h(x, len=len([1, 2, 3])):
                 return x
-            """
-        )
+            """)
         call = next(d for d in func.args.defaults if isinstance(d, nodes.Call))
         inferred = next(call.infer())
         assert isinstance(inferred, nodes.Const)
         assert inferred.value == 3
 
     def test_kwonly_default_uses_enclosing_builtin(self) -> None:
-        func: nodes.FunctionDef = extract_node(
-            """
+        func: nodes.FunctionDef = extract_node("""
             def h(x, *, len=len([1, 2, 3])):
                 return x
-            """
-        )
+            """)
         call = next(
             d for d in (func.args.kw_defaults or ()) if isinstance(d, nodes.Call)
         )

--- a/tests/brain/test_builtin.py
+++ b/tests/brain/test_builtin.py
@@ -368,6 +368,24 @@ class TestShadowedBuiltins:
         assert isinstance(inferred, nodes.Const)
         assert inferred.value == 3
 
+    @pytest.mark.parametrize(
+        "default",
+        [
+            pytest.param("[len(y) for y in ([1, 2, 3],)]", id="comprehension"),
+            pytest.param("lambda: len([1, 2, 3])", id="lambda"),
+        ],
+    )
+    def test_nested_scope_in_default_uses_enclosing_builtin(self, default: str) -> None:
+        """A comprehension or lambda in a default is still in the enclosing scope."""
+        func: nodes.FunctionDef = extract_node(f"""
+            def h(x, len={default}):
+                return x
+            """)
+        call = next(func.args.defaults[0].nodes_of_class(nodes.Call))
+        inferred = next(call.infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == 3
+
     def test_shadowing_in_another_scope_is_ignored(self) -> None:
         node: nodes.Call = _extract_single_node("""
         def takes_a_len(len):

--- a/tests/brain/test_builtin.py
+++ b/tests/brain/test_builtin.py
@@ -396,3 +396,33 @@ class TestShadowedBuiltins:
         inferred = next(node.infer())
         assert isinstance(inferred, nodes.Const)
         assert inferred.value == 3
+
+    @pytest.mark.xfail(
+        reason="_is_from_builtins_import matches the alias, not the imported name"
+    )
+    def test_builtins_import_under_another_builtin_name(self) -> None:
+        """``str`` here is really ``builtins.int``, so it must not infer as ``str``.
+
+        ``lookup()`` already guarantees the binding is called ``str``; what is
+        left to check is *what* was imported under that name.
+        """
+        node: nodes.Call = _extract_single_node("""
+        from builtins import int as str
+        str(42) #@
+        """)
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == 42
+
+    @pytest.mark.xfail(
+        reason="scope_lookup sends defaults to the enclosing scope, annotations not yet"
+    )
+    def test_annotation_uses_enclosing_builtin(self) -> None:
+        """Annotations are evaluated in the enclosing scope, like defaults."""
+        func: nodes.FunctionDef = extract_node("""
+            def h(x: str("apple") = 1, str=None):
+                return x
+            """)
+        inferred = next(func.args.annotations[0].infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == "apple"

--- a/tests/brain/test_builtin.py
+++ b/tests/brain/test_builtin.py
@@ -448,3 +448,20 @@ class TestShadowedBuiltins:
         inferred = next(func.returns.infer())
         assert isinstance(inferred, nodes.Const)
         assert inferred.value == "apple"
+
+    @pytest.mark.xfail(
+        reason="a bare annotation is taken for a binding, so the builtin is lost"
+    )
+    def test_bare_annotation_does_not_shadow(self) -> None:
+        """``len: int`` says what ``len`` should hold, it does not put anything there.
+
+        ``lookup()`` still hands back the annotated name, so the tip reads it as a
+        shadow and steps aside, where the builtin is really the one being called.
+        """
+        node: nodes.Call = _extract_single_node("""
+        len: int
+        len([1, 2, 3]) #@
+        """)
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == 3

--- a/tests/brain/test_builtin.py
+++ b/tests/brain/test_builtin.py
@@ -279,12 +279,100 @@ class TestShadowedBuiltins:
             pytest.param("str(42) #@", nodes.Const, id="str"),
             pytest.param("tuple([1, 2]) #@", nodes.Tuple, id="tuple"),
             pytest.param("type(1) #@", nodes.ClassDef, id="type"),
+            pytest.param(
+                'getattr("apple", "upper") #@', bases.BoundMethod, id="getattr"
+            ),
+            pytest.param(
+                'hasattr("apple", "upper") #@', nodes.Const, id="hasattr"
+            ),
+            pytest.param(
+                "property(lambda self: 1) #@", objects.Property, id="property"
+            ),
+            pytest.param(
+                """
+                class Animal:
+                    def speak(self):
+                        return "generic"
+
+                class Cat(Animal):
+                    def speak(self):
+                        super() #@
+                """,
+                objects.Super,
+                id="super",
+            ),
+            pytest.param(
+                """
+                from builtins import str
+                str(42) #@
+                """,
+                nodes.Const,
+                id="from-builtins-import",
+            ),
+            pytest.param(
+                """
+                from builtins import *
+                str(42) #@
+                """,
+                nodes.Const,
+                id="from-builtins-star-import",
+            ),
+            pytest.param(
+                """
+                class Fruit:
+                    size = len("apple")  #@
+                    def len(self):
+                        return 0
+                """,
+                nodes.Const,
+                id="class-body-before-method-shadow",
+            ),
+            pytest.param(
+                """
+                len([1, 2, 3])  #@
+                def len(x):
+                    return "shadowed"
+                """,
+                nodes.Const,
+                id="module-use-before-def",
+            ),
         ],
     )
     def test_unshadowed_builtin_call(self, code: str, expected: type) -> None:
         """The brains must keep firing when the builtin is not shadowed."""
-        node: nodes.Call = _extract_single_node(code)
-        assert isinstance(next(node.infer()), expected)
+        node = _extract_single_node(code)
+        if isinstance(node, nodes.Assign):
+            node = node.value
+        assert isinstance(node, nodes.Call)
+        inferred = next(node.infer())
+        assert isinstance(inferred, expected)
+
+    def test_default_arg_uses_enclosing_builtin(self) -> None:
+        """Defaults are evaluated in the enclosing scope, not the function body."""
+        func: nodes.FunctionDef = extract_node(
+            """
+            def h(x, len=len([1, 2, 3])):
+                return x
+            """
+        )
+        call = next(d for d in func.args.defaults if isinstance(d, nodes.Call))
+        inferred = next(call.infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == 3
+
+    def test_kwonly_default_uses_enclosing_builtin(self) -> None:
+        func: nodes.FunctionDef = extract_node(
+            """
+            def h(x, *, len=len([1, 2, 3])):
+                return x
+            """
+        )
+        call = next(
+            d for d in (func.args.kw_defaults or ()) if isinstance(d, nodes.Call)
+        )
+        inferred = next(call.infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == 3
 
     def test_shadowing_in_another_scope_is_ignored(self) -> None:
         node: nodes.Call = _extract_single_node("""

--- a/tests/brain/test_builtin.py
+++ b/tests/brain/test_builtin.py
@@ -397,9 +397,6 @@ class TestShadowedBuiltins:
         assert isinstance(inferred, nodes.Const)
         assert inferred.value == 3
 
-    @pytest.mark.xfail(
-        reason="_is_from_builtins_import matches the alias, not the imported name"
-    )
     def test_builtins_import_under_another_builtin_name(self) -> None:
         """``str`` here is really ``builtins.int``, so it must not infer as ``str``.
 
@@ -411,12 +408,9 @@ class TestShadowedBuiltins:
         str(42) #@
         """)
         inferred = next(node.infer())
-        assert isinstance(inferred, nodes.Const)
-        assert inferred.value == 42
+        assert isinstance(inferred, bases.Instance)
+        assert inferred.pytype() == "builtins.int"
 
-    @pytest.mark.xfail(
-        reason="scope_lookup sends defaults to the enclosing scope, annotations not yet"
-    )
     def test_annotation_uses_enclosing_builtin(self) -> None:
         """Annotations are evaluated in the enclosing scope, like defaults."""
         func: nodes.FunctionDef = extract_node("""
@@ -424,5 +418,33 @@ class TestShadowedBuiltins:
                 return x
             """)
         inferred = next(func.args.annotations[0].infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == "apple"
+
+    @pytest.mark.parametrize(
+        "signature",
+        [
+            pytest.param('*args: str("apple"), str=None', id="vararg"),
+            pytest.param('str=None, **kwargs: str("apple")', id="kwarg"),
+            pytest.param('x: str("apple") = 1, /, *, str=None', id="posonly"),
+            pytest.param('*, x: str("apple") = 1, str=None', id="kwonly"),
+        ],
+    )
+    def test_every_annotation_uses_enclosing_builtin(self, signature: str) -> None:
+        func: nodes.FunctionDef = extract_node(f"""
+            def h({signature}):
+                return 1
+            """)
+        call = next(func.args.nodes_of_class(nodes.Call))
+        inferred = next(call.infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == "apple"
+
+    def test_return_annotation_uses_enclosing_builtin(self) -> None:
+        func: nodes.FunctionDef = extract_node("""
+            def h(x, str=None) -> str("apple"):
+                return x
+            """)
+        inferred = next(func.returns.infer())
         assert isinstance(inferred, nodes.Const)
         assert inferred.value == "apple"

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -101,6 +101,29 @@ class LookupTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual(base.name, "YO")
         self.assertEqual(base.root().name, "data.module")
 
+    def test_name_nested_in_default_looks_up_in_enclosing_scope(self) -> None:
+        """A name inside a default value is evaluated in the enclosing scope.
+
+        That holds for a name nested in the default, not only for the default
+        itself, so a comprehension or a lambda there must not see the
+        parameters it sits next to.
+        """
+        for default in ("[x for x in (v,)]", "lambda: v"):
+            with self.subTest(default=default):
+                module = builder.parse(f"""
+                    v = 42
+                    def func(v={default}):
+                        return v
+                """)
+                name = next(
+                    n
+                    for n in module["func"].args.defaults[0].nodes_of_class(nodes.Name)
+                    if n.name == "v"
+                )
+                _, stmts = name.lookup("v")
+                self.assertEqual(len(stmts), 1)
+                self.assertEqual(stmts[0].lineno, 2)
+
     def test_class(self) -> None:
         klass = self.module["YOUPI"]
         my_dict = next(klass.ilookup("MY_DICT"))

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -8,6 +8,7 @@ import functools
 import unittest
 
 from astroid import builder, nodes
+from astroid.const import PY312_PLUS
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
@@ -123,6 +124,37 @@ class LookupTest(resources.SysPathSetup, unittest.TestCase):
                 _, stmts = name.lookup("v")
                 self.assertEqual(len(stmts), 1)
                 self.assertEqual(stmts[0].lineno, 2)
+
+    def test_name_in_annotation_looks_up_in_enclosing_scope(self) -> None:
+        """An annotation is evaluated in the enclosing scope, like a default."""
+        module = builder.parse("""
+            v = 42
+            def func(x: v = 1, v=None) -> v:
+                return x
+        """)
+        func = module["func"]
+        for name in (func.args.annotations[0], func.returns):
+            with self.subTest(name=name):
+                _, stmts = name.lookup("v")
+                self.assertEqual(len(stmts), 1)
+                self.assertEqual(stmts[0].lineno, 2)
+
+    @unittest.skipUnless(PY312_PLUS, "PEP 695 syntax requires Python 3.12")
+    def test_annotation_sees_type_parameters(self) -> None:
+        """Annotations are evaluated in the type parameter scope, defaults are not."""
+        module = builder.parse("""
+            def func[T](x: T = T) -> T:
+                return x
+        """)
+        func = module["func"]
+        for name in (func.args.annotations[0], func.returns):
+            with self.subTest(name=name):
+                _, stmts = name.lookup("T")
+                self.assertEqual(len(stmts), 1)
+                self.assertIsInstance(stmts[0].parent, nodes.TypeVar)
+
+        _, stmts = func.args.defaults[0].lookup("T")
+        self.assertEqual(stmts, [])
 
     def test_class(self) -> None:
         klass = self.module["YOUPI"]


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`register_builtin_transform` picks its tip by name text alone. A parameter called `type` is treated as `builtins.type`:

```python
def convert_type(x, type):
    return type(x)

convert_type(12.34, str).split(".")
```

astroid turns that into `ClassDef.float`, and pylint reports `E1101: Class 'float' has no 'split' member` (pylint-dev/pylint#10994). Same hole for every transform registered this way (`len`, `str`, `list`, ...).

The fix is to resolve the name before running the transform, and fall back to normal inference when it is not the real builtin. Lookup goes through the name node (so later defs in the same scope do not count), with a small extra step for default args, which run in the enclosing scope. `from builtins import str` is treated as the builtin too.

## Review follow-up

Addressed the cases Pierre flagged where the first version was too strict:

- `from builtins import str` / `from builtins import *`
- use before a later `def` in the same module or class body
- default and kw-only default values (`def h(x, len=len([...]))`)

Also filled in the missing unshadowed controls for `getattr`, `hasattr`, `property`, and `super`.

On the cache note: the check stays inside the tip (same place as before) so the cheap name filter is unchanged. Restructuring so the tip could still be cached on a miss did not seem worth the churn for this fix; happy to revisit if it shows up in profiles.

## Verification

```
tests/brain/test_builtin.py  57 passed
full suite                   2108 passed, 66 skipped, 15 xfailed
```

Closes pylint-dev/pylint#10994
