### PR TITLE
guard AstroidError.__str__ against user text in the message

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,14 @@ What's New in astroid 4.3.1?
 ============================
 Release date: TBA
 
+* Fix a crash when a ``namedtuple`` or ``Enum`` type name or field name
+  contains ``str.format`` markup, as in ``namedtuple("{0}", "abc")``. The name
+  is interpolated into an error message that astroid then reformats, so
+  building the message raised ``IndexError``. Inference now falls back to its
+  default.
+
+  Closes #3199
+
 
 
 What's New in astroid 4.3.0?

--- a/astroid/exceptions.py
+++ b/astroid/exceptions.py
@@ -63,10 +63,14 @@ class AstroidError(Exception):
             setattr(self, key, value)
 
     def __str__(self) -> str:
+        # message is the template itself and may embed interpolated user text
+        # (e.g. a namedtuple typename), so keep it out of the fields and fall
+        # back to it verbatim rather than raising or reinterpreting it.
+        fields = {k: v for k, v in vars(self).items() if k != "message"}
         try:
-            return self.message.format(**vars(self))
-        except ValueError:
-            return self.message  # Return raw message if formatting fails
+            return self.message.format(**fields)
+        except (LookupError, ValueError, AttributeError, TypeError):
+            return self.message
 
 
 class AstroidBuildingError(AstroidError):

--- a/tests/brain/test_named_tuple.py
+++ b/tests/brain/test_named_tuple.py
@@ -218,6 +218,16 @@ class NamedTupleTest(unittest.TestCase):
         inferred = next(node.infer())
         self.assertIs(util.Uninferable, inferred)  # would raise ValueError
 
+    def test_format_placeholder_typename_does_not_crash_inference(self) -> None:
+        """Reported in https://github.com/pylint-dev/astroid/issues/3199 as a crash."""
+        node = builder.extract_node("""
+        from collections import namedtuple
+        Tuple = namedtuple("{0}", "abc")
+        Tuple #@
+        """)
+        inferred = next(node.infer())
+        self.assertIs(util.Uninferable, inferred)  # would raise IndexError
+
     def test_keyword_typename_does_not_crash_inference(self) -> None:
         node = builder.extract_node("""
         from collections import namedtuple


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

AstroidError.__str__ runs self.message.format(**vars(self)), but many astroid errors interpolate untrusted source text into the message first, so an invalid identifier like namedtuple("{0}", "abc") ends up re-read as a str.format template. {0} raises IndexError, {message.foo} raises AttributeError, and a width field such as {message:200000000} builds a huge string, all during inference and none of them caught by the existing except ValueError, so the exception escapes node.infer() and crashes the caller. keeping the self-referential message out of the substitution fields and widening the fallback stops injected braces from crashing or allocating, while the {field!r} message templates still render.

Closes #3199