### PR TITLE
Preserve sequence length with ambiguous elements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,12 @@ What's New in astroid 4.4.0?
 ============================
 Release date: TBA
 
+* Preserve the length of inferred list and tuple concatenations when an element
+  has multiple possible values. The element is now represented as unknown
+  instead of being expanded into multiple sequence items.
+
+  Closes pylint-dev/pylint#2621
+
 * Fix inference of the attributes of a ``namedtuple`` created with
   ``rename=True``. The renamed fields were applied to ``_fields`` and to the
   class body, but the instance kept the field names as written, so an instance

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -262,18 +262,15 @@ def _multiply_seq_by_int(
     return node
 
 
-def _filter_uninferable_nodes(
+def _infer_sequence_elements(
     elts: Sequence[InferenceResult], context: InferenceContext
 ) -> Iterator[SuccessfulInferenceResult]:
     for elt in elts:
-        if isinstance(elt, util.UninferableBase):
+        inferred = util.safe_infer(elt, context)
+        if inferred is None or isinstance(inferred, util.UninferableBase):
             yield node_classes.UNATTACHED_UNKNOWN
         else:
-            for inferred in elt.infer(context):
-                if not isinstance(inferred, util.UninferableBase):
-                    yield inferred
-                else:
-                    yield node_classes.UNATTACHED_UNKNOWN
+            yield inferred
 
 
 @decorators.yes_if_nothing_inferred
@@ -304,8 +301,8 @@ def tl_infer_binary_op(
         node = self.__class__(parent=opnode)
         node.elts = list(
             itertools.chain(
-                _filter_uninferable_nodes(self.elts, context),
-                _filter_uninferable_nodes(other.elts, context),
+                _infer_sequence_elements(self.elts, context),
+                _infer_sequence_elements(other.elts, context),
             )
         )
         yield node

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1249,6 +1249,62 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual(inferred[0].elts[0].value, 1)
         self.assertEqual(inferred[0].elts[1].value, 2)
 
+    def test_binary_op_tuple_add_preserves_ambiguous_element(self) -> None:
+        node = extract_node("""
+        def choose():
+            value = 1
+            if value < 0:
+                value = -value
+            return value
+
+        (0, choose()) + (2,) #@
+        """)
+
+        inferred = next(node.infer())
+
+        self.assertIsInstance(inferred, nodes.Tuple)
+        self.assertEqual(len(inferred.elts), 3)
+        self.assertIsInstance(inferred.elts[1], nodes.Unknown)
+
+    def test_binary_op_sequence_add_preserves_ambiguous_edge_elements(self) -> None:
+        expressions = extract_node("""
+        def choose():
+            value = 1
+            if value < 0:
+                value = -value
+            return value
+
+        (choose(), 1) + (2, choose()) #@
+        [choose(), 1] + [2, choose()] #@
+        """)
+
+        for expression, sequence_type in zip(expressions, (nodes.Tuple, nodes.List)):
+            with self.subTest(sequence_type=sequence_type):
+                inferred = next(expression.infer())
+
+                self.assertIsInstance(inferred, sequence_type)
+                self.assertEqual(len(inferred.elts), 4)
+                self.assertIsInstance(inferred.elts[0], nodes.Unknown)
+                self.assertEqual(inferred.elts[1].value, 1)
+                self.assertEqual(inferred.elts[2].value, 2)
+                self.assertIsInstance(inferred.elts[3], nodes.Unknown)
+
+    def test_binary_op_tuple_add_preserves_uninferable_elements(self) -> None:
+        node = extract_node("""
+        from missing import Unknown
+
+        (Unknown, 1) + (2, Unknown) #@
+        """)
+
+        inferred = next(node.infer())
+
+        self.assertIsInstance(inferred, nodes.Tuple)
+        self.assertEqual(len(inferred.elts), 4)
+        self.assertIsInstance(inferred.elts[0], nodes.Unknown)
+        self.assertEqual(inferred.elts[1].value, 1)
+        self.assertEqual(inferred.elts[2].value, 2)
+        self.assertIsInstance(inferred.elts[3], nodes.Unknown)
+
     def test_binary_op_custom_class(self) -> None:
         code = """
         class myarray:


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

Tuple and list concatenation expanded an element with multiple inferred values into multiple sequence items. This produced the wrong sequence length and caused downstream false positives when unpacking.

Each source element now contributes exactly one result. A unique inferred value stays precise, while an ambiguous or uninferable value becomes an unknown element.

Closes pylint-dev/pylint#2621

## Verification

- Full test suite: 2078 passed, 66 skipped, 15 xfailed
- Inference tests: 462 passed, 7 skipped, 10 xfailed
- Ruff, Black, mypy, Pylint, and diff checks passed
- The downstream Pylint reproducer no longer reports unbalanced-tuple-unpacking

The complete pre-commit command could not initialize its copyright hook because git fetch could not connect to github.com on port 443. The corresponding local checks above passed.