### PR TITLE
Honor metaclass __bool__/__len__ in ClassDef.bool_value

### DIFF
--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2926,12 +2926,53 @@ class ClassDef(
         """
         return self._compute_mro(context=context)
 
-    def bool_value(self, context: InferenceContext | None = None) -> Literal[True]:
-        """Determine the boolean value of this node.
+    def bool_value(
+        self, context: InferenceContext | None = None
+    ) -> bool | util.UninferableBase:
+        """Determine the boolean value of this class.
 
-        :returns: The boolean value of this node.
-            For a :class:`ClassDef` this is always ``True``.
+        A class is normally truthy, but if its metaclass defines
+        ``__bool__`` or ``__len__`` those override the default, mirroring
+        Python's own semantics (``bool(C)`` is ``type(C).__bool__(C)``,
+        falling back to ``type(C).__len__(C)``).
+
+        :returns: ``True`` when no metaclass override applies (the default),
+            the truthiness inferred from the metaclass's ``__bool__`` /
+            ``__len__`` return value when one is found, or
+            :data:`~astroid.util.Uninferable` when a metaclass override
+            exists but its return value cannot be inferred.
         """
+        metaclass = self.metaclass(context=context)
+        if metaclass is None or isinstance(metaclass, util.UninferableBase):
+            return True
+        # ``type`` and ``object`` do not define non-default ``__bool__`` /
+        # ``__len__``, so a class whose metaclass is ``type`` itself keeps
+        # the historical always-truthy behavior.
+        if metaclass.qname() == "builtins.type":
+            return True
+        context = context or InferenceContext()
+        context.boundnode = self
+        for method_name in ("__bool__", "__len__"):
+            try:
+                meth = next(metaclass.igetattr(method_name, context=context), None)
+            except (AttributeInferenceError, InferenceError):
+                continue
+            if meth is None or not hasattr(meth, "infer_call_result"):
+                continue
+            if not meth.callable():
+                continue
+            try:
+                context.callcontext = CallContext(args=[], callee=meth)
+                for value in meth.infer_call_result(self, context=context):
+                    if isinstance(value, util.UninferableBase):
+                        return value
+                    try:
+                        inferred = next(value.infer(context=context))
+                    except (InferenceError, StopIteration):
+                        return util.Uninferable
+                    return inferred.bool_value()
+            except InferenceError:
+                continue
         return True
 
     def get_children(self):

--- a/doc/whatsnew/fragments/183.bugfix
+++ b/doc/whatsnew/fragments/183.bugfix
@@ -1,0 +1,10 @@
+``ClassDef.bool_value`` and the inference of ``bool(cls)`` now honor a metaclass
+that defines ``__bool__`` or ``__len__``. Previously a class was always inferred
+as truthy, so a metaclass whose ``__len__`` returned ``0`` (or whose ``__bool__``
+returned ``False``) was silently ignored — mismatching Python's own semantics,
+where ``bool(cls)`` is ``type(cls).__bool__(cls)`` with a fallback to
+``__len__``. When the metaclass override cannot be inferred, ``bool_value`` now
+yields ``Uninferable``. A class whose metaclass is ``type`` itself (or which
+defines neither dunder) keeps the historical always-truthy behavior.
+
+Closes #183

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2993,6 +2993,104 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         else:
             self.assertIs(inferred.bool_value(), True)
 
+    def test_bool_value_metaclass(self) -> None:
+        """A class' truthiness follows its metaclass' ``__bool__``/``__len__``.
+
+        Reproducer from https://github.com/pylint-dev/astroid/issues/183 —
+        ``bool(C)`` runs ``type(C).__bool__(C)`` (falling back to
+        ``__len__``), so a metaclass that overrides either overrides the
+        class' truthiness. A class without such an override stays truthy.
+        """
+        classes = extract_node("""
+        class FalseLenMeta(type):
+            def __len__(cls):
+                return 0
+        class TrueLenMeta(type):
+            def __len__(cls):
+                return 3
+        class FalseBoolMeta(type):
+            def __bool__(cls):
+                return False
+        class TrueBoolMeta(type):
+            def __bool__(cls):
+                return True
+        class BoolWinsMeta(type):
+            def __bool__(cls):
+                return True
+            def __len__(cls):
+                return 0
+        class InferErrorMeta(type):
+            def __bool__(cls):
+                return undefined_name
+        class NoBoolNoLenMeta(type):
+            pass
+
+        class FalseLenCls(metaclass=FalseLenMeta):
+            pass
+        class TrueLenCls(metaclass=TrueLenMeta):
+            pass
+        class FalseBoolCls(metaclass=FalseBoolMeta):
+            pass
+        class TrueBoolCls(metaclass=TrueBoolMeta):
+            pass
+        class BoolWinsCls(metaclass=BoolWinsMeta):
+            pass
+        class InferErrorCls(metaclass=InferErrorMeta):
+            pass
+        class NoOverrideCls(metaclass=NoBoolNoLenMeta):
+            pass
+        class NoMetaclassCls:
+            pass
+
+        FalseLenCls  #@
+        TrueLenCls  #@
+        FalseBoolCls  #@
+        TrueBoolCls  #@
+        BoolWinsCls  #@
+        InferErrorCls  #@
+        NoOverrideCls  #@
+        NoMetaclassCls  #@
+        """)
+        expected = (
+            False,
+            True,
+            False,
+            True,
+            True,
+            util.Uninferable,
+            True,
+            True,
+        )
+        for node, expected_value in zip(classes, expected):
+            inferred = next(node.infer())
+            self.assertEqual(
+                inferred.bool_value(),
+                expected_value,
+                msg=f"bool_value() for {node.name} was wrong",
+            )
+
+    def test_bool_value_metaclass_bool_call(self) -> None:
+        """``bool(cls)`` inference respects the metaclass override too."""
+        false_call, true_call = extract_node("""
+        class FalseMeta(type):
+            def __len__(cls):
+                return 0
+        class TrueMeta(type):
+            def __bool__(cls):
+                return True
+        class FalseCls(metaclass=FalseMeta):
+            pass
+        class TrueCls(metaclass=TrueMeta):
+            pass
+
+        bool(FalseCls)  #@
+        bool(TrueCls)  #@
+        """)
+        (false_inferred,) = false_call.inferred()
+        self.assertEqual(false_inferred.value, False)
+        (true_inferred,) = true_call.inferred()
+        self.assertEqual(true_inferred.value, True)
+
     def test_infer_coercion_rules_for_floats_complex(self) -> None:
         ast_nodes = extract_node("""
         1 + 1.0 #@


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`ClassDef.bool_value` always returned `True`, so `bool(C)` inference always came out truthy — even for a class whose metaclass overrode `__bool__` / `__len__` to make it falsy. Python's own semantics for `bool(C)` are `type(C).__bool__(C)`, falling back to `type(C).__len__(C)`; the class-level check now mirrors that.

Before this change:

```python
import astroid

module = astroid.parse('''
class Meta(type):
    def __len__(self):
        return 0

class C(metaclass=Meta):
    pass
''')

module['C'].bool_value()   # True   (wrong: real Python says False)

astroid.extract_node('''
class Meta(type):
    def __len__(cls): return 0
class C(metaclass=Meta): pass
bool(C)  #@
''').inferred()            # [Const.bool(value=True)]  (wrong)
```

Both the `bool_value()` API and the `bool(C)` inference path now return `False` here, matching CPython.

## Approach

`ClassDef.bool_value` now consults the metaclass:

- If the metaclass is missing or resolves to `Uninferable`, or is `builtins.type` itself, keep the historical always-truthy result — this is the common case, so it's the fast path and can't regress any class that isn't using a custom metaclass.
- Otherwise, look up `__bool__` on the metaclass; if callable, call it with the class as the first argument (the same pattern `_infer_method_result_truth` uses for instances) and translate the return value's `bool_value()` back out.
- If `__bool__` isn't defined or its return can't be inferred (via `AttributeInferenceError` / `InferenceError`), fall back to `__len__`.
- If both are unresolved, return `True`.
- If a metaclass override is found but its return value is `Uninferable`, return `Uninferable` — a class whose truthiness we can't determine shouldn't silently masquerade as truthy.

## Tests

- New `test_bool_value_metaclass` covers all the branches: `__len__` returning 0/non-zero, `__bool__` returning False/True, `__bool__` winning over `__len__`, unresolvable return values, metaclasses that define neither dunder, and classes with no custom metaclass at all.
- New `test_bool_value_metaclass_bool_call` covers the same behavior through the `bool(cls)` inference path, which was the second surface the issue described.
- Existing `test_bool_value*` tests still pass, so classes without a metaclass override keep their historical truthiness.
- Full `tests/test_inference.py` passes locally (462 passed, 7 skipped, 10 xfailed).
- Full `tests/` passes locally aside from three pre-existing failures unrelated to this change (`test_typed_dict_required_and_optional_keys`, `test_symlink_resolution`, `test_identify_old_namespace_package_protocol` — the last one fails on missing `pkg_resources` in the environment; they fail identically on `main` without this patch).

Closes #183