### PR TITLE
use separator-aware containment check in module_in_path

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,11 @@ What's New in astroid 4.4.0?
 ============================
 Release date: TBA
 
+* ``modutils.module_in_path`` no longer reports a module as living under a
+  directory when its path only shares a leading name with that directory, such
+  as a module in ``proj_extra`` matching the path ``proj``. It now uses the same
+  separator-aware containment check as ``_get_relative_base_path``.
+
 * Fix inference of the attributes of a ``namedtuple`` created with
   ``rename=True``. The renamed fields were applied to ``_fields`` and to the
   class body, but the instance kept the field names as written, so an instance

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -544,9 +544,9 @@ def module_in_path(modname: str, path: str | Iterable[str]) -> bool:
     filename = _normalize_path(filename)
 
     if isinstance(path, str):
-        return filename.startswith(_cache_normalize_path(path))
+        return _is_subpath(filename, _cache_normalize_path(path))
 
-    return any(filename.startswith(_cache_normalize_path(entry)) for entry in path)
+    return any(_is_subpath(filename, _cache_normalize_path(entry)) for entry in path)
 
 
 def is_relative(modname: str, from_file: str) -> bool:

--- a/tests/test_modutils.py
+++ b/tests/test_modutils.py
@@ -450,6 +450,23 @@ class ModuleInPathTest(resources.SysPathSetup, unittest.TestCase):
         assert not modutils.module_in_path("etree", datadir)
         assert not modutils.module_in_path("astroid", datadir)
 
+    def test_sibling_prefix_not_in_path(self) -> None:
+        # A module living in a directory whose name merely shares a prefix with
+        # the allowed path is not "in" that path.
+        with tempfile.TemporaryDirectory() as root:
+            allowed = os.path.join(root, "proj")
+            sibling = os.path.join(root, "proj_extra")
+            os.mkdir(allowed)
+            os.mkdir(sibling)
+            with open(os.path.join(sibling, "sibling_mod.py"), "w", encoding="utf-8"):
+                pass
+            sys.path.insert(0, sibling)
+            try:
+                assert not modutils.module_in_path("sibling_mod", allowed)
+                assert not modutils.module_in_path("sibling_mod", (allowed,))
+            finally:
+                sys.path.remove(sibling)
+
 
 class IsRelativeTest(unittest.TestCase):
     def test_known_values_is_relative_1(self) -> None:


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

module_in_path decides whether a resolved module file lives under a given path with filename.startswith on the normalized path, which has no separator boundary, so a module in a sibling directory that only shares a leading name (a file under proj_extra checked against the path proj) is reported as inside proj. the module already ships _is_subpath, the separator-aware containment check _get_relative_base_path uses; both the str and iterable branches of module_in_path now route through it so a prefix-only match no longer counts as containment. regression added in tests/test_modutils.py.