### PR TITLE
Make xfail strict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ ini_options.addopts = '-m "not acceptance"'
 ini_options.python_files = [ "*test_*.py" ]
 ini_options.testpaths = [ "tests" ]
 ini_options.filterwarnings = "error"
+ini_options.xfail_strict = true
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
## Type of Changes

|     | Type              |
| --- | ----------------- |
| ✓   | :hammer: Refactor |

## Description

Sets `xfail_strict = true` for pytest.

Right now an `xfail` that starts passing is silently absorbed: pytest reports
`XPASS`, the suite stays green, and the mark stays in the file. So the test goes
on being advertised as expected-to-fail long after it works, and the next person
to read it has no reason to doubt that. With `xfail_strict` an unexpected pass
fails the suite, which is the only moment anyone would think to delete the mark.

This came up on #3211, where two `xfail`s were added for known holes. Non-strict,
they would have outlived the fixes.

No test needed changing. All 15 `xfail`s still fail, on 3.13 and on 3.14:

```
2080 passed, 61 skipped, 15 xfailed     # 3.13
2050 passed, 90 skipped, 15 xfailed     # 3.14
```

I can only check Linux locally, so CI is the real test for the two marks whose
outcome could plausibly differ elsewhere --- `c_buffer` in
`tests/brain/test_ctypes.py` and `test_factory_methods_inside_binary_operation`.
If either turns up as `XPASS` on Windows or PyPy the fix is a condition on the
mark, not a revert.

Noticed while here, not touched: the reason on
`test_factory_methods_inside_binary_operation` still says "cannot be inferred on
Python 3.8", which astroid has not supported for a while. The test does still
fail, so the mark is right and only the reason is stale.