### PR TITLE
Bump astroid to 4.3.1, update changelog

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -50,9 +50,9 @@ Contributors
 - Antonio <antonio@zoftko.com>
 - Fridayworks <aifriday700@gmail.com>
 - Akhil Kamat <akhil.kamat@gmail.com>
+- KALI 834X <kali834x@gmail.com>
 - Tim Martin <tim@asymptotic.co.uk>
 - Phil Schaf <flying-sheep@web.de>
-- KALI 834X <kali834x@gmail.com>
 - Alex Hall <alex.mojaki@gmail.com>
 - Vincent Gao <gaobing1230@gmail.com>
 - Samarth D N <dnsam550@gmail.com>
@@ -245,6 +245,7 @@ Contributors
 - Alexander Scheel <alexander.m.scheel@gmail.com>
 - Alexander Presnyakov <flagist0@gmail.com>
 - Ahmed Azzaoui <ahmed.azzaoui@engie.com>
+- Florian Meyer <fflorian.meyer@outlook.com>
 
 Co-Author
 ---------

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,9 +9,15 @@ Release date: TBA
 
 
 
-What's New in astroid 4.3.1?
+What's New in astroid 4.3.2?
 ============================
 Release date: TBA
+
+
+
+What's New in astroid 4.3.1?
+============================
+Release date: 2026-08-17
 
 * Fix inference of the attributes of a ``namedtuple`` created with
   ``rename=True``. The renamed fields were applied to ``_fields`` and to the

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -2,5 +2,5 @@
 # For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 
-__version__ = "4.3.0"
+__version__ = "4.3.1"
 version = __version__

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/astroid"
 
 [version]
-current = "4.3.0"
+current = "4.3.1"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's New in astroid 4.3.1?
============================
Release date: 2026-08-17

* Fix inference of the attributes of a ``namedtuple`` created with
  ``rename=True``. The renamed fields were applied to ``_fields`` and to the
  class body, but the instance kept the field names as written, so an instance
  of ``namedtuple("Tuple", "abc def", rename=True)`` was inferred as having a
  ``def`` attribute instead of ``_1``, and duplicate field names collapsed into
  a single attribute instead of being renamed.

  Closes #242