### PR TITLE
Fix AttributeError when PEP 695 type parameter is named __slots__

### DIFF
--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2719,6 +2719,8 @@ class ClassDef(
             return None
         for slots in slots_attributes:
             # check if __slots__ is a valid type
+            if not hasattr(slots, "getattr"):
+                continue
             for meth in ITER_METHODS:
                 try:
                     slots.getattr(meth)

--- a/doc/whatsnew/fragments/3258.bugfix
+++ b/doc/whatsnew/fragments/3258.bugfix
@@ -1,0 +1,7 @@
+``ClassDef.slots()`` no longer crashes on a class that declares a PEP 695
+type parameter literally named ``__slots__`` (e.g. ``class C[__slots__]:``).
+The type parameter's ``TypeVar`` node was mistaken for the class's actual
+``__slots__`` value; ``slots()`` now returns ``None`` for such classes
+instead of raising ``AttributeError``.
+
+Refs #3258

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -1585,6 +1585,14 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         # must return None instead of raising ``InferenceError``.
         self.assertIsNone(module["Klass"].slots())
 
+    def test_slots_pep695_type_param_named_slots(self) -> None:
+        module = builder.parse("""
+        class C[__slots__]:
+            def __init__(self):
+                self.a = 1
+        """)
+        self.assertIsNone(module["C"].slots())
+
     def test_slots_added_dynamically_still_inferred(self) -> None:
         code = """
         class NodeBase(object):


### PR DESCRIPTION
Fixes #3258

ClassDef.slots() raises AttributeError when a PEP 695 type parameter is
named __slots__. Guard the attribute lookup so the TypeVar node is
skipped instead of causing a crash.

Added a regression test and newsfragment.