### PR TITLE
escape f-string literal parts so as_string round-trips

### DIFF
--- a/astroid/nodes/as_string.py
+++ b/astroid/nodes/as_string.py
@@ -323,13 +323,13 @@ class AsStringVisitor:
         formatted = "".join(
             value.accept(self)
             for value in node.values
-            if type(value).__name__ != "Const"
+            if not isinstance(value, nodes.Const)
         )
         quote = "'" if "'" not in formatted else '"'
         string = "".join(
             (
                 _escaped_fstring_literal(value.value, quote)
-                if type(value).__name__ == "Const"
+                if isinstance(value, nodes.Const)
                 else value.accept(self)
             )
             for value in node.values

--- a/astroid/nodes/as_string.py
+++ b/astroid/nodes/as_string.py
@@ -317,18 +317,22 @@ class AsStringVisitor:
             if quote not in string:
                 return "f" + quote + string + quote
 
-        # Every candidate quote is present in the body. Re-escape the literal
-        # parts against a quote absent from the {expression} parts (which cannot
-        # hold a backslash) so the f-string cannot terminate early.
+        # Every candidate quote is present in the body. Pick a delimiter absent
+        # from the {expression} parts (which cannot hold a backslash) and
+        # escape it in the literal parts so the f-string cannot terminate early.
         formatted = "".join(
             value.accept(self)
             for value in node.values
             if not isinstance(value, nodes.Const)
         )
-        quote = "'" if "'" not in formatted else '"'
+        quote = next(
+            (q for q in ("'", '"', "'''", '"""') if q not in formatted),
+            # Unrepresentable: every delimiter occurs in an expression part.
+            "'''",
+        )
         string = "".join(
             (
-                _escaped_fstring_literal(value.value, quote)
+                _escaped_fstring_literal(value.value, quote[0])
                 if isinstance(value, nodes.Const)
                 else value.accept(self)
             )

--- a/astroid/nodes/as_string.py
+++ b/astroid/nodes/as_string.py
@@ -312,11 +312,28 @@ class AsStringVisitor:
 
         # Try to find surrounding quotes that don't appear at all in the string.
         # Because the formatted values inside {} can't contain backslash (\)
-        # using a triple quote is sometimes necessary
+        # using a triple quote is sometimes necessary.
         for quote in ("'", '"', '"""', "'''"):
             if quote not in string:
-                break
+                return "f" + quote + string + quote
 
+        # Every candidate quote is present in the body. Re-escape the literal
+        # parts against a quote absent from the {expression} parts (which cannot
+        # hold a backslash) so the f-string cannot terminate early.
+        formatted = "".join(
+            value.accept(self)
+            for value in node.values
+            if type(value).__name__ != "Const"
+        )
+        quote = "'" if "'" not in formatted else '"'
+        string = "".join(
+            (
+                _escaped_fstring_literal(value.value, quote)
+                if type(value).__name__ == "Const"
+                else value.accept(self)
+            )
+            for value in node.values
+        )
         return "f" + quote + string + quote
 
     def visit_formattedvalue(self, node: nodes.FormattedValue) -> str:
@@ -728,6 +745,19 @@ class AsStringVisitor:
 
     def visit_unknown(self, node: nodes.Unknown) -> str:
         return str(node)
+
+
+def _escaped_fstring_literal(value: str, quote: str) -> str:
+    """Return the inner text of an f-string literal part delimited by *quote*
+    (a single quote character), escaping *quote* and doubling braces."""
+    literal = repr(value)
+    if literal[0] == quote:
+        body = literal[1:-1]
+    else:
+        # repr escapes only its own quote; unescape it and escape *quote*.
+        body = literal[1:-1].replace("\\" + literal[0], literal[0])
+        body = body.replace(quote, "\\" + quote)
+    return body.replace("{", "{{").replace("}", "}}")
 
 
 def _import_string(names: list[tuple[str, str | None]]) -> str:

--- a/doc/whatsnew/fragments/3235.bugfix
+++ b/doc/whatsnew/fragments/3235.bugfix
@@ -1,5 +1,5 @@
-``as_string()`` no longer renders an f-string wrapped in a quote that also
-appears in its body. Such an f-string terminated early and either failed to
+``as_string()`` no longer renders an f-string whose delimiter reappears
+unescaped in its body. Such an f-string terminated early and either failed to
 parse or reparsed to a different expression, which matters because
 ``brain_dataclasses`` and ``brain_namedtuple_enum`` reparse ``as_string()``
 output.

--- a/doc/whatsnew/fragments/3235.bugfix
+++ b/doc/whatsnew/fragments/3235.bugfix
@@ -1,0 +1,7 @@
+``as_string()`` no longer renders an f-string wrapped in a quote that also
+appears in its body. Such an f-string terminated early and either failed to
+parse or reparsed to a different expression, which matters because
+``brain_dataclasses`` and ``brain_namedtuple_enum`` reparse ``as_string()``
+output.
+
+Refs #3235

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1853,6 +1853,22 @@ def test_parse_fstring_debug_mode() -> None:
     assert node.as_string() == "f'3={3!r}'"
 
 
+def test_fstring_as_string_roundtrip_with_mixed_quotes() -> None:
+    # Adjacent f-strings merge into one JoinedStr whose parts together contain
+    # every candidate quote style, so as_string() must not pick a delimiter that
+    # reappears in the body: that would terminate the f-string early and let the
+    # tail reparse as a different expression.
+    node = astroid.extract_node("f'\"\"\"{v}' f\"'''\"")
+    assert isinstance(node, nodes.JoinedStr)
+    reparsed = astroid.extract_node(node.as_string())
+    assert isinstance(reparsed, nodes.JoinedStr)
+    assert reparsed.as_string() == node.as_string()
+
+    # A body crafted to inject an operator must still round-trip to an f-string.
+    injected = astroid.extract_node("f\"A'''+BAD+'''B{v}\" f'\"\"\"'")
+    assert isinstance(astroid.extract_node(injected.as_string()), nodes.JoinedStr)
+
+
 def test_parse_type_comments_with_proper_parent() -> None:
     code = """
     class D: #@

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1868,6 +1868,14 @@ def test_fstring_as_string_roundtrip_with_mixed_quotes() -> None:
     injected = astroid.extract_node("f\"A'''+BAD+'''B{v}\" f'\"\"\"'")
     assert isinstance(astroid.extract_node(injected.as_string()), nodes.JoinedStr)
 
+    # Both single-character quotes occur inside the expression part, so the
+    # fallback must move on to a triple-quoted delimiter.
+    mixed = astroid.extract_node("f\"'''\" f'\"\"\"' f'''{d[\"it's\"]}'''")
+    assert isinstance(mixed, nodes.JoinedStr)
+    reparsed = astroid.extract_node(mixed.as_string())
+    assert isinstance(reparsed, nodes.JoinedStr)
+    assert reparsed.as_string() == mixed.as_string()
+
 
 def test_parse_type_comments_with_proper_parent() -> None:
     code = """


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`AsStringVisitor.visit_joinedstr` renders an f-string by joining the literal parts and the `{expression}` parts, then picks a surrounding quote from a fixed list by taking the first one that does not appear in the rendered body. When all four candidates (`'`, `"`, `'''`, `"""`) occur in the body the loop falls through and the last value `'''` is used anyway, so the emitted f-string terminates early. Adjacent f-strings such as `f'"""{v}' f"'''"` merge into a single `JoinedStr` whose parts together carry every quote sequence, which is enough to hit this from ordinary source. `as_string()` is meant to round-trip, and a couple of brains reparse its output: `brain_dataclasses` feeds it into a synthesized `__init__` and `brain_namedtuple_enum` into a mocked `Enum` member, so the broken string either raises `AstroidSyntaxError` during a plain `parse()` or reparses to a different expression and quietly rewrites the synthesized `__init__` signature. I ran into it checking that dataclass field defaults survive a round-trip. The fix leaves the existing fast path alone and, only when no candidate quote is free, re-escapes the literal parts against a quote that is absent from the `{expression}` parts, which cannot hold a backslash, so the output parses back to the same node. Added a regression test in `tests/test_nodes.py`.
