### PR TITLE
guard mock-class reconstruction in infer_enum_class

### DIFF
--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -18,6 +18,7 @@ from astroid.builder import AstroidBuilder, _extract_single_node, extract_node
 from astroid.context import InferenceContext
 from astroid.exceptions import (
     AstroidError,
+    AstroidSyntaxError,
     AstroidTypeError,
     AstroidValueError,
     InferenceError,
@@ -465,37 +466,45 @@ def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
                     continue
                 target_names.add(target.name)
                 # Replace all the assignments with our mocked class.
-                classdef = dedent(
-                    """
-                class {name}({types}):
-                    @property
-                    def value(self):
-                        return {return_value}
-                    @property
-                    def _value_(self):
-                        return {return_value}
-                    @property
-                    def name(self):
-                        return "{name}"
-                    @property
-                    def _name_(self):
-                        return "{name}"
-                """.format(
-                        name=target.name,
-                        types=", ".join(node.basenames),
-                        return_value=inferred_return_value,
+                try:
+                    classdef = dedent(
+                        """
+                    class {name}({types}):
+                        @property
+                        def value(self):
+                            return {return_value}
+                        @property
+                        def _value_(self):
+                            return {return_value}
+                        @property
+                        def name(self):
+                            return "{name}"
+                        @property
+                        def _name_(self):
+                            return "{name}"
+                    """.format(
+                            name=target.name,
+                            types=", ".join(node.basenames),
+                            return_value=inferred_return_value,
+                        )
                     )
-                )
-                if "IntFlag" in basename:
-                    # Alright, we need to add some additional methods.
-                    # Unfortunately we still can't infer the resulting objects as
-                    # Enum members, but once we'll be able to do that, the following
-                    # should result in some nice symbolic execution
-                    classdef += INT_FLAG_ADDITION_METHODS.format(name=target.name)
+                    if "IntFlag" in basename:
+                        # Alright, we need to add some additional methods.
+                        # Unfortunately we still can't infer the resulting objects as
+                        # Enum members, but once we'll be able to do that, the following
+                        # should result in some nice symbolic execution
+                        classdef += INT_FLAG_ADDITION_METHODS.format(name=target.name)
 
-                fake = AstroidBuilder(
-                    AstroidManager(), apply_transforms=False
-                ).string_build(classdef)[target.name]
+                    fake = AstroidBuilder(
+                        AstroidManager(), apply_transforms=False
+                    ).string_build(classdef)[target.name]
+                except (ValueError, AstroidSyntaxError):
+                    # The member value could not be rendered back into the mocked
+                    # class body, e.g. an integer literal past the int-to-str
+                    # conversion limit (``A = 0xff...``). Unlike the dataclass init
+                    # transform, this reconstruction has no exception boundary, so
+                    # leave such a member untransformed instead of crashing.
+                    break
                 fake.parent = target.parent
                 for method in node.mymethods():
                     fake.locals[method.name] = [method]
@@ -503,7 +512,8 @@ def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
                 if stmt.value is None:
                     continue
                 dunder_members[local] = fake
-            node.locals[local] = new_targets
+            else:
+                node.locals[local] = new_targets
 
         # The undocumented `_value2member_map_` member:
         node.locals["_value2member_map_"] = [

--- a/doc/whatsnew/fragments/3256.bugfix
+++ b/doc/whatsnew/fragments/3256.bugfix
@@ -1,0 +1,9 @@
+Infer an ``enum`` subclass without crashing when a member value cannot be
+rendered back into the mocked member class. An integer literal past the
+int-to-str conversion limit, such as ``A = 0xff...`` (a large hex literal the
+tokenizer accepts), previously made ``infer_enum_class`` raise an uncaught
+``ValueError`` while building the module. The member-class reconstruction is now
+guarded like the dataclass ``__init__`` transform, leaving such a member
+untransformed instead.
+
+Refs #3256

--- a/tests/brain/test_enum.py
+++ b/tests/brain/test_enum.py
@@ -624,3 +624,26 @@ class EnumBrainTest(unittest.TestCase):
         # Inference must not raise ``DuplicateBasesError``.
         inferred = next(node.infer())
         assert isinstance(inferred, nodes.ClassDef)
+
+    def test_enum_oversized_integer_member_does_not_crash(self) -> None:
+        """A member value that cannot be rendered back into the mocked class body.
+
+        A hexadecimal literal is accepted by the tokenizer but its decimal
+        formatting can exceed ``sys.get_int_max_str_digits``, which used to make
+        the enum transform raise an uncaught ``ValueError``.
+        """
+        oversized = "0x" + "f" * 4000
+        class_node, member_value = builder.extract_node(f"""
+        import enum
+
+        class Flags(enum.IntFlag):  #@
+            A = {oversized}
+            B = 2
+
+        Flags.B.value  #@
+        """)
+        assert isinstance(next(class_node.infer()), nodes.ClassDef)
+        # The unrepresentable member is left untransformed, but a well-formed
+        # sibling is still mocked and infers to its value.
+        inferred = member_value.inferred()
+        assert [n.value for n in inferred if isinstance(n, nodes.Const)] == [2]


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Description

`infer_enum_class` mocks each enum member by rendering a small class body with `str.format` and reparsing it through `string_build`. A non-str `Const` value is handed to `.format()` as-is, so an integer literal past the int-to-str conversion limit written as a hex literal that the tokenizer still accepts (`A = 0xff...`) makes the `.format()` raise `ValueError: Exceeds the limit (4300 digits)` and aborts the whole transform while astroid is just building the module.

Such a value is now rendered back as a hex literal, which the tokenizer accepts at any length, so the member is still mocked like any other and `Flags.A.value` infers to the actual int. Regression test added.