### PR TITLE
Do not crash on an argument that repeats the name of a variadic one

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -935,19 +935,17 @@ class Arguments(
         :raises NoDefault: If there is no default value defined for the
             given argument.
         """
-        args = [
-            arg for arg in self.arguments if arg.name not in [self.vararg, self.kwarg]
-        ]
-
         index = _find_arg(argname, self.kwonlyargs)[0]
         if (index is not None) and (len(self.kw_defaults) > index):
             if self.kw_defaults[index] is not None:
                 return self.kw_defaults[index]
             raise NoDefault(func=self.parent, name=argname)
 
-        index = _find_arg(argname, args)[0]
+        positional = [*(self.posonlyargs or ()), *(self.args or ())]
+        index = _find_arg(argname, positional)[0]
         if index is not None:
-            idx = index - (len(args) - len(self.defaults) - len(self.kw_defaults))
+            # ``defaults`` covers the last positional arguments.
+            idx = index - (len(positional) - len(self.defaults))
             if idx >= 0:
                 return self.defaults[idx]
 

--- a/doc/whatsnew/fragments/3259.bugfix
+++ b/doc/whatsnew/fragments/3259.bugfix
@@ -1,0 +1,7 @@
+``Arguments.default_value()`` no longer raises ``IndexError`` when a keyword-only
+argument repeats the name of ``*args`` or ``**kwargs``, as in ``def f(x, *y, y)``.
+Such a definition parses even though it does not compile, and excluding the
+variadic arguments by name also dropped the keyword-only argument, which shifted
+the lookup into ``defaults``.
+
+Closes #3259

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -44,6 +44,7 @@ from astroid.exceptions import (
     AstroidSyntaxError,
     AstroidTypeError,
     AttributeInferenceError,
+    NoDefault,
     StatementMissing,
 )
 from astroid.nodes.node_classes import UNATTACHED_UNKNOWN
@@ -2291,6 +2292,33 @@ def test_arguments_default_value():
 
     node = extract_node("def fruit(seeds, flavor='good', *, peel='maybe'): ...")
     assert node.args.default_value("flavor").value == "good"
+
+
+@pytest.mark.parametrize("func", ["def f(x, *y, y): ...", "def f(x, *, y, **y): ..."])
+def test_arguments_default_value_name_shared_with_vararg(func: str) -> None:
+    """An argument may repeat the name of ``*args`` or ``**kwargs``.
+
+    Such a definition parses even though it does not compile, so the name of a
+    variadic argument does not identify it on its own.
+    """
+    node = extract_node(func)
+    with pytest.raises(NoDefault):
+        node.args.default_value("x")
+    with pytest.raises(NoDefault):
+        node.args.default_value("y")
+
+
+def test_arguments_default_value_positional_shares_vararg_name() -> None:
+    """The default of a positional argument shadowed by ``*args`` is still found."""
+    node = extract_node("def f(y=1, *y): ...")
+    assert node.args.default_value("y").value == 1
+
+
+def test_infer_argument_sharing_vararg_name() -> None:
+    """Inferring such an argument yields ``Uninferable`` rather than crashing."""
+    node = extract_node("def f(x, *y, y: tuple[x]): ...")
+    subscript = node.args.kwonlyargs_annotations[0]
+    assert next(subscript.slice.infer()) is Uninferable
 
 
 def test_arguments_annotations():


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`default_value()` narrowed `arguments` to the non-variadic ones by dropping every
entry whose name matched `vararg` or `kwarg`. A name can be shared: `def f(x, *y, y)`
and `def f(x, *, y, **y)` parse and only fail at compile time with "duplicate
argument". The keyword-only `y` was dropped with the variadic one, so the offset
into `defaults` came from a list one entry short and `defaults[0]` was read from an
empty list.

It now builds the list from `posonlyargs` and `args`, offset by `defaults` alone.
Keyword-only arguments are already handled by the `kw_defaults` lookup above, and
`def f(y=1, *y)` now reports its default.

New tests fail on `main` at `node_classes.py:952`. Suite: 2108 passed.

Closes #3259
