### PR TITLE
fix(issue #3259): IndexError when inferring function arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ doc/api/objectmodel/
 doc/api/objects/
 doc/api/typing/
 doc/api/util/
+.cie/
+.venv/
+.forge/

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -948,7 +948,7 @@ class Arguments(
         index = _find_arg(argname, args)[0]
         if index is not None:
             idx = index - (len(args) - len(self.defaults) - len(self.kw_defaults))
-            if idx >= 0:
+            if 0 <= idx < len(self.defaults):
                 return self.defaults[idx]
 
         raise NoDefault(func=self.parent, name=argname)

--- a/tests/test_forge_3259.py
+++ b/tests/test_forge_3259.py
@@ -1,7 +1,11 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 """Regression test for IndexError when inferring function arguments.
 
 See: https://github.com/pylint-dev/astroid/issues/3259
 """
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_forge_3259.py
+++ b/tests/test_forge_3259.py
@@ -1,0 +1,34 @@
+"""Regression test for IndexError when inferring function arguments.
+
+See: https://github.com/pylint-dev/astroid/issues/3259
+"""
+from __future__ import annotations
+
+import pytest
+
+from astroid import extract_node
+from astroid.exceptions import NoDefault
+
+
+def test_default_value_no_index_error_with_duplicate_vararg_kwonlyarg_name() -> None:
+    """A keyword-only argument sharing the vararg name must not corrupt
+    the default-value index calculation, causing an IndexError."""
+    code = "def f(x, *y, y: tuple[x]):\n    pass"
+    node = extract_node(code)
+    args = node.args
+    # 'x' has no default value; default_value should raise NoDefault,
+    # not IndexError.
+    with pytest.raises(NoDefault):
+        args.default_value("x")
+
+
+def test_infer_annotation_no_crash() -> None:
+    """Inferring the annotation ``tuple[x]`` should not raise."""
+    code = "def f(x, *y, y: tuple[x]):\n    pass"
+    node = extract_node(code)
+    # The annotation of the keyword-only argument 'y' is tuple[x].
+    kwonly_arg = node.args.kwonlyargs[0]
+    annotation = node.args.kwonlyargs_annotations[0]
+    # This used to raise IndexError -> AstroidError.
+    results = list(annotation.infer())
+    assert results, "Expected at least one inference result for the annotation"


### PR DESCRIPTION
Fixes https://github.com/pylint-dev/astroid/issues/3259

## What
autonomous fix via `atomic-forge fix` — CIE (code graph over MCP) localized the bug, generated a failing regression test, and forge's repair loop fixed the source against it.

## Issue
> **IndexError when inferring function arguments**

```python
def f(x, *y, y: tuple[x]):
    pass
```

`Arguments.default_value()` computes a positional-default index `idx` from `argname`'s position minus the number of positional/kw defaults, but only checked `idx >= 0` before indexing `self.defaults[idx]`. When a parameter name collides between a `*args`-style vararg and an annotation elsewhere in the signature, the computed `idx` can be >= `len(self.defaults)`, raising a raw `IndexError` instead of astroid's own `NoDefault`.

## Fix
`astroid/nodes/node_classes.py`: tighten the bounds check from `idx >= 0` to `0 <= idx < len(self.defaults)` so an out-of-range index falls through to the existing `NoDefault` path instead of crashing.

## How it was verified
- CIE-generated regression test: `tests/test_forge_3259.py` (fails on the pre-fix code, passes on the fix)
- repair rounds: 1  failures: 1 -> 0
- repaired file(s): astroid/nodes/node_classes.py
- independently re-verified with a standalone repro script against both the pre-fix commit and the fix commit: raises the reported error before the fix, completes cleanly after

---
<!-- atomic-forge:pr -->
[![Fixed by Forge](https://img.shields.io/badge/fixed_by-atomic--forge-6f42c1?logo=github)](https://github.com/kannamma-labs/atomic-forge)

🔨 Fixed by [Forge](https://github.com/kannamma-labs/atomic-forge) — an autonomous, test-driven issue→PR repair engine (`atomic-forge fix <issue-url>`).

⭐ If you found this useful, a star on [atomic-forge](https://github.com/kannamma-labs/atomic-forge) helps other maintainers find the tool that fixed your bug.
