### PR TITLE
Fix the signature of the fallback `__new__` in the object model

### DIFF
--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -141,8 +141,15 @@ class ObjectModel:
         """Calling cls.__new__(type) on an object returns an instance of 'type'."""
         from astroid import builder  # pylint: disable=import-outside-toplevel
 
+        # ``__new__`` is a static method: the class is passed explicitly and
+        # ``BoundMethod.implicit_parameters()`` is 0 for it, so the first
+        # parameter is the one filled by ``cls`` in ``self.__new__(cls)`` or
+        # ``super().__new__(cls)``. The *args and **kwargs are necessary not
+        # to trigger warnings about extra parameters for ``__new__`` methods
+        # we don't infer correctly (e.g. ``tp_new`` of C types), just like
+        # the ``__init__`` fallback below.
         node: nodes.FunctionDef = builder.extract_node(
-            """def __new__(self, cls): return cls()"""
+            """def __new__(cls, *args, **kwargs): return cls()"""
         )
         # We set the parent as being the ClassDef of 'object' as that
         # triggers correct inference as a call to __new__ in bases.py

--- a/doc/whatsnew/fragments/3237.bugfix
+++ b/doc/whatsnew/fragments/3237.bugfix
@@ -1,0 +1,10 @@
+The fallback ``__new__`` of the object model, used when the real one cannot be found
+(``instance.__new__``, ``super().__new__(cls)`` under an uninferable ancestor, or the
+``__new__`` of a C type outside ``builtins``), now has the signature
+``(cls, *args, **kwargs)`` instead of ``(self, cls)``. Since ``__new__`` takes the
+class explicitly, the old signature reported the class argument as missing and any
+other argument as unexpected.
+
+Closes #3237
+Closes pylint-dev/pylint#8325
+Refs pylint-dev/pylint#10670

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -55,6 +55,34 @@ class InstanceModelTest(unittest.TestCase):
         self.assertIsInstance(attr, nodes.Const)
         self.assertEqual(attr.value, 42)
 
+    def test_instance_dunder_new_accepts_explicit_class(self) -> None:
+        """``__new__`` is a static method: the class is passed explicitly.
+
+        Regression test for https://github.com/pylint-dev/pylint/issues/8325
+        """
+        ast_nodes = builder.extract_node("""
+        class A:
+            def clone(self):
+                return self.__new__(type(self))
+
+        a = A()
+        a.__new__ #@
+        a.clone() #@
+        """)
+        assert isinstance(ast_nodes, list)
+        dunder_new = next(ast_nodes[0].infer())
+        self.assertIsInstance(dunder_new, astroid.BoundMethod)
+        self.assertEqual(dunder_new.implicit_parameters(), 0)
+        # The first parameter is the class, the others absorb whatever a
+        # ``__new__`` we can't model precisely is called with.
+        self.assertEqual(dunder_new.argnames(), ["cls", "args", "kwargs"])
+        self.assertIsNotNone(dunder_new.args.vararg)
+        self.assertIsNotNone(dunder_new.args.kwarg)
+
+        inferred = next(ast_nodes[1].infer())
+        self.assertIsInstance(inferred, astroid.Instance)
+        self.assertEqual(inferred.name, "A")
+
     @pytest.mark.xfail(reason="Instance lookup cannot override object model")
     def test_instance_local_attributes_overrides_object_model(self):
         # The instance lookup needs to be changed in order for this to work.
@@ -175,6 +203,42 @@ class ClassModelTest(unittest.TestCase):
         inferred = next(ast_node.infer())
         self.assertIsInstance(inferred, nodes.Const)
         self.assertEqual(inferred.value, "first")
+
+    def test_class_dunder_new_with_unknown_ancestor(self) -> None:
+        """``super().__new__(cls)`` falls back to the object model when an
+        ancestor cannot be inferred; the explicit class must fill the first
+        parameter and extra arguments must be accepted.
+
+        Regression test for https://github.com/pylint-dev/pylint/issues/8325
+        """
+        ast_nodes = builder.extract_node("""
+        from missing import Base
+
+        class A(Base):
+            def __new__(cls, value):
+                super().__new__ #@
+                return super().__new__(cls)
+
+        class B(Base):
+            @classmethod
+            def make(cls):
+                return cls.__new__(cls)
+
+        B.__new__ #@
+        A(1) #@
+        B.make() #@
+        """)
+        assert isinstance(ast_nodes, list)
+        for node in ast_nodes[:2]:
+            dunder_new = next(node.infer())
+            self.assertIsInstance(dunder_new, astroid.BoundMethod)
+            self.assertEqual(dunder_new.implicit_parameters(), 0)
+            self.assertEqual(dunder_new.argnames(), ["cls", "args", "kwargs"])
+
+        for node, name in zip(ast_nodes[2:], ["A", "B"]):
+            inferred = next(node.infer())
+            self.assertIsInstance(inferred, astroid.Instance)
+            self.assertEqual(inferred.name, name)
 
     def test_class_model_correct_mro_subclasses_proxied(self) -> None:
         ast_nodes = builder.extract_node("""


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`ObjectModel.attr___new__` is the `__new__` astroid hands out when the real one cannot be found. That happens more often than it sounds: `instance.__new__` always goes there (`Instance.getattr` consults the model before the class), `super().__new__(cls)` goes there when an ancestor cannot be inferred (a base from an uninstalled package), and the `__new__` of every C type outside `builtins` that defines its own `tp_new` goes there too, because `raw_building.imported_member` records such a `__new__` as `ImportFrom("builtins", "__new__")` and the builtins *module* resolves that through this same model.

It was built from `def __new__(self, cls): return cls()`. But `BoundMethod.implicit_parameters()` is `0` for `__new__` — the class is passed explicitly — so the class argument fills `self`, `cls` is reported as missing, and anything else is "unexpected". pylint turns each case into a false positive:

| code | pylint before |
| --- | --- |
| `self.__new__(type(self))` | `no-value-for-parameter: No value for argument 'cls'` (pylint-dev/pylint#8325) |
| `super().__new__(cls)` with an uninferable base | same (the comment on that issue) |
| `cls.__new__(cls, **kwargs)` in the stdlib's `ssl.SSLSocket._create` | `unexpected-keyword-arg` ×4 + `no-value-for-parameter` |
| `array.array.__new__(cls, "b", data)` | `too-many-function-args` |
| `datetime.datetime.__new__(...)` on Python 3.11 | `too-many-function-args` (pylint-dev/pylint#10670 — it only stopped reproducing on 3.12+ because `datetime` resolves to `_pydatetime` there) |

This changes the fallback to `def __new__(cls, *args, **kwargs): return cls()`, which is the same shape as the `__init__` fallback right below it (and for the same reason: its comment says the `*args, **kwargs` are "necessary not to trigger warnings about missing or extra parameters for `__init__` methods we don't infer correctly").

Result inference is unaffected: calls to this fallback are intercepted by `UnboundMethod.infer_call_result` → `_infer_builtin_new` because the node's parent is `builtins.object`, so `self.__new__(type(self))` still infers to an instance of the class. The body is never used.

### Tests

Two regression tests in `tests/test_object_model.py`, one per entry point (instance model, class model with an uninferable ancestor). Each asserts the fallback's `argnames()` is `["cls", "args", "kwargs"]` with `implicit_parameters() == 0`, and that the call still infers to an `Instance` of the right class. Both fail on `main` with `['self', 'cls'] != ['cls', 'args', 'kwargs']`.

With this branch installed, pylint's functional suite is unchanged, and a file with all five rows above produces no messages, while `self.__new__()` (no class at all) is still reported.

### Not done here

`_infer_builtin_new` also turns `X.__new__(cls, 1)` into `Const(1)` for *any* `__new__` rooted in `builtins`, including `object.__new__` and this fallback, even though only `int.__new__(cls, 1)`-style calls warrant that. That predates this change and is independent of the signature, so I left it alone; happy to follow up if you want it scoped to non-`object` builtins.

Closes #3237
Closes pylint-dev/pylint#8325
Refs pylint-dev/pylint#10670
