### PR TITLE
Infer pathlib.Path / str (and str / Path) as a Path

### DIFF
--- a/astroid/brain/brain_pathlib.py
+++ b/astroid/brain/brain_pathlib.py
@@ -47,9 +47,42 @@ def infer_parents_subscript(
     raise UseInferenceDefault
 
 
+def _looks_like_path_binop(node: nodes.BinOp) -> bool:
+    """Return True if a ``/`` BinOp has a pathlib path operand."""
+    if node.op != "/":
+        return False
+    for operand in (node.left, node.right):
+        try:
+            for value in operand.infer():
+                if isinstance(value, bases.UninferableBase):
+                    continue
+                if (
+                    isinstance(value, bases.Instance)
+                    and isinstance(value._proxied, nodes.ClassDef)
+                    and value._proxied.qname().startswith("pathlib.")
+                ):
+                    return True
+        except (InferenceError, StopIteration):
+            continue
+    return False
+
+
+def infer_path_binop(
+    binop_node: nodes.BinOp, ctx: context.InferenceContext | None = None
+) -> Iterator[bases.Instance]:
+    """Infer ``Path / X`` and ``X / Path`` as a new pathlib path."""
+    path_cls = next(_extract_single_node(PATH_TEMPLATE).infer())
+    return iter([path_cls.instantiate_class()])
+
+
 def register(manager: AstroidManager) -> None:
     manager.register_transform(
         nodes.Subscript,
         inference_tip(infer_parents_subscript),
         _looks_like_parents_subscript,
+    )
+    manager.register_transform(
+        nodes.BinOp,
+        inference_tip(infer_path_binop),
+        _looks_like_path_binop,
     )

--- a/tests/brain/test_pathlib.py
+++ b/tests/brain/test_pathlib.py
@@ -73,3 +73,55 @@ def test_inference_parents_subscript_not_path() -> None:
     inferred = name_node.inferred()
     assert len(inferred) == 1
     assert inferred[0] is Uninferable
+
+
+def test_inference_path_truediv() -> None:
+    """Test inference of ``Path / X`` as a pathlib path."""
+    node = astroid.extract_node("""
+    from pathlib import Path
+
+    Path('/tmp') / 'sub'  #@
+    """)
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], bases.Instance)
+    assert inferred[0].qname() == "pathlib.Path"
+
+
+def test_inference_path_rtruediv() -> None:
+    """Test inference of ``X / Path`` as a pathlib path."""
+    node = astroid.extract_node("""
+    from pathlib import Path
+
+    'sub' / Path('/tmp')  #@
+    """)
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], bases.Instance)
+    assert inferred[0].qname() == "pathlib.Path"
+
+
+def test_inference_path_truediv_attribute_access() -> None:
+    """Test that methods of a slash-joined path resolve to pathlib."""
+    node = astroid.extract_node("""
+    from pathlib import Path
+
+    path = Path('/tmp') / 'file.txt'
+    path.read_text  #@
+    """)
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], bases.BoundMethod)
+    assert inferred[0].root().name == "pathlib"
+
+
+def test_inference_binop_not_path() -> None:
+    """Test inference of non-path ``/`` BinOps is unaffected."""
+    node = astroid.extract_node("""
+    a = 10
+    b = 2
+    a / b  #@
+    """)
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert inferred[0].value == 5


### PR DESCRIPTION
Closes pylint-dev/pylint#11202

## Problem

`pathlib` paths support the `/` operator — `Path('/tmp') / 'sub'` returns a new `Path`. astroid did not infer this `BinOp`, so the receiver of a method call on a slash-joined path resolved to `Uninferable`:

```python
(Path('/') / 'tmp').read_text()   # receiver inferred as Uninferable
p: Path = Path('/') / 'tmp'       # same even with a type annotation
p.read_text()
```

Because the receiver was `Uninferable`, pylint diagnostics that depend on the method's type — e.g. `unspecified-encoding` (W1514) on `read_text`/`write_text`/`open` — were silently skipped, while the equivalent direct `Path('/tmp').read_text()` was flagged.

## Change

Add a brain transform in `brain_pathlib.py` (mirroring the existing `Path.parents[i]` handling) that infers a `/` `BinOp` with a pathlib path operand as a new `pathlib.Path` instance:

- `Path('/') / 'tmp'` → `pathlib.Path`
- `'tmp' / Path('/')` → `pathlib.Path` (pathlib also supports the reflected operator)

Non-path `/` BinOps (e.g. `10 / 2`) are untouched, as is any other existing inference.

## Verification

- New tests in `tests/brain/test_pathlib.py` cover both operand orders, method resolution on a slash-joined path, and that plain division is unaffected.
- `tests/brain/` + `tests/test_inference.py`: **848 passed** (1 pre-existing env failure unrelated to this change).
- End-to-end with pylint: the issue's repro now flags all four `read_text()` calls with W1514 (previously only the two direct ones).
- pylint `tests/test_functional.py`: failure set is **identical** with and without this change (14 pre-existing Python 3.14 env failures), i.e. zero regressions.

---

*AI-assistance disclosure: this change was developed with the assistance of an AI coding agent (Codebuff).*
