### PR TITLE
Fix crash on `super()` in a classmethod defined outside a class

### DIFF
--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -530,8 +530,13 @@ def infer_super(
         raise UseInferenceDefault
 
     cls = scoped_nodes.get_wrapping_class(scope)
-    assert cls is not None
     if not node.args:
+        if cls is None:
+            # A ``classmethod`` or ``method`` that is not defined inside a
+            # class, e.g. a module level function decorated with
+            # ``@classmethod``: there is nothing for the zero argument
+            # form to refer to.
+            raise UseInferenceDefault
         mro_pointer = cls
         mro_owner = _mro_owner(cls, context)
         # In we are in a classmethod, the interpreter will fill

--- a/doc/whatsnew/fragments/8755.bugfix
+++ b/doc/whatsnew/fragments/8755.bugfix
@@ -1,0 +1,4 @@
+Fix a crash when inferring a ``super()`` call inside a function that is decorated
+with ``@classmethod`` but is not defined inside a class.
+
+Closes pylint-dev/pylint#8755

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -648,6 +648,32 @@ class SuperTests(unittest.TestCase):
         """)
         self.assertEqual(list(node.infer()), [util.Uninferable])
 
+    def test_super_outside_of_a_class(self) -> None:
+        """A ``classmethod`` defined at module level does not crash inference.
+
+        Regression test for https://github.com/pylint-dev/pylint/issues/8755
+        """
+        zero_arg, two_arg = builder.extract_node("""
+        class C:
+            pass
+
+        @classmethod
+        def foo(cls, a):
+            b = super() #@
+            return b.foo(a)
+
+        @classmethod
+        def bar(cls, a):
+            b = super(C, cls) #@
+            return b.bar(a)
+        """)
+        inferred = next(zero_arg.value.infer())
+        self.assertIsInstance(inferred, bases.Instance)
+        self.assertEqual(inferred.qname(), "builtins.super")
+        inferred = next(two_arg.value.infer())
+        self.assertIsInstance(inferred, Super)
+        self.assertEqual(inferred.mro_pointer.name, "C")
+
     def test_super_invalid_types(self) -> None:
         node = builder.extract_node("""
         import collections


### PR DESCRIPTION
## Type of Changes

| | Type |
|---|---|
| ✓ | :bug: Bug fix |
| | :sparkles: New feature |
| | :hammer: Refactoring |
| | :scroll: Docs |

## Description

`infer_super` asserts that the function enclosing a `super()` call has a wrapping class as soon as the function's type is `classmethod` or `method`. A module level function decorated with `@classmethod` has that type but no wrapping class, so `get_wrapping_class` returns `None`, the assertion fails and pylint reports an `astroid-error` for code like:

```python
class C:
    pass

@classmethod
def foo(cls, a):
    b = super(C, cls).foo(a)
    return b
```

This falls back to the default inference for the zero argument form in that case. The two argument form does not need the enclosing class and is inferred as a `Super` object as usual.

Closes pylint-dev/pylint#8755