### PR TITLE
Fix InferenceError silently aborting BaseInstance.infer_call_result (…

### DIFF
--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -329,11 +329,16 @@ class BaseInstance(Proxy):
         context = bind_context_to_node(context, self)
         inferred = False
 
-        # If the call is an attribute on the instance, we infer the attribute itself
+        # If the call is an attribute on the instance, we infer the attribute itself.
+        # A failed lookup here must not abort inference entirely -- fall through to
+        # resolving __call__ normally below. See issue #3077.
         if isinstance(caller, nodes.Call) and isinstance(caller.func, nodes.Attribute):
-            for res in self.igetattr(caller.func.attrname, context):
-                inferred = True
-                yield res
+            try:
+                for res in self.igetattr(caller.func.attrname, context):
+                    inferred = True
+                    yield res
+            except InferenceError:
+                pass
 
         # Otherwise we infer the call to the __call__ dunder normally
         for node in self._proxied.igetattr("__call__", context):

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -4025,6 +4025,37 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         inferred = next(node.infer_call_result(caller=node))
         self.assertIsInstance(inferred, nodes.Const)
 
+    def test_infer_call_result_dunder_call_consistent_with_attribute_call(self) -> None:
+        """Regression test for https://github.com/pylint-dev/astroid/issues/3077.
+
+        Calling an instance directly (via __call__ sugar) must not silently
+        abort inference if a preliminary attribute lookup on the instance
+        fails -- it should still fall through to resolving __call__, the
+        same way an explicit method call on the instance would resolve.
+        """
+        implicit_call, explicit_call = extract_node("""
+        class Base:
+            def __call__(self):
+                return 1
+            def run(self):
+                return 1
+
+        class Holder:
+            def __init__(self):
+                self.base = Base()
+            def via_call(self):
+                return self.base()  #@
+            def via_run(self):
+                return self.base.run()  #@
+        """)
+        implicit_result = next(implicit_call.value.infer())
+        explicit_result = next(explicit_call.value.infer())
+        # Both call styles do the exact same thing at runtime, so astroid
+        # should not be Uninferable for one and resolved for the other.
+        assert (implicit_result is util.Uninferable) == (
+            explicit_result is util.Uninferable
+        )
+
     def test_context_call_for_context_managers(self) -> None:
         ast_nodes = extract_node("""
         class A:


### PR DESCRIPTION
Fixes #3077

## Summary

`typing.cast(T, self)` inside a method was inferring differently depending on how the enclosing instance was called — directly via implicit `__call__` sugar (`obj()`) versus an explicit method call (`obj.method()`) — even though both are structurally identical and behave identically at runtime.

## Root cause

`BaseInstance.infer_call_result` (astroid/bases.py) has an optional first step that tries to resolve a call like `obj()` as an attribute lookup on the instance. When that lookup fails (as it always will for `obj()`-style calls where the attribute name doesn't exist on the callee), the resulting `InferenceError` was left unhandled. Since this is a generator function, the unhandled exception silently aborted the *entire* function — including the fallback logic just below it that correctly resolves `__call__`. That fallback was never reached, so the call fell back to `Uninferable`.

## Fix

Wrap the optional attribute-lookup branch in `try/except InferenceError: pass`, so a failed lookup no longer prevents falling through to the `__call__` resolution below, matching the existing code comment's original intent ("Otherwise we infer the call to the `__call__` dunder normally").

## Testing

Added `test_infer_call_result_dunder_call_consistent_with_attribute_call` in `tests/test_inference.py`, reproducing the minimal case from #3077. Ran the full existing test suite (`pytest tests/`) — no new failures introduced; the only pre-existing failures are unrelated Windows-environment issues (symlink permissions, missing test fixtures) and one pre-existing unrelated `TypedDict` failure confirmed to also occur on unmodified `main`.

- [x] Write a good description on what the PR does.
