### PR TITLE
prevent docstrings breaking out of the as_string literal

### DIFF
--- a/astroid/nodes/as_string.py
+++ b/astroid/nodes/as_string.py
@@ -32,14 +32,28 @@ class AsStringVisitor:
         """Makes this visitor behave as a simple function"""
         return node.accept(self).replace(DOC_NEWLINE, "\n")
 
+    def _docstring(self, value: str) -> str:
+        """Render a docstring as a literal that reparses to the same text.
+
+        Emit it verbatim in triple quotes, but fall back to ``repr`` when the
+        text could terminate or escape the literal, so it round-trips.
+        """
+        if (
+            '"""' not in value
+            and not value.endswith('"')
+            and "\\" not in value
+            and "\0" not in value
+            and "\r" not in value
+        ):
+            return '"""{}"""'.format(value.replace("\n", DOC_NEWLINE))
+        return repr(value)
+
     def _docs_dedent(self, doc_node: nodes.Const | None) -> str:
         """Stop newlines in docs being indented by self._stmt_list"""
         if not doc_node:
             return ""
 
-        return '\n{}"""{}"""'.format(
-            self.indent, doc_node.value.replace("\n", DOC_NEWLINE)
-        )
+        return "\n" + self.indent + self._docstring(doc_node.value)
 
     def _stmt_list(self, stmts: list, indent: bool = True) -> str:
         """return a list of nodes to string"""
@@ -434,7 +448,7 @@ class AsStringVisitor:
 
     def visit_module(self, node: nodes.Module) -> str:
         """return an nodes.Module node as string"""
-        docs = f'"""{node.doc_node.value}"""\n\n' if node.doc_node else ""
+        docs = f"{self._docstring(node.doc_node.value)}\n\n" if node.doc_node else ""
         return docs + "\n".join(n.accept(self) for n in node.body) + "\n\n"
 
     def visit_name(self, node: nodes.Name) -> str:

--- a/doc/whatsnew/fragments/3249.bugfix
+++ b/doc/whatsnew/fragments/3249.bugfix
@@ -1,0 +1,8 @@
+``AsStringVisitor`` no longer lets a docstring break out of the triple-quoted
+literal it is rendered into. A docstring value containing ``"""``, ending in a
+quote, or holding a NUL byte previously closed the literal early or, through the
+``DOC_NEWLINE`` sentinel, injected extra lines into ``as_string()`` output, which
+the dataclass and namedtuple brains reparse. Such values now fall back to
+``repr`` so the output round-trips.
+
+Refs #3249

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -160,6 +160,31 @@ def function(var):
         ast = abuilder.string_build(code)
         self.assertEqual(ast.as_string(), code)
 
+    def test_docstring_as_string_roundtrip(self) -> None:
+        """A docstring must not be able to break out of or inject into as_string()."""
+        docstrings = (
+            'ends with a quote"',
+            'has a """ triple quote',
+            "a\x00b",  # NUL collides with the newline sentinel
+            "carriage\rreturn",
+            "back\\slash",
+        )
+        templates = ("def f():\n    {}\n    x = 1", "class C:\n    {}\n    x = 1")
+        for doc in docstrings:
+            for template in templates:
+                rebuilt = abuilder.string_build(template.format(repr(doc)))
+                # The rendered source must reparse to the same docstring, with no
+                # statement smuggled in past the literal.
+                scope = abuilder.string_build(rebuilt.as_string()).body[0]
+                self.assertEqual(scope.doc_node.value, doc)
+                self.assertEqual(len(scope.body), 1)
+
+        module = abuilder.string_build(repr('a module """ docstring'))
+        self.assertEqual(
+            abuilder.string_build(module.as_string()).doc_node.value,
+            'a module """ docstring',
+        )
+
     def test_3k_annotations_and_metaclass(self) -> None:
         code = '''
         def function(var: int):


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

as_string interpolates a function, class or module docstring straight into a triple-quoted literal, and _docs_dedent carries its newlines through the DOC_NEWLINE ("\0") sentinel that __call__ turns back into newlines. a docstring that embeds a `"""`, ends in a quote, or holds a literal NUL then closes the literal early or, via the sentinel, expands into extra source lines, and brain_dataclasses / brain_namedtuple_enum reparse that output. a docstring value like `"""\0    __import__("os").system("id")\0    """` currently round-trips into an injected call statement, and plainer values such as one ending in `"` just make the output unparseable. `_docstring` now keeps the verbatim triple-quoted form only when the text cannot break the literal and falls back to `repr()` otherwise; `_docs_dedent` and `visit_module` both route through it so the emitted source reparses to the same string.
