### PR TITLE
don't re-format inference error messages that embed str.format fields

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,15 @@ Release date: TBA
 
   Refs pylint-dev/pylint#11229
 
+* Do not crash when an inference error message embeds analyzed source that
+  looks like a ``str.format`` replacement field. A ``namedtuple`` or ``Enum``
+  name such as ``"{0}"`` or ``"{foo}"`` ended up in the exception message
+  verbatim and was re-interpreted as a format field by ``AstroidError.__str__``,
+  raising ``IndexError``/``KeyError``/``AttributeError`` instead of falling back
+  to the raw message.
+
+  Closes #3199
+
 
 
 What's New in astroid 4.3.2?

--- a/astroid/exceptions.py
+++ b/astroid/exceptions.py
@@ -65,8 +65,12 @@ class AstroidError(Exception):
     def __str__(self) -> str:
         try:
             return self.message.format(**vars(self))
-        except ValueError:
-            return self.message  # Return raw message if formatting fails
+        except (ValueError, IndexError, KeyError, AttributeError):
+            # A message that already embeds analyzed source is not a valid
+            # format template. A namedtuple/enum name such as "{0}" or "{foo}"
+            # reaches here verbatim, so str.format treats it as a replacement
+            # field and raises. Fall back to the raw message in that case.
+            return self.message
 
 
 class AstroidBuildingError(AstroidError):

--- a/tests/brain/test_named_tuple.py
+++ b/tests/brain/test_named_tuple.py
@@ -253,6 +253,26 @@ class NamedTupleTest(unittest.TestCase):
         inferred = next(node.infer())
         self.assertIs(util.Uninferable, inferred)  # would raise ValueError
 
+    def test_format_field_typename_does_not_crash_inference(self) -> None:
+        node = builder.extract_node("""
+        from collections import namedtuple
+        Tuple = namedtuple("{0}", "abc")
+        Tuple #@
+        """)
+        inferred = next(node.infer())
+        # The rejected typename is embedded in the error message; it must not be
+        # re-interpreted as a str.format replacement field (would raise IndexError).
+        self.assertIs(util.Uninferable, inferred)
+
+    def test_format_field_fieldname_does_not_crash_inference(self) -> None:
+        node = builder.extract_node("""
+        from collections import namedtuple
+        Tuple = namedtuple("Tuple", "{a}")
+        Tuple #@
+        """)
+        inferred = next(node.infer())
+        self.assertIs(util.Uninferable, inferred)
+
     def test_typeerror_does_not_crash_inference(self) -> None:
         node = builder.extract_node("""
         from collections import namedtuple


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

**Inference-error messages that embed analyzed source get re-run through str.format**

`AstroidError.__str__` treats `self.message` as a format template and calls `self.message.format(**vars(self))`. Several brain helpers build the message with an f-string that already splices in a name from the analyzed code, so `namedtuple("{0}", "")` or `namedtuple("T", "{a}")` leaves a stray `{0}`/`{a}` in the message; the second `.format` reads it as a replacement field and raises `IndexError`/`KeyError`/`AttributeError`, none of which the `except ValueError` caught, so inferring that snippet crashes. Widened the fallback to cover those so the raw message is returned instead.

Closes #3199
