### PR TITLE
Fix as_string() dropping parentheses around a comparison that is the left operand of another comparison

### DIFF
--- a/astroid/nodes/as_string.py
+++ b/astroid/nodes/as_string.py
@@ -74,13 +74,15 @@ class AsStringVisitor:
             # 3 * (4 + 5)
             return True
 
-        if (
-            node_precedence == child_precedence
-            and is_left != node.op_left_associative()
-        ):
-            # 3 - (4 - 5)
-            # (2**3)**4
-            return True
+        if node_precedence == child_precedence:
+            if isinstance(node, nodes.Compare):
+                # Comparisons chain rather than associate, so a comparison
+                # operand always needs parentheses: (a < b) == (c < d)
+                return True
+            if is_left != node.op_left_associative():
+                # 3 - (4 - 5)
+                # (2**3)**4
+                return True
 
         return False
 

--- a/doc/whatsnew/fragments/3239.bugfix
+++ b/doc/whatsnew/fragments/3239.bugfix
@@ -1,0 +1,7 @@
+``as_string()`` no longer drops the parentheses around a comparison used as
+the left operand of another comparison. ``(a is None) == (b is None)``
+previously round-tripped to ``a is None == (b is None)``, which Python parses
+as the semantically different chained comparison
+``(a is None) and (None == (b is None))``.
+
+Refs #3239

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -230,6 +230,22 @@ y = (3).imag
             for code in f:
                 self.check_as_string_ast_equality(code)
 
+    def test_nested_compare_as_left_operand(self) -> None:
+        """Comparisons chain rather than associate, so a comparison that is
+        the left operand of another comparison keeps its parentheses.
+
+        Regression test for #3239.
+        """
+        for code in (
+            "(a is None) == (b is None)",
+            "(a is None) != (b is None)",
+            "(a < b) == (c < d)",
+            "((a < b) == (c < d)) == (e < f)",
+        ):
+            self.assertEqual(extract_node(code).as_string(), code)
+        # A genuine chained comparison must stay unparenthesized.
+        self.assertEqual(extract_node("a < b < c").as_string(), "a < b < c")
+
     @staticmethod
     def check_as_string_ast_equality(code: str) -> None:
         """

--- a/tests/testdata/python3/data/operator_precedence.py
+++ b/tests/testdata/python3/data/operator_precedence.py
@@ -25,3 +25,8 @@ assert (lambda x: lambda: x + 1)(2)() == 3
 
 f = lambda x, y, z: y(x, z)
 assert f(1, lambda x, y: x + y[1], (2, 3)) == 4
+
+assert (True is None) == (False is None)
+assert (True is None) != (False is not None)
+assert (1 < 2) == (3 < 4)
+assert ((1 < 2) == (3 < 4)) == ((5 < 6) == (7 < 8))


### PR DESCRIPTION
## Type of Changes

| ✓ | Type |
| --- | ---- |
| ✓ | 🐛 Bug fix |

## Description

`as_string()` dropped the parentheses around a comparison used as the **left**
operand of another comparison:

```
source   : assert (a is None) == (b is None)
unparsed : assert a is None == (b is None)
```

The unparsed line is a **chained** comparison — `(a is None) and (None == (b is None))`
— a semantically different expression.

`AsStringVisitor._should_wrap` handled equal precedence purely via associativity, and
`Compare` used the default "left associative", so a left `Compare` operand was never
wrapped. But comparisons chain rather than associate, so a `Compare` operand of a
`Compare` must be parenthesized on either side (the right side was only wrapped
because `is_left=False` happened to disagree with the assumed left-associativity).

At equal precedence, a `Compare` operand of a `Compare` is now always wrapped.
Genuine chained comparisons (`a < b < c`) are unaffected: their operands sit below
`Compare` precedence and take the existing paths.

Regression tests: exact-text round-trips in `AsStringTest.test_nested_compare_as_left_operand`,
plus new lines in `tests/testdata/python3/data/operator_precedence.py` (both fail without
the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
