### PR TITLE
Infer recent dict and list subscript assignments

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3864,10 +3864,7 @@ class Subscript(NodeNG):
             if not self._side_effect_free_assignment_value(current.value):
                 return None
 
-        try:
-            previous = current.previous_sibling()
-        except ParentMissingError:
-            return None
+        previous = current.previous_sibling()
         while previous is not None:
             if isinstance(previous, _base_nodes.MultiLineBlockNode):
                 return None

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3749,6 +3749,74 @@ class Subscript(NodeNG):
         yield self.value
         yield self.slice
 
+    # pylint: disable-next=too-many-return-statements
+    def _infer_adjacent_dict_assignment(self) -> Dict | None:
+        """Return a literal dict stored by the immediately preceding assignment."""
+        if not isinstance(self.value, Name) or not isinstance(self.slice, Const):
+            return None
+        if not isinstance(self.parent, Subscript) or self.parent.value is not self:
+            return None
+        current = self.parent.parent
+        if (
+            not isinstance(current, Assign)
+            or current.targets != [self.parent]
+            or not isinstance(current.value, Const)
+        ):
+            return None
+
+        from astroid.nodes import ClassDef  # pylint: disable=import-outside-toplevel
+
+        if isinstance(current.frame(), ClassDef):
+            # A metaclass can supply an arbitrary mapping for a class namespace.
+            return None
+
+        try:
+            previous = current.previous_sibling()
+        except ParentMissingError:
+            return None
+        if not isinstance(previous, Assign) or len(previous.targets) != 1:
+            return None
+        target = previous.targets[0]
+        replacement = previous.value
+        if not isinstance(target, Subscript) or not (
+            isinstance(replacement, Dict)
+            and all(
+                isinstance(key, Const) and isinstance(value, Const)
+                for key, value in replacement.items
+            )
+        ):
+            return None
+        if (
+            not isinstance(target.value, Name)
+            or target.value.name != self.value.name
+            or not isinstance(target.slice, Const)
+            or type(target.slice.value) is not type(self.slice.value)
+            or target.slice.value != self.slice.value
+        ):
+            return None
+
+        initialization = previous.previous_sibling()
+        if not isinstance(initialization, Assign) or len(initialization.targets) != 1:
+            return None
+        initial_target = initialization.targets[0]
+        if (
+            not isinstance(initial_target, AssignName)
+            or initial_target.name != self.value.name
+            or not isinstance(initialization.value, Dict)
+            or len(initialization.value.items) != 1
+        ):
+            return None
+        initial_key, initial_value = initialization.value.items[0]
+        if (
+            not isinstance(initial_key, Const)
+            or type(initial_key.value) is not type(self.slice.value)
+            or initial_key.value != self.slice.value
+            or not isinstance(initial_value, Const)
+            or initial_value.value is not None
+        ):
+            return None
+        return replacement
+
     def _infer_subscript(
         self, context: InferenceContext | None = None
     ) -> Generator[InferenceResult, None, InferenceErrorInfo | None]:
@@ -3760,6 +3828,13 @@ class Subscript(NodeNG):
         handle each supported index type accordingly.
         """
         from astroid import helpers  # pylint: disable=import-outside-toplevel
+
+        assigned = (
+            self._infer_adjacent_dict_assignment() if self.ctx == Context.Load else None
+        )
+        if assigned is not None:
+            yield from assigned.infer(context)
+            return InferenceErrorInfo(node=self, context=context)
 
         found_one = False
         for value in self.value.infer(context):

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3749,19 +3749,102 @@ class Subscript(NodeNG):
         yield self.value
         yield self.slice
 
+    @staticmethod
+    def _name_rooted_literal_path(
+        node: Subscript,
+    ) -> tuple[Name, tuple[Const, ...]] | None:
+        """Return the name and constant keys in a subscript chain."""
+        keys: list[Const] = []
+        current: NodeNG = node
+        while isinstance(current, Subscript):
+            if not isinstance(current.slice, Const):
+                return None
+            keys.append(current.slice)
+            current = current.value
+        if not isinstance(current, Name):
+            return None
+        return current, tuple(reversed(keys))
+
+    @staticmethod
+    def _side_effect_free_assignment_value(node: NodeNG) -> bool:
+        """Return whether evaluating an assignment value cannot call user code."""
+        if isinstance(node, (Const, Name)):
+            return True
+        if isinstance(node, Dict):
+            return all(
+                key is not None
+                and Subscript._side_effect_free_assignment_value(key)
+                and Subscript._side_effect_free_assignment_value(value)
+                for key, value in node.items
+            )
+        if isinstance(node, (List, Set, Tuple)):
+            return all(
+                Subscript._side_effect_free_assignment_value(element)
+                for element in node.elts
+            )
+        if isinstance(node, IfExp):
+            return (
+                isinstance(node.test, (Const, Name))
+                and Subscript._side_effect_free_assignment_value(node.body)
+                and Subscript._side_effect_free_assignment_value(node.orelse)
+            )
+        return False
+
+    @staticmethod
+    def _path_for_builtin_container(
+        node: Subscript, context: InferenceContext | None
+    ) -> tuple[Dict | List, tuple[Const, ...]] | None:
+        path = Subscript._name_rooted_literal_path(node)
+        if path is None:
+            return None
+        root, keys = path
+        inferred_root = util.safe_infer(root, copy_context(context))
+        if not isinstance(inferred_root, (Dict, List)):
+            return None
+        return inferred_root, keys
+
+    @staticmethod
+    def _same_literal_keys(left: tuple[Const, ...], right: tuple[Const, ...]) -> bool:
+        return len(left) == len(right) and all(
+            type(left_key.value) is type(right_key.value)
+            and left_key.value == right_key.value
+            for left_key, right_key in zip(left, right)
+        )
+
+    @staticmethod
+    def _contains_unsafe_call(
+        statement: NodeNG, context: InferenceContext | None
+    ) -> bool:
+        """Return whether a statement can mutate state while scanning backwards."""
+        from astroid.nodes import FunctionDef  # pylint: disable=import-outside-toplevel
+
+        for call in statement.nodes_of_class(Call):
+            inferred = util.safe_infer(call.func, copy_context(context))
+            if not (
+                isinstance(inferred, FunctionDef)
+                and inferred.qname() == "builtins.print"
+            ):
+                return True
+        return False
+
+    @staticmethod
+    def _is_assignment_target(node: Subscript, assignment: Assign) -> bool:
+        return any(
+            descendant is node
+            for target in assignment.targets
+            for descendant in target.nodes_of_class(Subscript)
+        )
+
     # pylint: disable-next=too-many-return-statements
-    def _infer_adjacent_dict_assignment(self) -> Dict | None:
-        """Return a literal dict stored by the immediately preceding assignment."""
-        if not isinstance(self.value, Name) or not isinstance(self.slice, Const):
+    def _infer_recent_builtin_assignment(
+        self, context: InferenceContext | None
+    ) -> NodeNG | None:
+        """Find the latest safe assignment to this built-in container path."""
+        if self.ctx != Context.Load:
             return None
-        if not isinstance(self.parent, Subscript) or self.parent.value is not self:
-            return None
-        current = self.parent.parent
-        if (
-            not isinstance(current, Assign)
-            or current.targets != [self.parent]
-            or not isinstance(current.value, Const)
-        ):
+        try:
+            current = self.statement()
+        except AstroidError:
             return None
 
         from astroid.nodes import ClassDef  # pylint: disable=import-outside-toplevel
@@ -3770,52 +3853,75 @@ class Subscript(NodeNG):
             # A metaclass can supply an arbitrary mapping for a class namespace.
             return None
 
+        current_path = self._path_for_builtin_container(self, context)
+        if current_path is None:
+            return None
+        current_root, current_keys = current_path
+
+        if isinstance(current, Assign) and self._is_assignment_target(self, current):
+            # Assignment values are evaluated before their targets. Avoid using stale
+            # state if the value can call user code or rebind a name expression.
+            if not self._side_effect_free_assignment_value(current.value):
+                return None
+
         try:
             previous = current.previous_sibling()
         except ParentMissingError:
             return None
-        if not isinstance(previous, Assign) or len(previous.targets) != 1:
-            return None
-        target = previous.targets[0]
-        replacement = previous.value
-        if not isinstance(target, Subscript) or not (
-            isinstance(replacement, Dict)
-            and all(
-                isinstance(key, Const) and isinstance(value, Const)
-                for key, value in replacement.items
-            )
-        ):
-            return None
-        if (
-            not isinstance(target.value, Name)
-            or target.value.name != self.value.name
-            or not isinstance(target.slice, Const)
-            or type(target.slice.value) is not type(self.slice.value)
-            or target.slice.value != self.slice.value
-        ):
-            return None
+        while previous is not None:
+            if isinstance(previous, _base_nodes.MultiLineBlockNode):
+                return None
+            if self._contains_unsafe_call(previous, context):
+                return None
 
-        initialization = previous.previous_sibling()
-        if not isinstance(initialization, Assign) or len(initialization.targets) != 1:
-            return None
-        initial_target = initialization.targets[0]
-        if (
-            not isinstance(initial_target, AssignName)
-            or initial_target.name != self.value.name
-            or not isinstance(initialization.value, Dict)
-            or len(initialization.value.items) != 1
-        ):
-            return None
-        initial_key, initial_value = initialization.value.items[0]
-        if (
-            not isinstance(initial_key, Const)
-            or type(initial_key.value) is not type(self.slice.value)
-            or initial_key.value != self.slice.value
-            or not isinstance(initial_value, Const)
-            or initial_value.value is not None
-        ):
-            return None
-        return replacement
+            targets: tuple[NodeNG, ...] = ()
+            assigned_value: NodeNG | None = None
+            if isinstance(previous, Assign):
+                targets = tuple(previous.targets)
+                assigned_value = previous.value
+            elif isinstance(previous, AnnAssign):
+                targets = (previous.target,)
+                assigned_value = previous.value
+            elif isinstance(previous, (AugAssign, Delete)):
+                targets = (
+                    (previous.target,)
+                    if isinstance(previous, AugAssign)
+                    else tuple(previous.targets)
+                )
+
+            for target in targets:
+                if not isinstance(target, Subscript):
+                    continue
+                target_path = self._path_for_builtin_container(target, context)
+                if target_path is None:
+                    continue
+                target_root, target_keys = target_path
+                if target_root is not current_root:
+                    continue
+
+                common_length = min(len(target_keys), len(current_keys))
+                if not self._same_literal_keys(
+                    target_keys[:common_length], current_keys[:common_length]
+                ):
+                    continue
+                if len(target_keys) < len(current_keys):
+                    # Let normal recursive subscript inference use this ancestor.
+                    return None
+                if len(target_keys) > len(current_keys):
+                    continue
+
+                if (
+                    assigned_value is None
+                    or not self._side_effect_free_assignment_value(assigned_value)
+                ):
+                    return None
+                receiver = util.safe_infer(target.value, copy_context(context))
+                if not isinstance(receiver, (Dict, List)):
+                    return None
+                return assigned_value
+
+            previous = previous.previous_sibling()
+        return None
 
     def _infer_subscript(
         self, context: InferenceContext | None = None
@@ -3829,9 +3935,7 @@ class Subscript(NodeNG):
         """
         from astroid import helpers  # pylint: disable=import-outside-toplevel
 
-        assigned = (
-            self._infer_adjacent_dict_assignment() if self.ctx == Context.Load else None
-        )
+        assigned = self._infer_recent_builtin_assignment(context)
         if assigned is not None:
             yield from assigned.infer(context)
             return InferenceErrorInfo(node=self, context=context)

--- a/doc/whatsnew/fragments/3220.bugfix
+++ b/doc/whatsnew/fragments/3220.bugfix
@@ -1,0 +1,7 @@
+Infer recent constant-key assignments to built-in dictionaries and lists. This
+prevents stale inference from a container literal across reads, writes, deletes,
+aliases, and deeper subscript chains while preserving custom item access
+semantics.
+
+Refs #3220
+Refs pylint-dev/pylint#10050

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7470,10 +7470,25 @@ def test_decimal_inference():
         container[0]["inner"] = 1  #@
         """,
         """
+        container = {"outer": None}
+        container["outer"] = [None]
+        container["outer"][0] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        container["outer"]: dict = {"inner": None}
+        container["outer"]["inner"] = 1  #@
+        """,
+        """
         container = {"first": None}
         container["first"] = {"second": None}
         container["first"]["second"] = {"third": None}
         container["first"]["second"]["third"] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        container["outer"] = {"inner": {"leaf": None}}
+        container["outer"]["inner"]["leaf"] = 1  #@
         """,
     ],
 )
@@ -7483,7 +7498,7 @@ def test_infer_recent_literal_container_assignment(source: str) -> None:
 
     inferred = next(assignment.targets[0].value.infer())
 
-    assert isinstance(inferred, nodes.Dict)
+    assert isinstance(inferred, (nodes.Dict, nodes.List))
 
 
 def test_infer_recent_literal_container_assignment_for_read_and_delete() -> None:
@@ -7585,6 +7600,38 @@ def test_infer_ambiguous_recent_literal_container_assignment() -> None:
         container = {"outer": None}
         container["outer"] = {"leaf": mutate_container()}
         container["outer"]["leaf"] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        if flag:
+            container["outer"] = {"inner": None}
+        container["outer"]["inner"] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        container["outer"] += {"inner": None}
+        container["outer"]["inner"] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        del container["outer"]
+        container["outer"]["inner"] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        key = "outer"
+        container[key] = {"inner": None}
+        container["outer"]["inner"] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        container["other"] = {"inner": None}
+        container["outer"]["inner"] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        container["outer"] = {"inner": value.attribute}
+        container["outer"]["inner"] = 1  #@
         """,
         """
         container = {"outer": None}

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7438,18 +7438,89 @@ def test_decimal_inference():
         module.getattr(node.names[0][0])
 
 
-def test_infer_adjacent_literal_dict_assignment() -> None:
-    """Infer a literal dict assigned to a literal dict's existing slot."""
-    assignment = extract_node("""
-    if __name__ == "__main__":
+@pytest.mark.parametrize(
+    "source",
+    [
+        """
         container = {"outer": None}
         container["outer"] = {"inner": None}
         container["outer"]["inner"] = 1  #@
-    """)
+        """,
+        """
+        container = {"outer": None}
+        container["outer"] = {"inner": None}
+        print(container)
+        container["outer"]["inner"] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        alias = container
+        alias["outer"] = {"inner": None}
+        container["outer"]["inner"] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        alias = container
+        alias["outer"] = {"inner": None}
+        alias["outer"]["inner"] = 1  #@
+        """,
+        """
+        container = [None]
+        container[0] = {"inner": None}
+        container[0]["inner"] = 1  #@
+        """,
+        """
+        container = {"first": None}
+        container["first"] = {"second": None}
+        container["first"]["second"] = {"third": None}
+        container["first"]["second"]["third"] = 1  #@
+        """,
+    ],
+)
+def test_infer_recent_literal_container_assignment(source: str) -> None:
+    """Infer recent constant-key writes to built-in dicts and lists."""
+    assignment = extract_node(source)
 
     inferred = next(assignment.targets[0].value.infer())
 
     assert isinstance(inferred, nodes.Dict)
+
+
+def test_infer_recent_literal_container_assignment_for_read_and_delete() -> None:
+    """Use the latest item assignment for reads and delete receivers."""
+    read = extract_node("""
+    container = {"outer": None}
+    container["outer"] = {"inner": 1}
+    container["outer"]["inner"]  #@
+    """)
+    deleted = extract_node("""
+    container = {"outer": None}
+    container["outer"] = {"inner": 1}
+    del container["outer"]["inner"]  #@
+    """)
+
+    read_receiver = next(read.value.infer())
+    delete_receiver = next(deleted.targets[0].value.infer())
+
+    assert isinstance(read_receiver, nodes.Dict)
+    assert isinstance(delete_receiver, nodes.Dict)
+
+
+def test_infer_ambiguous_recent_literal_container_assignment() -> None:
+    """Preserve every possible value written by an ambiguous assignment."""
+    assignment = extract_node("""
+    def store(flag):
+        container = {"outer": None}
+        container["outer"] = {"inner": None} if flag else None
+        container["outer"]["inner"] = 1  #@
+    """)
+
+    inferred = list(assignment.targets[0].value.infer())
+
+    assert any(isinstance(value, nodes.Dict) for value in inferred)
+    assert any(
+        isinstance(value, nodes.Const) and value.value is None for value in inferred
+    )
 
 
 @pytest.mark.parametrize(
@@ -7479,27 +7550,9 @@ def test_infer_adjacent_literal_dict_assignment() -> None:
         """,
         """
         container = {"outer": None}
-        alias = container
-        alias["outer"] = {"inner": None}
-        container["outer"]["inner"] = 1  #@
-        """,
-        """
-        container = {"outer": None}
         key = "outer"
         container[key] = {"inner": None}
         container[key]["inner"] = 1  #@
-        """,
-        """
-        container = {"outer": None}
-        container["outer"] = {"inner": None}
-        unrelated = 1
-        container["outer"]["inner"] = 1  #@
-        """,
-        """
-        container = {"outer": None}
-        alias = container
-        alias["outer"] = {"inner": None}
-        alias["outer"]["inner"] = 1  #@
         """,
         """
         container = {"outer": None}
@@ -7534,14 +7587,10 @@ def test_infer_adjacent_literal_dict_assignment() -> None:
         container["outer"]["leaf"] = 1  #@
         """,
         """
-        container = {"outer": None, "outer": Reentrant()}
+        container = {"outer": None}
         container["outer"] = {"leaf": None}
+        mutate(container)
         container["outer"]["leaf"] = 1  #@
-        """,
-        """
-        container = [None]
-        container[0] = {"leaf": None}
-        container[0]["leaf"] = 1  #@
         """,
         """
         class DiscardingMapping:
@@ -7569,8 +7618,8 @@ def test_infer_adjacent_literal_dict_assignment() -> None:
         """,
     ],
 )
-def test_do_not_infer_unsafe_adjacent_subscript_assignment(source: str) -> None:
-    """Do not assume custom item or property assignment stores its value."""
+def test_do_not_infer_unsafe_recent_subscript_assignment(source: str) -> None:
+    """Do not track writes through custom containers or side effects."""
     assignment = extract_node(source)
 
     inferred = next(assignment.targets[0].value.infer())

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7436,3 +7436,155 @@ def test_decimal_inference():
     for node in extract_node(code):
         module = node.do_import_module(node.modname)
         module.getattr(node.names[0][0])
+
+
+def test_infer_adjacent_literal_dict_assignment() -> None:
+    """Infer a literal dict assigned to a literal dict's existing slot."""
+    assignment = extract_node("""
+    if __name__ == "__main__":
+        container = {"outer": None}
+        container["outer"] = {"inner": None}
+        container["outer"]["inner"] = 1  #@
+    """)
+
+    inferred = next(assignment.targets[0].value.infer())
+
+    assert isinstance(inferred, nodes.Dict)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        """
+        class DiscardingMapping:
+            def __getitem__(self, key):
+                return None
+
+            def __setitem__(self, key, value):
+                pass
+
+        container = DiscardingMapping()
+        container["outer"] = {"inner": None}
+        container["outer"]["inner"] = 1  #@
+        """,
+        """
+        class Holder:
+            @property
+            def mapping(self):
+                return {"outer": None}
+
+        holder = Holder()
+        holder.mapping["outer"] = {"inner": None}
+        holder.mapping["outer"]["inner"] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        alias = container
+        alias["outer"] = {"inner": None}
+        container["outer"]["inner"] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        key = "outer"
+        container[key] = {"inner": None}
+        container[key]["inner"] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        container["outer"] = {"inner": None}
+        unrelated = 1
+        container["outer"]["inner"] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        alias = container
+        alias["outer"] = {"inner": None}
+        alias["outer"]["inner"] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        container["outer"] = container = {"outer": None}
+        container["outer"]["inner"] = 1  #@
+        """,
+        """
+        class DiscardingMapping:
+            def __getitem__(self, key):
+                return None
+
+            def __setitem__(self, key, value):
+                pass
+
+        container = {"outer": DiscardingMapping()}
+        container["outer"]["inner"] = {"key": None}
+        container["outer"]["inner"]["key"] = 1  #@
+        """,
+        """
+        container = {"outer": None}
+        container["outer"] = {"leaf": None}
+        container["outer"]["leaf"] = (container := {"outer": None})  #@
+        """,
+        """
+        container = {"outer": None}
+        container["outer"] = {"leaf": None}
+        container["outer"]["leaf"] = container.clear()  #@
+        """,
+        """
+        container = {"outer": None}
+        container["outer"] = {"leaf": mutate_container()}
+        container["outer"]["leaf"] = 1  #@
+        """,
+        """
+        container = {"outer": None, "outer": Reentrant()}
+        container["outer"] = {"leaf": None}
+        container["outer"]["leaf"] = 1  #@
+        """,
+        """
+        container = [None]
+        container[0] = {"leaf": None}
+        container[0]["leaf"] = 1  #@
+        """,
+        """
+        class DiscardingMapping:
+            def __getitem__(self, key):
+                return None
+
+            def __setitem__(self, key, value):
+                pass
+
+        class Namespace(dict):
+            def __setitem__(self, key, value):
+                if key == "container":
+                    value = DiscardingMapping()
+                super().__setitem__(key, value)
+
+        class Meta(type):
+            @classmethod
+            def __prepare__(mcs, name, bases):
+                return Namespace()
+
+        class Container(metaclass=Meta):
+            container = {"outer": None}
+            container["outer"] = {"leaf": None}
+            container["outer"]["leaf"] = 1  #@
+        """,
+    ],
+)
+def test_do_not_infer_unsafe_adjacent_subscript_assignment(source: str) -> None:
+    """Do not assume custom item or property assignment stores its value."""
+    assignment = extract_node(source)
+
+    inferred = next(assignment.targets[0].value.infer())
+
+    assert isinstance(inferred, nodes.Const)
+    assert inferred.value is None
+
+
+def test_infer_detached_subscript() -> None:
+    """An otherwise inferable subscript can be detached from its statement."""
+    subscript = extract_node("[1][0]")
+    subscript.parent = subscript.root()
+
+    inferred = next(subscript.infer())
+
+    assert isinstance(inferred, nodes.Const)
+    assert inferred.value == 1


### PR DESCRIPTION
## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Description

Track the latest safe constant-key write to a name-rooted built-in dict or list within the same statement block. Subscript inference now uses that value for reads, writes, deletes, aliases, and deeper chains instead of returning the stale value from the original container literal.

The scan stops at dynamic keys, custom containers or properties, class namespaces, control-flow boundaries, and expressions that can call user code. Ambiguous assignments retain every inferred possibility rather than choosing one.

This covers the additional boundary cases added to pylint-dev/pylint#11255.

Refs pylint-dev/pylint#10050.

Implementation and tests were developed with OpenAI Codex assistance; I reviewed the inference behavior and verification results.

## Verification

- tests/test_inference.py: 483 passed, 2 skipped, 10 xfailed
- focused new inference cases: 19 passed
- changed-file pre-commit: Ruff, Black, Pylint, mypy, and repository hooks passed
- downstream Pylint functional case: all six newly documented false positives are removed
- full Astroid suite: 2,126 passed, 25 skipped, 15 xfailed; the remaining 9 NumPy/Pydantic/macOS failures reproduce unchanged on the parent commit
