### PR TITLE
guard empty six.with_metaclass() call against IndexError

### DIFF
--- a/astroid/brain/brain_six.py
+++ b/astroid/brain/brain_six.py
@@ -220,6 +220,11 @@ def transform_six_with_metaclass(node):
     If so, inject its argument as the metaclass of the underlying class.
     """
     call = node.bases[0]
+    if not call.args:
+        # ``six.with_metaclass()`` written with no positional metaclass
+        # argument is invalid, but the predicate still matches it. Leave the
+        # class untransformed instead of indexing into an empty argument list.
+        return node
     node._metaclass = call.args[0]
     return node
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1578,9 +1578,15 @@ class FunctionDef(
         ):
             if isinstance(caller.args, node_classes.Arguments):
                 assert caller.args.args is not None
-                metaclass = next(caller.args.args[0].infer(context), None)
+                metaclass = (
+                    next(caller.args.args[0].infer(context), None)
+                    if caller.args.args
+                    else None
+                )
             elif isinstance(caller.args, list):
-                metaclass = next(caller.args[0].infer(context), None)
+                metaclass = (
+                    next(caller.args[0].infer(context), None) if caller.args else None
+                )
             else:
                 raise TypeError(  # pragma: no cover
                     f"caller.args was neither Arguments nor list; got {type(caller.args)}"

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1578,19 +1578,22 @@ class FunctionDef(
         ):
             if isinstance(caller.args, node_classes.Arguments):
                 assert caller.args.args is not None
-                metaclass = (
-                    next(caller.args.args[0].infer(context), None)
-                    if caller.args.args
-                    else None
-                )
+                call_args = caller.args.args
             elif isinstance(caller.args, list):
-                metaclass = (
-                    next(caller.args[0].infer(context), None) if caller.args else None
-                )
+                call_args = caller.args
             else:
                 raise TypeError(  # pragma: no cover
                     f"caller.args was neither Arguments nor list; got {type(caller.args)}"
                 )
+            if not call_args:
+                # ``with_metaclass()`` called without a metaclass argument is
+                # invalid; there is nothing to infer.
+                raise InferenceError(
+                    "with_metaclass() call has no metaclass argument",
+                    node=self,
+                    context=context,
+                )
+            metaclass = next(call_args[0].infer(context), None)
             if isinstance(metaclass, ClassDef):
                 class_bases = [_infer_last(x, context) for x in caller.args[1:]]
                 new_class = ClassDef(

--- a/doc/whatsnew/fragments/3248.bugfix
+++ b/doc/whatsnew/fragments/3248.bugfix
@@ -1,6 +1,7 @@
 Do not crash when inferring a class that uses ``six.with_metaclass()`` with no
 positional metaclass argument. The call is invalid, but astroid raised
-``IndexError`` while building the module, and again when the call was inferred,
-instead of leaving the class untransformed.
+``IndexError`` while building the module, and again when the call was inferred.
+The class is now left untransformed and inferring the call raises an
+``InferenceError`` instead.
 
 Refs #3248

--- a/doc/whatsnew/fragments/3248.bugfix
+++ b/doc/whatsnew/fragments/3248.bugfix
@@ -1,0 +1,6 @@
+Do not crash when inferring a class that uses ``six.with_metaclass()`` with no
+positional metaclass argument. The call is invalid, but astroid raised
+``IndexError`` while building the module, and again when the call was inferred,
+instead of leaving the class untransformed.
+
+Refs #3248

--- a/tests/brain/test_six.py
+++ b/tests/brain/test_six.py
@@ -138,6 +138,22 @@ class SixBrainTest(unittest.TestCase):
         klass = astroid.extract_node(code)
         assert next(klass.ancestors()).name == "Enum"
 
+    def test_with_metaclass_no_arguments(self) -> None:
+        # ``six.with_metaclass()`` with no positional argument must not crash
+        # the module build; the class is simply left untransformed.
+        module = builder.parse("""
+        import six
+        class A(six.with_metaclass()):
+            pass
+
+        class B(six.with_metaclass(a=1)):
+            pass
+        """)
+        for name in ("A", "B"):
+            klass = module[name]
+            self.assertIsInstance(klass, nodes.ClassDef)
+            self.assertIsNone(getattr(klass, "_metaclass", None))
+
     def test_six_with_metaclass_with_additional_transform(self) -> None:
         def transform_class(cls: Any) -> ClassDef:
             if cls.name == "A":

--- a/tests/brain/test_six.py
+++ b/tests/brain/test_six.py
@@ -153,6 +153,9 @@ class SixBrainTest(unittest.TestCase):
             klass = module[name]
             self.assertIsInstance(klass, nodes.ClassDef)
             self.assertIsNone(getattr(klass, "_metaclass", None))
+            # Inferring the invalid call raises an InferenceError rather than
+            # yielding a bogus ``temporary_class`` ancestor.
+            self.assertEqual([a.name for a in klass.ancestors()], [])
 
     def test_six_with_metaclass_with_additional_transform(self) -> None:
         def transform_class(cls: Any) -> ClassDef:


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`transform_six_with_metaclass` indexes `call.args[0]` for any class whose sole base is a `six.with_metaclass(...)` call, but the predicate matches even when that call has no positional argument, so `class Foo(six.with_metaclass())` raises `IndexError` while the module is being built. The generic `with_metaclass` handling in `FunctionDef.infer_call_result` hits the same `IndexError` on `caller.args[0]` when such a call is inferred. Raise `InferenceError` at both sites when the argument list is empty instead of indexing into it.

Refs #3248

