### PR TITLE
Avoid inferring functional Enums with non-string names

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,12 @@ What's New in astroid 4.4.0?
 ============================
 Release date: TBA
 
+* Do not infer a functional ``Enum`` whose class name is not a string. Such a
+  definition is invalid at runtime and could expose a non-string class name to
+  consumers.
+
+  Refs pylint-dev/pylint#11229
+
 
 
 What's New in astroid 4.3.1?

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -149,6 +149,10 @@ def infer_func_form(
         # ``Enum("e", (1,))``) means the definition is invalid, so fall back to
         # the default inference instead of crashing.
         raise UseInferenceDefault
+    if enum and not isinstance(name, str):
+        # Enum class names must be strings; inferring a class with any other
+        # name can make consumers crash when they perform string operations.
+        raise UseInferenceDefault
     attributes = [attr for attr in attributes if " " not in attr]
 
     # If we can't infer the name of the class, don't crash, up to this point

--- a/tests/brain/test_enum.py
+++ b/tests/brain/test_enum.py
@@ -195,6 +195,15 @@ class EnumBrainTest(unittest.TestCase):
         # Inference must not raise ``TypeError``; it falls back to default.
         assert next(node.infer()) is util.Uninferable
 
+    def test_enum_func_form_non_string_class_name_no_crash(self) -> None:
+        """A functional Enum with a non-string class name is invalid."""
+        node = builder.extract_node("""
+        from enum import Enum
+        Enum(1, "")  #@
+        """)
+        # Inference must not create a class with a non-string name.
+        assert next(node.infer()) is util.Uninferable
+
     def test_enum_func_form_bytes_field_names_no_crash(self) -> None:
         """A functional Enum whose field names are bytes is invalid.
 


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

The functional `Enum` transform currently accepts a non-string class name and creates a `ClassDef` whose `name` is not a string. For example, `Enum(1, "")` produces an inferred class named `1`, even though CPython rejects the call with `TypeError`.

Fall back to default inference for this invalid form, matching the existing handling for invalid functional Enum member names. This also prevents downstream consumers such as Pylint from crashing when they perform string operations on class names.

Refs pylint-dev/pylint#11229
Refs pylint-dev/pylint#11238

## Verification

- `python -m pytest tests/brain/test_enum.py -q` — 35 passed
- `python -m pytest tests/brain -q` — 385 passed, 64 skipped, 3 xfailed
- All configured pre-commit hooks passed on the changed files
- Pylint 4.0.6 with this Astroid branch processes the reported reproducer without crashing
