### PR TITLE
Keep the annotations of *args and **kwargs in as_string output

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -841,7 +841,7 @@ class Arguments(
                 )
             )
         if self.vararg:
-            result.append(f"*{self.vararg}")
+            result.append(_format_starred_arg("*", self.vararg, self.varargannotation))
         if self.kwonlyargs:
             if not self.vararg:
                 result.append("*")
@@ -854,7 +854,7 @@ class Arguments(
                 )
             )
         if self.kwarg:
-            result.append(f"**{self.kwarg}")
+            result.append(_format_starred_arg("**", self.kwarg, self.kwargannotation))
         return ", ".join(result)
 
     def _get_arguments_data(
@@ -1047,6 +1047,13 @@ def _find_arg(argname, args):
         if arg.name == argname:
             return i, arg
     return None, None
+
+
+def _format_starred_arg(prefix: str, name: str, annotation: NodeNG | None) -> str:
+    """Format a ``*args``/``**kwargs`` argument with its annotation, if any."""
+    if annotation is None:
+        return f"{prefix}{name}"
+    return f"{prefix}{name}: {annotation.as_string()}"
 
 
 def _format_args(

--- a/doc/whatsnew/fragments/3222.breaking
+++ b/doc/whatsnew/fragments/3222.breaking
@@ -1,0 +1,10 @@
+``as_string`` now renders the annotations of ``*args`` and ``**kwargs``.
+``Arguments.format_args`` built those two parameters from their names alone, so
+``def func(*args: str, **kwargs: float)`` came back as
+``def func(*args, **kwargs)`` even though ``varargannotation`` and
+``kwargannotation`` were set on the node. Positional and keyword-only
+parameters already rendered theirs. A PEP 646 ``def func(*args: *Ts)`` is
+covered as well. Code that compares or reparses ``as_string`` output for such
+signatures will see the annotations.
+
+Refs #3222

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -105,6 +105,22 @@ class AsStringTest(resources.SysPathSetup, unittest.TestCase):
         ast = abuilder.string_build("raise_string(*args, **kwargs)").body[0]
         self.assertEqual(ast.as_string(), "raise_string(*args, **kwargs)")
 
+    def test_annotated_varargs_kwargs_as_string(self) -> None:
+        """The annotations of ``*args`` and ``**kwargs`` are kept."""
+        func = abuilder.string_build(
+            "def func(a: int, *args: str, b: bool = True, **kwargs: float): pass"
+        ).body[0]
+        self.assertEqual(
+            func.args.format_args(),
+            "a: int, *args: str, b: bool = True, **kwargs: float",
+        )
+
+    @pytest.mark.skipif(not PY311_PLUS, reason="Uses PEP 646 syntax added in 3.11")
+    def test_unpacked_varargs_annotation_as_string(self) -> None:
+        """A PEP 646 unpacked annotation on ``*args`` is kept."""
+        func = abuilder.string_build("def func(*args: *Ts): pass").body[0]
+        self.assertEqual(func.args.format_args(), "*args: *Ts")
+
     @pytest.mark.skipif(PY314_PLUS, reason="return in finally is now a syntax error")
     def test_module_as_string_pre_3_14(self) -> None:
         """Check as_string on a whole module prepared to be returned identically for py < 3.14."""


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`Arguments.format_args` rendered `*args` and `**kwargs` from their names alone, so annotations were dropped:

```python
>>> extract_node("def f(a: int, *args: str, **kw: float): pass").as_string()
"def f(a, *args, **kw):\n    pass"
```

They are on the node all along (`varargannotation`, `kwargannotation`), and positional and keyword-only parameters already render theirs. A PEP 646 `*args: *Ts` is covered too, since `Starred.as_string()` emits the star.

Two tests added. `pytest tests/` passes apart from four failures that also fail on an unmodified checkout here.