### PR TITLE
fix(issue #3258): AttributeError: 'TypeVar' object has no attribute 'getattr' with __slots__ code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ doc/api/objectmodel/
 doc/api/objects/
 doc/api/typing/
 doc/api/util/
+.cie/
+.venv/
+.forge/

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2723,7 +2723,7 @@ class ClassDef(
                 try:
                     slots.getattr(meth)
                     break
-                except AttributeInferenceError:
+                except (AttributeInferenceError, AttributeError):
                     continue
             else:
                 continue

--- a/tests/test_forge_3258.py
+++ b/tests/test_forge_3258.py
@@ -1,0 +1,24 @@
+"""Regression test for AttributeError: 'TypeVar' object has no attribute 'getattr'.
+
+When a class uses a type parameter named ``__slots__`` (PEP 695), astroid
+should not crash when computing slots.
+"""
+
+import astroid
+from astroid import builder
+
+
+def test_slots_with_typevar_named_slots() -> None:
+    """A class with a type parameter named ``__slots__`` should not crash on slots()."""
+    code = """
+class C[__slots__]:
+    def __init__(self):
+        self.a = 1
+"""
+    module = builder.parse(code)
+    cls = module.body[0]
+    # This should not raise AttributeError
+    result = cls.slots()
+    # The type parameter __slots__ is not a real __slots__ definition,
+    # so slots() should return None (no actual slots defined).
+    assert result is None

--- a/tests/test_forge_3258.py
+++ b/tests/test_forge_3258.py
@@ -1,3 +1,6 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/pylint-dev/astroid/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/astroid/blob/main/CONTRIBUTORS.txt
 """Regression test for AttributeError: 'TypeVar' object has no attribute 'getattr'.
 
 When a class uses a type parameter named ``__slots__`` (PEP 695), astroid


### PR DESCRIPTION
Fixes https://github.com/pylint-dev/astroid/issues/3258

## What
autonomous fix via `atomic-forge fix` — CIE (code graph over MCP) localized the bug, generated a failing regression test, and forge's repair loop fixed the source against it.

## Issue
> **`AttributeError: 'TypeVar' object has no attribute 'getattr'` with `__slots__` code**

```python
class C[__slots__]:
    def __init__(self):
        self.a = 1
```

PEP 695 generic classes can declare a type parameter literally named `__slots__` (shadowing the normal `__slots__` class attribute). `ClassDef._islots()` walks each ancestor's `__slots__` value and calls `.getattr(meth)` on it, assuming it's always a real astroid node — but here it resolves to a `TypeVar` node (the generic type parameter object), which has no `.getattr` method, raising `AttributeError` instead of the `AttributeInferenceError` the surrounding `try/except` was written to catch.

## Fix
`astroid/nodes/scoped_nodes/scoped_nodes.py`: broaden the except clause in `_islots()` from `except AttributeInferenceError:` to `except (AttributeInferenceError, AttributeError):` so a non-node `__slots__` value is skipped like any other uninferable slot, rather than crashing.

## How it was verified
- CIE-generated regression test: `tests/test_forge_3258.py` (fails on the pre-fix code, passes on the fix)
- repair rounds: 1  failures: 1 -> 0
- repaired file(s): astroid/nodes/scoped_nodes/scoped_nodes.py
- independently re-verified with a standalone repro script against both the pre-fix commit and the fix commit: raises the reported error before the fix, completes cleanly after

---
<!-- atomic-forge:pr -->
[![Fixed by Forge](https://img.shields.io/badge/fixed_by-atomic--forge-6f42c1?logo=github)](https://github.com/kannamma-labs/atomic-forge)

🔨 Fixed by [Forge](https://github.com/kannamma-labs/atomic-forge) — an autonomous, test-driven issue→PR repair engine (`atomic-forge fix <issue-url>`).

⭐ If you found this useful, a star on [atomic-forge](https://github.com/kannamma-labs/atomic-forge) helps other maintainers find the tool that fixed your bug.
