### PR TITLE
catch OverflowError in old-style %c string formatting

### DIFF
--- a/astroid/nodes/_base_nodes.py
+++ b/astroid/nodes/_base_nodes.py
@@ -418,7 +418,9 @@ class OperatorNode(NodeNG):
 
         try:
             return (nodes.const_factory(instance.value % values),)
-        except (TypeError, KeyError, ValueError):
+        except (TypeError, KeyError, ValueError, OverflowError):
+            # OverflowError: a "%c" conversion with an out-of-range code point,
+            # e.g. "%c" % 0x110000, which the size guard above does not catch.
             return (util.Uninferable,)
 
     @staticmethod

--- a/doc/whatsnew/fragments/3254.bugfix
+++ b/doc/whatsnew/fragments/3254.bugfix
@@ -1,0 +1,6 @@
+Infer a ``str``/``bytes`` old-style ``%`` interpolation without crashing when a
+``%c`` conversion receives an out-of-range code point, such as ``"%c" % 0x110000``
+or ``b"%c" % 256``. The evaluation now catches ``OverflowError`` and yields
+``Uninferable``, matching the other invalid interpolations.
+
+Refs #3254

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -7242,6 +7242,9 @@ class TestOldStyleStringFormatting:
             """,
             """20 % 0""",
             """("%" + str(20)) % 0""",
+            """"%c" % 0x110000""",
+            """"%c" % -1""",
+            """b"%c" % 256""",
         ],
     )
     def test_old_style_string_formatting_uninferable(self, format_string: str) -> None:


### PR DESCRIPTION
OperatorNode._infer_old_style_string_formatting evaluates instance.value % values but only catches TypeError, KeyError and ValueError, so inferring a "%c" conversion with a code point outside range(0x110000) (range(256) for bytes) raises an uncaught OverflowError while a tool like pylint analyzes the source. A literal such as "%c" % 0x110000, "%c" % -1 or b"%c" % 256 is enough to hit it, and the existing size guard does not cover the case since the template itself is tiny. Add OverflowError to the except tuple so these degrade to Uninferable like the other invalid interpolations.