### PR TITLE
Infer the `args` of an exception instance as a tuple of unknown contents

### DIFF
--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -817,8 +817,12 @@ class InstanceModel(ObjectModel):
 
 class ExceptionInstanceModel(InstanceModel):
     @property
-    def attr_args(self) -> nodes.Tuple:
-        return nodes.Tuple(parent=self._instance)
+    def attr_args(self) -> bases.Instance:
+        # The arguments an exception was created with are not known from the
+        # instance alone, so ``args`` is a tuple of unknown contents rather
+        # than a known empty tuple.
+        builtins_ast_module = AstroidManager().builtins_module
+        return builtins_ast_module["tuple"].instantiate_class()
 
     @property
     def attr___traceback__(self):

--- a/doc/whatsnew/fragments/11312.bugfix
+++ b/doc/whatsnew/fragments/11312.bugfix
@@ -1,0 +1,5 @@
+The ``args`` attribute of an exception instance is now inferred as a ``tuple``
+instance of unknown contents instead of a known empty tuple, so unpacking
+``exc.args`` no longer looks unbalanced.
+
+Closes pylint-dev/pylint#11312

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -6193,7 +6193,8 @@ def test_subclass_of_exception(code) -> None:
     inferred = next(extract_node(code).infer())
     assert isinstance(inferred, Instance)
     args = next(inferred.igetattr("args"))
-    assert isinstance(args, nodes.Tuple)
+    assert isinstance(args, Instance)
+    assert args.qname() == "builtins.tuple"
 
 
 def test_ifexp_inference() -> None:

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -698,7 +698,8 @@ class ExceptionModelTest(unittest.TestCase):
         """)
         assert isinstance(ast_nodes, list)
         args = next(ast_nodes[0].infer())
-        assert isinstance(args, nodes.Tuple)
+        assert isinstance(args, astroid.Instance)
+        assert args.qname() == "builtins.tuple"
         tb = next(ast_nodes[1].infer())
         # Python 3.11: If 'contextlib' is loaded, '__traceback__'
         # could be set inside '__exit__' method in
@@ -836,9 +837,24 @@ class TestExceptionInstanceModel:
         ast_node = builder.extract_node("""
         BaseException() #@
         """)
-        args: nodes.Tuple = next(ast_node.infer()).getattr("args")[0]
-        # BaseException doesn't have any required args, not even a string
-        assert not args.elts
+        args = next(ast_node.infer()).getattr("args")[0]
+        # BaseException doesn't have any required args, not even a string:
+        # ``args`` is a tuple whose contents are not known.
+        assert isinstance(args, astroid.Instance)
+        assert args.qname() == "builtins.tuple"
+
+    def test_args_unpacking_has_unknown_length(self) -> None:
+        """``args`` is not a known empty tuple: unpacking it cannot be checked."""
+        ast_node = builder.extract_node("""
+        try:
+            pass
+        except ValueError as err:
+            err.args #@
+        """)
+        args = next(ast_node.infer())
+        assert isinstance(args, astroid.Instance)
+        assert args.qname() == "builtins.tuple"
+        assert not isinstance(args, nodes.Tuple)
 
 
 @pytest.mark.parametrize("parentheses", (True, False))


### PR DESCRIPTION
## Type of Changes

| | Type |
|---|---|
| ✓ | :bug: Bug fix |
| | :sparkles: New feature |
| | :hammer: Refactoring |
| | :scroll: Docs |

## Description

`ExceptionInstanceModel.attr_args` returns a `nodes.Tuple` with no elements. Consumers read that as a *known empty* tuple: pylint reports `unbalanced-tuple-unpacking` with "right side has 0 values" for

```python
class PackageNotFoundError(ModuleNotFoundError):
    @property
    def name(self):
        (name,) = self.args   # stdlib, importlib/metadata/__init__.py
        return name
```

and for `first, second = exc.args` inside an `except` block.

The arguments an exception was created with are not known from the instance alone, so `args` is now inferred as an instance of `builtins.tuple` (unknown contents, still iterable and subscriptable). This keeps the intent of #1749 (no assumption that the first argument is a `str`) while no longer claiming a length of zero. The three existing tests that asserted `nodes.Tuple` are updated and a regression test is added; pylint's functional suite passes against this branch (apart from `unbalanced_tuple_unpacking`, which fails identically on current astroid main in my environment because of the `ctypes` brain).

Closes pylint-dev/pylint#11312