### PR TITLE
only treat bare require_version as gi's when imported from gi

### DIFF
--- a/astroid/brain/brain_gi.py
+++ b/astroid/brain/brain_gi.py
@@ -277,7 +277,19 @@ def _looks_like_require_version(node) -> bool:
         return False
 
     if isinstance(func, nodes.Name):
-        return func.name == "require_version"
+        if func.name != "require_version":
+            return False
+        # A bare ``require_version(...)`` only means gi's function when the name
+        # was imported from gi. Without this check any unrelated function of the
+        # same name in the analysed source makes ``_register_require_version``
+        # import gi and register an attacker-controlled version.
+        _, assignments = func.lookup(func.name)
+        return any(
+            isinstance(assignment, nodes.ImportFrom)
+            and assignment.modname == "gi"
+            and any(orig == "require_version" for orig, _ in assignment.names)
+            for assignment in assignments
+        )
 
     return False
 

--- a/doc/whatsnew/fragments/3277.bugfix
+++ b/doc/whatsnew/fragments/3277.bugfix
@@ -1,0 +1,8 @@
+``brain_gi`` no longer imports ``gi`` and calls ``gi.require_version`` for a bare
+``require_version(name, version)`` call in the analysed source that does not
+resolve to gi's function, such as a project-local function of that name or an
+undefined name. ``_looks_like_require_version`` now requires the bare-name form
+to be imported from ``gi``, matching the guard already applied to the
+``gi.require_version`` attribute form.
+
+Refs #3277

--- a/tests/brain/test_gi.py
+++ b/tests/brain/test_gi.py
@@ -12,6 +12,7 @@ except ImportError:
     HAS_GI = False
 
 from astroid import builder, nodes
+from astroid.brain.brain_gi import _looks_like_require_version
 
 
 @unittest.skipUnless(HAS_GI, "This test requires the gobject introspection library.")
@@ -54,4 +55,56 @@ class GiBrainClassificationTest(unittest.TestCase):
             funcdef.argnames()[0],
             {"self", funcdef.args.vararg},
             "Method does not accept 'self' as first argument",
+        )
+
+
+class RequireVersionMatchTest(unittest.TestCase):
+    """``_looks_like_require_version`` must only match gi's ``require_version``.
+
+    A match triggers ``import gi`` and ``gi.require_version(...)`` at build time,
+    so a false positive runs that side effect for unrelated source. This test
+    needs no gi and asserts the predicate, not the side effect.
+    """
+
+    @staticmethod
+    def _call(source: str) -> nodes.Call:
+        call = builder.extract_node(source)
+        assert isinstance(call, nodes.Call)
+        return call
+
+    def test_bare_name_from_gi_matches(self):
+        self.assertTrue(
+            _looks_like_require_version(
+                self._call(
+                    'from gi import require_version\nrequire_version("Gtk", "3.0")'
+                )
+            )
+        )
+
+    def test_gi_attribute_matches(self):
+        self.assertTrue(
+            _looks_like_require_version(
+                self._call('import gi\ngi.require_version("Gtk", "3.0")')
+            )
+        )
+
+    def test_local_function_does_not_match(self):
+        self.assertFalse(
+            _looks_like_require_version(
+                self._call(
+                    'def require_version(a, b): return None\nrequire_version("Gtk", "3.0")'
+                )
+            )
+        )
+
+    def test_undefined_name_does_not_match(self):
+        self.assertFalse(
+            _looks_like_require_version(self._call('require_version("Gtk", "3.0")'))
+        )
+
+    def test_other_module_attribute_does_not_match(self):
+        self.assertFalse(
+            _looks_like_require_version(
+                self._call('import other\nother.require_version("Gtk", "3.0")')
+            )
         )


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`brain_gi._looks_like_require_version` matches a bare `require_version(name, version)` call by name alone, so any two-constant-arg call to an unrelated function named `require_version` (a project-local `def`, or even an undefined name) makes the `_register_require_version` transform run `import gi` and call `gi.require_version(arg0, arg1)` with the source-supplied strings while the module is being built. that imports gi purely because analysed source reused a common function name, and registers a source-controlled version into gi's process-global `_versions` map, which can pre-empt the correct binding when the same process later imports `gi.repository`. the attribute form already guards on `func.expr.name == "gi"`; the bare-name branch now requires the name to resolve to a `from gi import require_version`, leaving legitimate gi usage untouched while same-named calls no longer trigger the import. added `RequireVersionMatchTest` (no gobject-introspection needed) covering the gi import and attribute forms plus the local-def, undefined and other-module cases.
