### PR TITLE
Give a renamed namedtuple's instance the renamed fields

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,15 @@ What's New in astroid 4.4.0?
 ============================
 Release date: TBA
 
+* Fix inference of the attributes of a ``namedtuple`` created with
+  ``rename=True``. The renamed fields were applied to ``_fields`` and to the
+  class body, but the instance kept the field names as written, so an instance
+  of ``namedtuple("Tuple", "abc def", rename=True)`` was inferred as having a
+  ``def`` attribute instead of ``_1``, and duplicate field names collapsed into
+  a single attribute instead of being renamed.
+
+  Closes #242
+
 
 
 What's New in astroid 4.3.1?

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -229,6 +229,18 @@ def infer_named_tuple(
     except AstroidValueError as exc:
         raise UseInferenceDefault("ValueError: " + str(exc)) from exc
 
+    if tuple(class_node.instance_attrs) != tuple(attributes):
+        # ``infer_func_form`` recorded the field names as written, but ``rename=True``
+        # replaces invalid, keyword or duplicate names with ``_N``, so the instance
+        # would otherwise carry names the namedtuple does not actually have (and lose
+        # the duplicated ones entirely). Rebuild them from the renamed fields.
+        class_node.instance_attrs.clear()
+        for attr in attributes:
+            fake_node = nodes.EmptyNode()
+            fake_node.parent = class_node
+            fake_node.attrname = attr
+            class_node.instance_attrs[attr] = [fake_node]
+
     replace_args = ", ".join(f"{arg}=None" for arg in attributes)
     field_def = (
         "    {name} = property(lambda self: self[{index:d}], "

--- a/tests/brain/test_named_tuple.py
+++ b/tests/brain/test_named_tuple.py
@@ -115,6 +115,32 @@ class NamedTupleTest(unittest.TestCase):
         self.assertIn("_1", inferred.locals)
         self.assertIn("_2", inferred.locals)
 
+    def test_namedtuple_rename_keywords_instance_attrs(self) -> None:
+        """The instance carries the renamed field, not the name as written.
+
+        https://github.com/pylint-dev/astroid/issues/242
+        """
+        node = builder.extract_node("""
+        from collections import namedtuple
+        Tuple = namedtuple("Tuple", "abc def", rename=True)
+        Tuple(1, 2) #@
+        """)
+        inferred = next(node.infer())
+        self.assertEqual(sorted(inferred.instance_attrs), ["_1", "abc"])
+
+    def test_namedtuple_rename_duplicates_instance_attrs(self) -> None:
+        """Duplicate fields are renamed rather than collapsed on the instance.
+
+        https://github.com/pylint-dev/astroid/issues/242
+        """
+        node = builder.extract_node("""
+        from collections import namedtuple
+        Tuple = namedtuple("Tuple", "abc abc abc", rename=True)
+        Tuple(1, 2, 3) #@
+        """)
+        inferred = next(node.infer())
+        self.assertEqual(sorted(inferred.instance_attrs), ["_1", "_2", "abc"])
+
     def test_namedtuple_rename_uninferable(self) -> None:
         node = builder.extract_node("""
         from collections import namedtuple


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #242.

`infer_func_form` records a namedtuple's field names as written:

```python
    for attr in attributes:
        fake_node = nodes.EmptyNode()
        fake_node.parent = class_node
        fake_node.attrname = attr
        class_node.instance_attrs[attr] = [fake_node]
```

`rename=True` replaces invalid, keyword and duplicate names with `_N`, but that happens
afterwards in `infer_named_tuple`, and only `_fields`, `_replace` and the class body were
rebuilt from the renamed list. `instance_attrs` kept the names as written, so the same
inferred class disagreed with itself for
`namedtuple("Tag", ["id", "def", "a"], rename=True)`:

```
_fields         ('id', '_1', 'a')     # renamed, correct
instance_attrs  ['a', 'def', 'id']    # 'def' is not an attribute of anything
```

Duplicates fared worse: `namedtuple("T", "a a a", rename=True)` writes the same key three
times, so the instance was left with one field instead of three.

In pylint this shows up as a missed error rather than a false one:

```python
from collections import namedtuple

U = namedtuple("U", ["_x", "y"], rename=True)
u = U(1, 2)
print(u._x)
```

At runtime that raises `AttributeError: 'U' object has no attribute '_x'. Did you mean:
'_0'?`. `pylint --disable=all --enable=E` rated the file 10.00/10 and reported nothing;
with this change it reports
`E1101: Instance of 'U' has no '_x' member; maybe '_0'? (no-member)`.

The rebuild is guarded by `tuple(class_node.instance_attrs) != tuple(attributes)`, so the
`rename=False` path is untouched.

Verified: the two new tests fail on the unpatched tree with
`['abc', 'def'] != ['_1', 'abc']` and `['abc'] != ['_1', '_2', 'abc']`, and pass with the
change. `tests/brain/test_named_tuple.py` 25 passed; `tests/brain/`,
`tests/test_inference.py`, `tests/test_regrtest.py` and `tests/test_scoped_nodes.py`
1052 passed, 1 failed — `test_typed_dict_required_and_optional_keys`, which fails the same
way on `main` without this change. `ruff check` and `black --check` clean.
