### PR TITLE
render non-finite floats so as_string round-trips

### DIFF
--- a/astroid/nodes/as_string.py
+++ b/astroid/nodes/as_string.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import sys
 import warnings
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
@@ -18,6 +19,9 @@ if TYPE_CHECKING:
 # pylint: disable=unused-argument
 
 DOC_NEWLINE = "\0"
+
+# Overflowing literal used to render non-finite floats, matching ast.unparse.
+_INF_LITERAL = f"1e{sys.float_info.max_10_exp + 1}"
 
 
 # Visitor pattern require argument all the time and is not better with staticmethod
@@ -217,6 +221,13 @@ class AsStringVisitor:
         """return an nodes.Const node as string"""
         if node.value is Ellipsis:
             return "..."
+        if isinstance(node.value, (float, complex)):
+            # repr renders inf/nan as bare names that reparse as Name lookups.
+            return (
+                repr(node.value)
+                .replace("inf", _INF_LITERAL)
+                .replace("nan", f"({_INF_LITERAL}-{_INF_LITERAL})")
+            )
         return repr(node.value)
 
     def visit_continue(self, node: nodes.Continue) -> str:

--- a/doc/whatsnew/fragments/3265.bugfix
+++ b/doc/whatsnew/fragments/3265.bugfix
@@ -1,0 +1,8 @@
+``as_string()`` now renders non-finite floats with an overflowing literal
+(``1e309`` for ``inf`` and ``(1e309-1e309)`` for ``nan``) instead of the bare
+``inf``/``nan`` tokens. The old output did not round-trip: reparsing it produced
+a ``Name`` lookup rather than the number, so a dataclass field default such as
+``1e999`` was synthesized into ``x: float = inf`` and resolved to whatever
+``inf`` referred to in scope.
+
+Refs #3265

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import copy
 import inspect
+import math
 import os
 import random
 import sys
@@ -184,6 +185,31 @@ def function(var):
             abuilder.string_build(module.as_string()).doc_node.value,
             'a module """ docstring',
         )
+
+    def test_non_finite_float_as_string_roundtrip(self) -> None:
+        """Non-finite floats must not render as bare ``inf``/``nan`` names."""
+        # repr() renders these as bare names; reparsing ``inf`` yields a Name
+        # lookup instead of the float, which the dataclass brain then reparses.
+        for literal, expected in (
+            ("1e999", math.inf),
+            ("1e999j", complex(0, math.inf)),
+        ):
+            node = extract_node(literal)
+            reparsed = extract_node(node.as_string())
+            self.assertEqual(next(reparsed.infer()).value, expected)
+
+        # A field default routed through the synthesized ``__init__`` must keep
+        # its value even when a name shadows the ``inf`` token in scope.
+        module = parse("""
+        inf = 42
+        from dataclasses import dataclass
+
+        @dataclass
+        class C:
+            x: float = 1e999
+        """)
+        default = module.body[-1].locals["__init__"][0].args.defaults[0]
+        self.assertEqual(next(default.infer()).value, math.inf)
 
     def test_3k_annotations_and_metaclass(self) -> None:
         code = '''


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`AsStringVisitor.visit_const` renders every constant through `repr()`, which turns a non-finite float such as the one behind `1e999` into the bare token `inf` (and `nan` for a NaN). That text does not round-trip: reparsing `inf` yields a `Name` lookup rather than the float. The dataclass brain reparses `as_string()` output when it synthesizes `__init__`, so a field default of `1e999` comes back as `def __init__(self, x: float = inf)`, and `inf` then resolves to whatever `inf` happens to be in the module, for instance a module-level `inf = os.system`, silently changing the inferred default. I ran into it while checking that field defaults survive the round-trip and saw the value resolving as a name. The fix mirrors `ast.unparse` and emits an overflowing literal, `1e309` for `inf` and `(1e309-1e309)` for `nan`, so float and complex constants render back to their own values. The change stays inside `visit_const` and leaves finite numbers, strings and other constants untouched. A ChangeLog fragment is included.