### PR TITLE
Avoid argument inference index errors

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -936,7 +936,9 @@ class Arguments(
             given argument.
         """
         args = [
-            arg for arg in self.arguments if arg.name not in [self.vararg, self.kwarg]
+            arg
+            for arg in self.arguments
+            if arg is not self.vararg_node and arg is not self.kwarg_node
         ]
 
         index = _find_arg(argname, self.kwonlyargs)[0]

--- a/doc/whatsnew/fragments/3259.bugfix
+++ b/doc/whatsnew/fragments/3259.bugfix
@@ -1,0 +1,3 @@
+Avoid an ``IndexError`` when inferring an argument whose name matches a vararg.
+
+Closes #3259

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -2293,6 +2293,13 @@ def test_arguments_default_value():
     assert node.args.default_value("flavor").value == "good"
 
 
+def test_argument_inference_with_vararg_and_kwonly_name_collision():
+    node = extract_node("def fruit(seed, *seeds, seeds: tuple[seed]): ...")
+    annotation = node.args.kwonlyargs_annotations[0]
+
+    assert list(annotation.slice.infer()) == [Uninferable]
+
+
 def test_arguments_annotations():
     node = extract_node(
         "def fruit(eat: str, /, peel: bool, *args: int, trim: float, **kwargs: bytes): ..."


### PR DESCRIPTION
Closes #3259. The argument default lookup now excludes the actual vararg and kwarg nodes by identity instead of excluding every parameter with the same name. This preserves valid keyword-only parameters that share a name with a vararg and prevents an IndexError during inference. Added regression coverage and a bugfix news fragment. Tests: 31 focused tests passed; full suite 2135 passed, 91 skipped, 15 xfailed, with one unrelated macOS symlink-resolution baseline failure; Ruff passed.